### PR TITLE
[FIX] fields: when not in onchange, do not update inverse field in cache

### DIFF
--- a/openerp/addons/base/tests/test_api.py
+++ b/openerp/addons/base/tests/test_api.py
@@ -251,16 +251,16 @@ class TestAPI(common.TransactionCase):
     def test_55_draft(self):
         """ Test draft mode nesting. """
         env = self.env
-        self.assertFalse(env.draft)
+        self.assertFalse(env.in_draft)
         with env.do_in_draft():
-            self.assertTrue(env.draft)
+            self.assertTrue(env.in_draft)
             with env.do_in_draft():
-                self.assertTrue(env.draft)
+                self.assertTrue(env.in_draft)
                 with env.do_in_draft():
-                    self.assertTrue(env.draft)
-                self.assertTrue(env.draft)
-            self.assertTrue(env.draft)
-        self.assertFalse(env.draft)
+                    self.assertTrue(env.in_draft)
+                self.assertTrue(env.in_draft)
+            self.assertTrue(env.in_draft)
+        self.assertFalse(env.in_draft)
 
     @mute_logger('openerp.models')
     def test_60_cache(self):

--- a/openerp/fields.py
+++ b/openerp/fields.py
@@ -402,9 +402,6 @@ class Field(object):
             if not getattr(self, attr):
                 setattr(self, attr, getattr(field, prop))
 
-        # special case: related fields never have an inverse field!
-        self.inverse_field = None
-
     def _compute_related(self, records):
         """ Compute the related field `self` on `records`. """
         for record in records:
@@ -675,13 +672,13 @@ class Field(object):
         # adapt value to the cache level
         value = self.convert_to_cache(value, env)
 
-        if env.draft or not record.id:
+        if env.in_draft or not record.id:
             # determine dependent fields
             spec = self.modified_draft(record)
 
             # set value in cache, inverse field, and mark record as dirty
             record._cache[self] = value
-            if env.draft:
+            if env.in_onchange:
                 if self.inverse_field:
                     self.inverse_field._update(value, record)
                 record._dirty = True
@@ -726,7 +723,7 @@ class Field(object):
         """ Determine the value of `self` for `record`. """
         env = record.env
 
-        if self.store and not (self.depends and env.draft):
+        if self.store and not (self.depends and env.in_draft):
             # this is a stored field
             if self.depends:
                 # this is a stored computed field, check for recomputation

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -3093,7 +3093,7 @@ class BaseModel(object):
         if self.pool._init:
             # columns may be missing from database, do not prefetch other fields
             pass
-        elif self.env.draft:
+        elif self.env.in_draft:
             # we may be doing an onchange, do not prefetch other fields
             pass
         elif field in self.env.todo:
@@ -5172,7 +5172,7 @@ class BaseModel(object):
         record = self.browse([NewId()])
         record._cache.update(self._convert_to_cache(values))
 
-        if record.env.draft:
+        if record.env.in_onchange:
             # The cache update does not set inverse fields, so do it manually.
             # This is useful for computing a function field on secondary
             # records, if that field depends on the main record.
@@ -5565,7 +5565,7 @@ class BaseModel(object):
                 subfields[name].add(subname)
 
         # create a new record with values, and attach `self` to it
-        with env.do_in_draft():
+        with env.do_in_onchange():
             record = self.new(values)
             values = dict(record._cache)
             # attach `self` with a different context (for cache consistency)
@@ -5587,7 +5587,7 @@ class BaseModel(object):
                 continue
             done.add(name)
 
-            with env.do_in_draft():
+            with env.do_in_onchange():
                 # apply field-specific onchange methods
                 if field_onchange.get(name):
                     record._onchange_eval(name, field_onchange[name], result)


### PR DESCRIPTION
When executing an onchange method, setting a relational field should update the
corresponding inverse field, so that values look consistent for the programmer.
However, we should not do this in general when computing field values, since it
may introduces access to the computed field before it is computed.

Consider a related many2one field which an inverse one2many field. While
computing the field's value, the one2many would be updated, which would trigger
reading the current value of the one2many, which requires the corresponding
many2one field. This fails when the one2many is read for several records, and
some of those records have not been computed yet.
