### PR TITLE
Differences less/scss compilation

### DIFF
--- a/addons/web/static/src/scss/__rde.less
+++ b/addons/web/static/src/scss/__rde.less
@@ -1,0 +1,45 @@
+@line-height-base_rde:        1.428571429; // 20/14
+@reward-size-mobile: 300px;
+/******/
+.test {
+    padding: -5px -25px;
+    margin: -5px -@reward-size-mobile;
+}
+.rde {
+    position: relative!important;
+
+    border: 0 solid rgba(0, 0, 0, 0);
+
+    line-height: @line-height-base_rde;
+
+    a, b {
+      z1, z2 {
+        color:red;
+      }
+    }
+
+    margin: -5% auto 0 -(@reward-size-mobile / 2);
+    margin: -5% auto 20px -(@reward-size-mobile / 2);
+    padding: -5% auto 20px (-(@reward-size-mobile / 2));
+
+    background-image: url('/web/static/src/img/mimetypes/image.png');
+}
+
+@roboto-font-path: '../fonts/Roboto';
+@font-face {
+    font-family: 'Roboto';
+    src: url('#{$roboto-font-path}/Roboto-#{$type}-webfont.eot');
+}
+
+
+
+
+.rde2 {
+    background-image: url(../img/checked.svg);
+}
+
+.a{color: rgba(0, 0, 0, 0);}
+.a{color: rgba(0, 0, 0, 1);}
+.a{color: rgba(0, 255, 0, 0.5);}
+.a{color: rgba(255, 0, 0, 1);}
+.a{color: rgba(123, 17, 42, 1);}

--- a/addons/web/static/src/scss/__rde.scss
+++ b/addons/web/static/src/scss/__rde.scss
@@ -1,0 +1,45 @@
+$line-height-base_rde:        1.428571429; // 20/14
+$reward-size-mobile: 300px;
+/***expended precision8 ****/
+.test {
+    padding: -5px -25px;
+    margin: -5px -$reward-size-mobile;
+}
+.rde {
+    position: relative!important;
+
+    border: 0 solid rgba(0, 0, 0, 0);
+
+    line-height: $line-height-base_rde;
+
+    a, b {
+      z1, z2 {
+        color:red;
+      }
+    }
+
+    margin: -5% auto 0 -($reward-size-mobile / 2);
+    margin: -5% auto 20px -($reward-size-mobile / 2);
+    padding: -5% auto 20px (-($reward-size-mobile / 2));
+
+    background-image: url('/web/static/src/img/mimetypes/image.png');
+}
+
+$roboto-font-path: '../fonts/Roboto';
+@font-face {
+    font-family: 'Roboto';
+    src: url('@{roboto-font-path}/Roboto-@{type}-webfont.eot');
+}
+
+
+
+
+.rde2 {
+    background-image: url(../img/checked.svg);
+}
+
+.a{color: rgba(0, 0, 0, 0);}
+.a{color: rgba(0, 0, 0, 1);}
+.a{color: rgba(0, 255, 0, 0.5);}
+.a{color: rgba(255, 0, 0, 1);}
+.a{color: rgba(123, 17, 42, 1);}

--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -40,7 +40,7 @@
 
             @include o-align-items(baseline);
             min-width: 50px;
-            margin: 0 -$o-form-spacing-unit/2;
+            margin: 0 (-$o-form-spacing-unit/2);
 
             > div, > span, > button, > label, > a, > input { // > * did not add a level of priority to the rule
                 @include o-flex(0, 0, auto);
@@ -124,7 +124,7 @@
         @include o-webclient-padding($top: $o-sheet-vpadding, $bottom: $o-sheet-vpadding);
 
         .o_form_statusbar {
-            margin: -$o-sheet-vpadding -$o-horizontal-padding $o-sheet-vpadding -$o-horizontal-padding;
+            margin: (-$o-sheet-vpadding) (-$o-horizontal-padding) $o-sheet-vpadding (-$o-horizontal-padding);
         }
     }
 

--- a/addons/web/static/src/scss/rainbow.scss
+++ b/addons/web/static/src/scss/rainbow.scss
@@ -9,9 +9,9 @@
     will-change: transform;
     z-index: $zindex-modal;
     padding: 50px;
-    margin: -5% auto 0 -($reward-size / 2);
+    margin: -5% auto 0 (-$reward-size / 2);
     @media (max-width: $screen-xs-max) {
-        margin: -5% auto 0 -($reward-size-mobile / 2);
+        margin: -5% auto 0 (-$reward-size-mobile / 2);
     }
     background-image: -webkit-radial-gradient(#EDEFF4 30%, transparent 70%, transparent);
     background-image: -o-radial-gradient(#EDEFF4 30%, transparent 70%, transparent);

--- a/addons/web/static/src/scss/utils.scss
+++ b/addons/web/static/src/scss/utils.scss
@@ -439,7 +439,7 @@
     padding: 0;
 
     > a {
-        margin: auto auto auto -$link-padding-gap;
+        margin: auto auto auto (-$link-padding-gap);
         padding: 3px $link-padding-gap;
         color: $text-color;
         display: block;

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -269,6 +269,10 @@
         <script type="text/javascript" src="/web/static/src/js/report/utils.js"/>
         <script type="text/javascript" src="/web/static/src/js/report/client_action.js"/>
         <link rel="stylesheet" type="text/scss" href="/web/static/src/scss/report_backend.scss"/>
+        
+        <link rel="stylesheet" type="text/less" href="/web/static/src/scss/__rde.less"/>
+        <link rel="stylesheet" type="text/scss" href="/web/static/src/scss/__rde.scss"/>
+        
     </template>
 
     <template id="web.assets_frontend" name="Website Assets">

--- a/addons/web_editor/static/src/scss/web_editor.ui.scss
+++ b/addons/web_editor/static/src/scss/web_editor.ui.scss
@@ -288,7 +288,7 @@ html[lang] > body.editor_enable [data-oe-translation-state] {
 
             width: $o-we-dropzone-size;
             float: left;
-            margin: 0 -$o-we-dropzone-size/2;
+            margin: 0 (-$o-we-dropzone-size/2);
 
             &:after {
                 width: 50%;

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -411,7 +411,14 @@ class AssetsBundle(object):
             try:
                 path_to_bs = get_resource_path('web', 'static', 'lib', 'bootstrap', 'scss')
                 path_to_bs_components = get_resource_path('web', 'static', 'lib', 'bootstrap', 'scss', 'bootstrap')
-                result = sass.compile(string=source.encode('utf-8'), include_paths=[path_to_bs, path_to_bs_components])
+                print("\n\n" + 'expanded' + '\n\n')
+                result = sass.compile(
+                             string=source.encode('utf-8'),
+                             include_paths=[path_to_bs, path_to_bs_components],
+                             output_style='expanded',
+                             precision=8,
+                         )
+                         
                 compiled = result.strip()
             except sass.CompileError as e:
                 return handle_compile_error(e, source=source)


### PR DESCRIPTION
Differences:

1. No return line before closing braces `}` in scss
     => PARTIALLY FIXED with `output_style='expanded'` in sass.compile() arguments
        But there is 2 differences with this (less problematic IMHO)
          1. There is an empty line between 2 css blocks
          2. Multiple selector are on the same line ('.a, .b, .c {')
  (/web_tour/static/src/scss/tip.scss)

2. space before `!important`
     => NOT A PROBLEM
3. rgba(w,x,y,z) are handled differently in scss and less:
     Less: If possible: > map to hexadecimal. If not: > leave unchanged
     Scss: If possible: > map to color name. If not, if possible: > map to hexadecimal. If not: > leave unchanged
     Obviously, the mapping is only tried when opacity is 1.
     Exemple:
        rgba(0, 0, 0, 1)
        = black on scss and #000000 on less
        rgba(255, 0, 0, 1)
        = red on scss and #ff0000 on less
        rgba(123, 17, 42, 1)
        = #7b112a on less & scss
     Note: rgba(0, 0, 0, 0) become `transparent` on scss which is better since it support IE8
     => BETTER THAT WAY
4. line-height: $line-height-base;
     1.42857; on scss
     1.42857143; on less
     => FIXED with `precision=8` in sass.compile() arguments
5. multiple selector nested are parsed in different order
     Exemple:
     ```
         a, b {
           z1, z2 {
             color:red;
           }
         }
     ```

     On less:
     a z1, b z1, a z2, b z2
     On scss:
     a z1, a z2, b z1, b z2
     => NOT A PROBLEM (I don't see how this could be a problem?)
     (/web/static/src/scss/rainbow.scss)
6. Scss perform calculation on property with multiple value and a negative sign. Less does not
     margin: -5% auto 0 -(@reward-size-mobile / 2);
     becomes:
     scss: .o_reward{margin: -5% auto -150px;} => 0 - 150px = -150px
     less: .o_reward{margin: -5% auto 0 -150px;}
     This breaks completely the behavior..

     | margin | TOP | RIGHT | BOTTOM | LEFT   |
     | --------- | ------ | ---------- | ------------ | ---------- |
     | scss     | -5%  | auto     | -150px     | auto     |
     | less      | -5%  | auto     | 0              | -150px |

     => THIS IS A HUGE PROBLEM
     => https://stackoverflow.com/questions/13296419/sass-negative-variable-value
     => -@reward-size-mobile -@reward-size-mobile -@reward-size-mobile (lets say @reward-size-mobile = 300px)
        = -900px in scss and `-300 -300 -300` in less
7. scale(1)
     scss: scale(1)
     less: scale(1.0)
     Can't reproduce with small sample but I don't see how it could be a problem anyway
     => NOT A PROBLEM
  (/web/static/src/scss/mimetypes.scss)
8. quotes on background-image: url('/web/static/src/img/mimetypes/image.png');
     scss: url('/web/static/src/img/mimetypes/image.png');
     less: url("/web/static/src/img/mimetypes/image.png");
     => NOT SURE ABOUT THIS ONE
  (/web_enterprise/static/src/scss/ui.scss)
9. Path double dot computation
     scss: url(/web_enterprise/static/src/scss/../img/checked.svg);
     less: url(/web_enterprise/static/src/img/checked.svg);
     => NOT A PROBLEM even if uglier
  (/web_enterprise/static/src/scss/fonts.scss)
10. Font-face URL has different quotes & path
     scss: "/web_enterprise/static/src/scss/../fonts/Roboto/Roboto-Thin-webfont.eot"
     less: '/web_enterprise/static/src/fonts/Roboto/Roboto-Thin-webfont.eot'
     => See 8. and 9.

/!\ TODO: Lot of differences with /web/static/lib/bootstrap-datetimepicker/src/scss/_bootstrap-datetimepicker.scss