### PR TITLE
[ADD] ir.attachment: add kw on web controller route

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1069,7 +1069,7 @@ class Binary(http.Controller):
     def content_image(self, xmlid=None, model='ir.attachment', id=None, field='datas',
                       filename_field='datas_fname', unique=None, filename=None, mimetype=None,
                       download=None, width=0, height=0, crop=False, related_id=None, access_mode=None,
-                      access_token=None, avoid_if_small=False, upper_limit=False, signature=False):
+                      access_token=None, avoid_if_small=False, upper_limit=False, signature=False, **kw):
         status, headers, content = binary_content(
             xmlid=xmlid, model=model, id=id, field=field, unique=unique, filename=filename,
             filename_field=filename_field, download=download, mimetype=mimetype,


### PR DESCRIPTION
Before this revision, it wasn't possible to access attachments
stored in the filestore added in a mass mailing campaign.
The reason was because on the route, the link tracker added the following args:
utm_source and utm_medium

which weren't recognized by the system and triggered an Internal Server Error.

Adding the kw is allowing the public attachment to be seen without being connected
to the instance, which should be the case on mass mailing campaigns.
There is no need to do anything with those args here, only not refusing them.

However, this fix will open the road to all kind of non senses args.
Regarding the two added args from here, nothing will be done with them.

I base this fix on what have been done in 12.1 and following versions.

opw-2060831