### PR TITLE
[REF] website, web_editor: move theme customization to edit mode

### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -807,8 +807,12 @@
         data-selector=".note-editable > div:not(.o_layout), .note-editable .oe_structure > div, td, th"
         data-exclude=".o_mail_no_resize, .o_mail_no_options"/>
 
-    <div data-js="colorpicker" string="Background Color"
-        data-selector=".note-editable > div:not(.o_layout), .note-editable .oe_structure > div, td, th"
-        data-exclude=".o_mail_no_colorpicker, .o_mail_no_options"/>
+    <div data-selector=".note-editable > div:not(.o_layout), .note-editable .oe_structure > div, td, th"
+         data-exclude=".o_mail_no_colorpicker, .o_mail_no_options">
+        <we-colorpicker string="Background Color"
+            data-select-style="true"
+            data-css-property="background-color"
+            data-color-prefix="bg-"/>
+    </div>
 </template>
 </odoo>

--- a/addons/web/static/src/js/widgets/colorpicker_dialog.js
+++ b/addons/web/static/src/js/widgets/colorpicker_dialog.js
@@ -76,7 +76,7 @@ var ColorpickerDialog = Dialog.extend({
         this.$opacitySliderPointer = this.$('.o_opacity_pointer');
 
         var defaultColor = this.options.defaultColor || '#FF0000';
-        var rgba = ColorpickerDialog.convertColorToRgba(defaultColor);
+        var rgba = ColorpickerDialog.convertCSSColorToRgba(defaultColor);
         if (rgba) {
             this._updateRgba(rgba.red, rgba.green, rgba.blue, rgba.opacity);
         }
@@ -143,7 +143,7 @@ var ColorpickerDialog = Dialog.extend({
      * @param {string} hex - hexadecimal code
      */
     _updateHex: function (hex) {
-        var rgb = ColorpickerDialog.convertHexToRgba(hex);
+        var rgb = ColorpickerDialog.convertCSSColorToRgba(hex);
         if (!rgb) {
             return;
         }
@@ -164,14 +164,17 @@ var ColorpickerDialog = Dialog.extend({
      * @param {integer} [a]
      */
     _updateRgba: function (r, g, b, a) {
-        var hex = ColorpickerDialog.convertRgbToHex(r, g, b);
+        // We update the hexadecimal code by transforming into a css color and
+        // ignoring the opacity (we don't display opacity component in hexa as
+        // not supported on all browsers)
+        var hex = ColorpickerDialog.convertRgbaToCSSColor(r, g, b);
         if (!hex) {
             return;
         }
         _.extend(this.colorComponents,
             {red: r, green: g, blue: b},
             a === undefined ? {} : {opacity: a},
-            hex,
+            {hex: hex},
             ColorpickerDialog.convertRgbToHsl(r, g, b)
         );
         this._updateCssColor();
@@ -189,10 +192,12 @@ var ColorpickerDialog = Dialog.extend({
         if (!rgb) {
             return;
         }
+        // We receive an hexa as we ignore the opacity
+        const hex = ColorpickerDialog.convertRgbaToCSSColor(rgb.red, rgb.green, rgb.blue);
         _.extend(this.colorComponents,
             {hue: h, saturation: s, lightness: l},
             rgb,
-            ColorpickerDialog.convertRgbToHex(rgb.red, rgb.green, rgb.blue)
+            {hex: hex}
         );
         this._updateCssColor();
     },
@@ -217,8 +222,12 @@ var ColorpickerDialog = Dialog.extend({
      * @private
      */
     _updateCssColor: function () {
+        const r = this.colorComponents.red;
+        const g = this.colorComponents.green;
+        const b = this.colorComponents.blue;
+        const a = this.colorComponents.opacity;
         _.extend(this.colorComponents,
-            {cssColor: ColorpickerDialog.formatColor(this.colorComponents)}
+            {cssColor: ColorpickerDialog.convertRgbaToCSSColor(r, g, b, a)}
         );
     },
 
@@ -359,84 +368,21 @@ var ColorpickerDialog = Dialog.extend({
 //--------------------------------------------------------------------------
 
 /**
- * Converts any color to string RGBA.
+ * Converts RGB color components to HSL components.
  *
  * @static
- * @param {Object|string} color
- * @returns {string} rgba (red, green, blue, opacity)
- */
-ColorpickerDialog.formatColor = function (color) {
-    if (typeof color === 'string') {
-        color = ColorpickerDialog.convertColorToRgba(color);
-    }
-    if (!color) {
-        return '';
-    }
-    if (color.opacity === 100) {
-        return ColorpickerDialog.convertRgbToHex(color.red, color.green, color.blue).hex;
-    }
-    return _.str.sprintf('rgba(%s, %s, %s, %s)',
-        color.red,
-        color.green,
-        color.blue,
-        color.opacity / 100
-    );
-};
-/**
- * Converts any color to  code to RGBA.
- *
- * @static
- * @param {string} color
- * @returns {Object|false} contains red, green, blue, opacity
- */
-ColorpickerDialog.convertColorToRgba = function (color) {
-    var rgba = color.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/);
-    if (rgba) {
-        if (rgba[4] === undefined) {
-            rgba[4] = 1;
-        }
-        return {
-            red: parseInt(rgba[1]),
-            green: parseInt(rgba[2]),
-            blue: parseInt(rgba[3]),
-            opacity: Math.round(parseFloat(rgba[4]) * 100),
-        };
-    } else {
-        return ColorpickerDialog.convertHexToRgba(color);
-    }
-};
-/**
- * Converts Hexadecimal code to RGB.
- *
- * @static
- * @param {string} hex - hexadecimal code
- * @returns {Object|false} contains red, green and blue
- */
-ColorpickerDialog.convertHexToRgba = function (hex) {
-    if (!/^#([0-9A-F]{6}|[0-9A-F]{8})$/i.test(hex)) {
-        return false;
-    }
-
-    return {
-        red: parseInt(hex.substr(1, 2), 16),
-        green: parseInt(hex.substr(3, 2), 16),
-        blue: parseInt(hex.substr(5, 2), 16),
-        opacity: (hex.length === 9 ? (parseInt(hex.substr(7, 2), 16) / 255) : 1) * 100,
-    };
-};
-/**
- * Converts RGB color to HSL.
- *
- * @static
- * @param {integer} r
- * @param {integer} g
- * @param {integer} b
- * @returns {Object|false} contains hue, saturation and lightness
+ * @param {integer} r - [0, 255]
+ * @param {integer} g - [0, 255]
+ * @param {integer} b - [0, 255]
+ * @returns {Object|false}
+ *          - hue [0, 360[
+ *          - saturation [0, 100]
+ *          - lightness [0, 100]
  */
 ColorpickerDialog.convertRgbToHsl = function (r, g, b) {
-    if (typeof (r) !== 'number' || isNaN(r) || r < 0 || r > 255 ||
-        typeof (g) !== 'number' || isNaN(g) || g < 0 || g > 255 ||
-        typeof (b) !== 'number' || isNaN(b) || b < 0 || b > 255) {
+    if (typeof (r) !== 'number' || isNaN(r) || r < 0 || r > 255
+            || typeof (g) !== 'number' || isNaN(g) || g < 0 || g > 255
+            || typeof (b) !== 'number' || isNaN(b) || b < 0 || b > 255) {
         return false;
     }
 
@@ -471,20 +417,24 @@ ColorpickerDialog.convertRgbToHsl = function (r, g, b) {
     };
 };
 /**
- * Converts HSL color to RGB.
+ * Converts HSL color components to RGB components.
  *
  * @static
- * @param {integer} h
- * @param {integer} s
- * @param {integer} l
- * @returns {Object|false} contains red, green and blue
+ * @param {integer} h - [0, 360[
+ * @param {integer} s - [0, 100]
+ * @param {integer} l - [0, 100]
+ * @returns {Object|false}
+ *          - red [0, 255]
+ *          - green [0, 255]
+ *          - blue [0, 255]
  */
 ColorpickerDialog.convertHslToRgb = function (h, s, l) {
-    if (typeof (h) !== 'number' || isNaN(h) || h < 0 || h > 360 ||
-        typeof (s) !== 'number' || isNaN(s) || s < 0 || s > 100 ||
-        typeof (l) !== 'number' || isNaN(l) || l < 0 || l > 100) {
+    if (typeof (h) !== 'number' || isNaN(h) || h < 0 || h > 360
+            || typeof (s) !== 'number' || isNaN(s) || s < 0 || s > 100
+            || typeof (l) !== 'number' || isNaN(l) || l < 0 || l > 100) {
         return false;
     }
+
     var huePrime = h / 60;
     var saturation = s / 100;
     var lightness = l / 100;
@@ -537,28 +487,98 @@ ColorpickerDialog.convertHslToRgb = function (h, s, l) {
             blue: secondComponent,
         };
     }
+    return false;
 };
 /**
- * Converts RGB color to Hexadecimal code.
+ * Converts RGBA color components to a normalized CSS color: if the opacity
+ * is invalid or equal to 100, a hex is returned; otherwise a rgba() css color
+ * is returned.
+ *
+ * Those choice have multiple reason:
+ * - A hex color is more common to c/c from other utilities on the web and is
+ *   also shorter than rgb() css colors
+ * - Opacity in hexadecimal notations is not supported on all browsers and is
+ *   also less common to use.
  *
  * @static
- * @param {integer} r
- * @param {integer} g
- * @param {integer} b
- * @returns {Object|false} contains hexadecimal code
+ * @param {integer} r - [0, 255]
+ * @param {integer} g - [0, 255]
+ * @param {integer} b - [0, 255]
+ * @param {float} a - [0, 100]
+ * @returns {string}
  */
-ColorpickerDialog.convertRgbToHex = function (r, g, b) {
-    if (typeof (r) !== 'number' || isNaN(r) || r < 0 || r > 255 ||
-        typeof (g) !== 'number' || isNaN(g) || g < 0 || g > 255 ||
-        typeof (b) !== 'number' || isNaN(b) || b < 0 || b > 255) {
+ColorpickerDialog.convertRgbaToCSSColor = function (r, g, b, a) {
+    if (typeof (r) !== 'number' || isNaN(r) || r < 0 || r > 255
+            || typeof (g) !== 'number' || isNaN(g) || g < 0 || g > 255
+            || typeof (b) !== 'number' || isNaN(b) || b < 0 || b > 255) {
         return false;
     }
-    var red = r < 16 ? '0' + r.toString(16) : r.toString(16);
-    var green = g < 16 ? '0' + g.toString(16) : g.toString(16);
-    var blue = b < 16 ? '0' + b.toString(16) : b.toString(16);
-    return {
-        hex: _.str.sprintf('#%s%s%s', red, green, blue)
-    };
+    if (typeof (a) !== 'number' || isNaN(a) || a < 0 || Math.abs(a - 100) < Number.EPSILON) {
+        const rr = r < 16 ? '0' + r.toString(16) : r.toString(16);
+        const gg = g < 16 ? '0' + g.toString(16) : g.toString(16);
+        const bb = b < 16 ? '0' + b.toString(16) : b.toString(16);
+        return (`#${rr}${gg}${bb}`).toUpperCase();
+    }
+    return `rgba(${r}, ${g}, ${b}, ${parseFloat((a / 100.0).toFixed(3))})`;
+};
+/**
+ * Converts a CSS color (rgb(), rgba(), hexadecimal) to RGBA color components.
+ *
+ * Note: we don't support using and displaying hexadecimal color with opacity
+ * but this method allows to receive one and returns the correct opacity value.
+ *
+ * @static
+ * @param {string} cssColor - hexadecimal code or rgb() or rgba()
+ * @returns {Object|false}
+ *          - red [0, 255]
+ *          - green [0, 255]
+ *          - blue [0, 255]
+ *          - opacity [0, 100.0]
+ */
+ColorpickerDialog.convertCSSColorToRgba = function (cssColor) {
+    // Check if cssColor is a rgba() or rgb() color
+    const rgba = cssColor.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/);
+    if (rgba) {
+        if (rgba[4] === undefined) {
+            rgba[4] = 1;
+        }
+        return {
+            red: parseInt(rgba[1]),
+            green: parseInt(rgba[2]),
+            blue: parseInt(rgba[3]),
+            opacity: Math.round(parseFloat(rgba[4]) * 100),
+        };
+    }
+
+    // Otherwise, check if cssColor is an hexadecimal code color
+    if (/^#([0-9A-F]{6}|[0-9A-F]{8})$/i.test(cssColor)) {
+        return {
+            red: parseInt(cssColor.substr(1, 2), 16),
+            green: parseInt(cssColor.substr(3, 2), 16),
+            blue: parseInt(cssColor.substr(5, 2), 16),
+            opacity: (cssColor.length === 9 ? (parseInt(cssColor.substr(7, 2), 16) / 255) : 1) * 100,
+        };
+    }
+
+    return false;
+};
+/**
+ * Converts a CSS color (rgb(), rgba(), hexadecimal) to a normalized version
+ * of the same color (@see convertRgbaToCSSColor).
+ *
+ * Normalized color can be safely compared using string comparison.
+ *
+ * @static
+ * @param {string} cssColor - hexadecimal code or rgb() or rgba()
+ * @returns {string} - the normalized css color or the given css color if it
+ *                     failed to be normalized
+ */
+ColorpickerDialog.normalizeCSSColor = function (cssColor) {
+    const rgba = ColorpickerDialog.convertCSSColorToRgba(cssColor);
+    if (!rgba) {
+        return cssColor;
+    }
+    return ColorpickerDialog.convertRgbaToCSSColor(rgba.red, rgba.green, rgba.blue, rgba.opacity);
 };
 
 return ColorpickerDialog;

--- a/addons/web/static/src/js/widgets/colorpicker_dialog.js
+++ b/addons/web/static/src/js/widgets/colorpicker_dialog.js
@@ -15,7 +15,7 @@ var ColorpickerDialog = Dialog.extend({
         'mousedown .o_color_pick_area': '_onMouseDownPicker',
         'mousedown .o_color_slider': '_onMouseDownSlider',
         'mousedown .o_opacity_slider': '_onMouseDownOpacitySlider',
-        'change .o_color_picker_inputs' : '_onChangeInputs',
+        'change .o_color_picker_inputs': '_onChangeInputs',
     }),
 
     /**
@@ -560,6 +560,9 @@ ColorpickerDialog.convertCSSColorToRgba = function (cssColor) {
         };
     }
 
+    // TODO maybe implement a support for receiving css color like 'red' or
+    // 'transparent' (which are now considered non-css color by isCSSColor...)
+
     return false;
 };
 /**
@@ -579,6 +582,16 @@ ColorpickerDialog.normalizeCSSColor = function (cssColor) {
         return cssColor;
     }
     return ColorpickerDialog.convertRgbaToCSSColor(rgba.red, rgba.green, rgba.blue, rgba.opacity);
+};
+/**
+ * Checks if a given string is a css color.
+ *
+ * @static
+ * @param {string} cssColor
+ * @returns {boolean}
+ */
+ColorpickerDialog.isCSSColor = function (cssColor) {
+    return ColorpickerDialog.convertCSSColorToRgba(cssColor) !== false;
 };
 
 return ColorpickerDialog;

--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -1,0 +1,140 @@
+odoo.define('web_editor.utils', function (require) {
+'use strict';
+
+/**
+ * window.getComputedStyle cannot work properly with CSS shortcuts (like
+ * 'border-width' which is a shortcut for the top + right + bottom + left border
+ * widths. If an option wants to customize such a shortcut, it should be listed
+ * here with the non-shortcuts property it stands for, in order.
+ *
+ * @type {Object<string[]>}
+ */
+const CSS_SHORTHANDS = {
+    'border-width': ['border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width'],
+    'border-radius': ['border-top-left-radius', 'border-top-right-radius', 'border-bottom-right-radius', 'border-bottom-left-radius'],
+};
+/**
+ * Key-value mapping to list converters from an unit A to an unit B.
+ * - The key is a string in the format '$1-$2' where $1 is the CSS symbol of
+ *   unit A and $2 is the CSS symbol of unit B.
+ * - The value is a function that converts the received value (expressed in
+ *   unit A) to another value expressed in unit B. Two other parameters is
+ *   received: the css property on which the unit applies and the jQuery element
+ *   on which that css property may change.
+ */
+const CSS_UNITS_CONVERSION = {
+    's-ms': () => 1000,
+    'ms-s': () => 0.001,
+    'rem-px': () => _computePxByRem(),
+    'px-rem': () => _computePxByRem(true),
+};
+
+/**
+ * Computes the number of "px" needed to make a "rem" unit. Subsequent calls
+ * returns the cached computed value.
+ *
+ * @param {boolean} [toRem=false]
+ * @returns {float} - number of px by rem if 'toRem' is false
+ *                  - the inverse otherwise
+ */
+function _computePxByRem(toRem) {
+    if (_computePxByRem.PX_BY_REM === undefined) {
+        const htmlStyle = window.getComputedStyle(document.documentElement);
+        _computePxByRem.PX_BY_REM = parseFloat(htmlStyle['font-size']);
+    }
+    return toRem ? (1 / _computePxByRem.PX_BY_REM) : _computePxByRem.PX_BY_REM;
+}
+/**
+ * Converts the given (value + unit) string to a numeric value expressed in
+ * the other given css unit.
+ *
+ * e.g. fct('400ms', 's') -> 0.4
+ *
+ * @param {string} value
+ * @param {string} unitTo
+ * @param {string} [cssProp] - the css property on which the unit applies
+ * @param {jQuery} [$target] - the jQuery element on which that css property
+ *                             may change
+ * @returns {number}
+ */
+function _convertValueToUnit(value, unitTo, cssProp, $target) {
+    const m = _getNumericAndUnit(value);
+    if (!m) {
+        return NaN;
+    }
+    const numValue = parseFloat(m[1]);
+    const valueUnit = m[2];
+    return _convertNumericToUnit(numValue, valueUnit, unitTo, cssProp, $target);
+}
+/**
+ * Converts the given numeric value expressed in the given css unit into
+ * the corresponding numeric value expressed in the other given css unit.
+ *
+ * e.g. fct(400, 'ms', 's') -> 0.4
+ *
+ * @param {number} value
+ * @param {string} unitFrom
+ * @param {string} unitTo
+ * @param {string} [cssProp] - the css property on which the unit applies
+ * @param {jQuery} [$target] - the jQuery element on which that css property
+ *                             may change
+ * @returns {number}
+ */
+function _convertNumericToUnit(value, unitFrom, unitTo, cssProp, $target) {
+    if (Math.abs(value) < Number.EPSILON || unitFrom === unitTo) {
+        return value;
+    }
+    const converter = CSS_UNITS_CONVERSION[`${unitFrom}-${unitTo}`];
+    if (converter === undefined) {
+        throw new Error(`Cannot convert '${unitFrom}' units into '${unitTo}' units !`);
+    }
+    return value * converter(cssProp, $target);
+}
+/**
+ * Returns the numeric value and unit of a css value.
+ *
+ * e.g. fct('400ms') -> [400, 'ms']
+ *
+ * @param {string} value
+ * @returns {Array|null}
+ */
+function _getNumericAndUnit(value) {
+    return value.trim().match(/^([0-9.]+)(\w*)$/);
+}
+/**
+ * Checks if two css values are equal.
+ *
+ * @param {string} value1
+ * @param {string} value2
+ * @param {string} [cssProp] - the css property on which the unit applies
+ * @param {jQuery} [$target] - the jQuery element on which that css property
+ *                             may change
+ * @returns {boolean}
+ */
+function _areCssValuesEqual(value1, value2, cssProp, $target) {
+    // String comparison first
+    if (value1 === value2) {
+        return true;
+    }
+
+    // Convert the second value in the unit of the first one and compare
+    // floating values
+    const data = _getNumericAndUnit(value1);
+    if (!data) {
+        return false;
+    }
+    const numValue1 = data[0];
+    const numValue2 = _convertValueToUnit(value2, data[1], cssProp, $target);
+    return (Math.abs(numValue1 - numValue2) < Number.EPSILON);
+}
+
+return {
+    CSS_SHORTHANDS: CSS_SHORTHANDS,
+    CSS_UNITS_CONVERSION: CSS_UNITS_CONVERSION,
+    computePxByRem: _computePxByRem,
+    convertValueToUnit: _convertValueToUnit,
+    convertNumericToUnit: _convertNumericToUnit,
+    getNumericAndUnit: _getNumericAndUnit,
+    areCssValuesEqual: _areCssValuesEqual,
+};
+});

--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -14,6 +14,7 @@ const ColorpickerDialog = require('web.ColorpickerDialog');
 const CSS_SHORTHANDS = {
     'border-width': ['border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width'],
     'border-radius': ['border-top-left-radius', 'border-top-right-radius', 'border-bottom-right-radius', 'border-bottom-left-radius'],
+    'border-color': ['border-top-color', 'border-right-color', 'border-bottom-color', 'border-left-color'],
 };
 /**
  * Key-value mapping to list converters from an unit A to an unit B.

--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -1,6 +1,8 @@
 odoo.define('web_editor.utils', function (require) {
 'use strict';
 
+const ColorpickerDialog = require('web.ColorpickerDialog');
+
 /**
  * window.getComputedStyle cannot work properly with CSS shortcuts (like
  * 'border-width' which is a shortcut for the top + right + bottom + left border
@@ -112,6 +114,10 @@ function _getNumericAndUnit(value) {
  * @returns {boolean}
  */
 function _areCssValuesEqual(value1, value2, cssProp, $target) {
+    // If not colors, they will be left untouched
+    value1 = ColorpickerDialog.normalizeCSSColor(value1);
+    value2 = ColorpickerDialog.normalizeCSSColor(value2);
+
     // String comparison first
     if (value1 === value2) {
         return true;

--- a/addons/web_editor/static/src/js/editor/rte.js
+++ b/addons/web_editor/static/src/js/editor/rte.js
@@ -767,6 +767,7 @@ return {
 odoo.define('web_editor.rte.summernote_custom_colors', function (require) {
 'use strict';
 
+// These colors are already normalized as per normalizeCSSColor in web.ColorpickerDialog
 return [
     ['#000000', '#424242', '#636363', '#9C9C94', '#CEC6CE', '#EFEFEF', '#F7F7F7', '#FFFFFF'],
     ['#FF0000', '#FF9C00', '#FFFF00', '#00FF00', '#00FFFF', '#0000FF', '#9C00FF', '#FF00FF'],

--- a/addons/web_editor/static/src/js/editor/rte.summernote.js
+++ b/addons/web_editor/static/src/js/editor/rte.summernote.js
@@ -4,6 +4,7 @@ odoo.define('web_editor.rte.summernote', function (require) {
 var Class = require('web.Class');
 const concurrency = require('web.concurrency');
 var core = require('web.core');
+const ColorpickerDialog = require('web.ColorpickerDialog');
 var ColorPaletteWidget = require('web_editor.ColorPalette').ColorPaletteWidget;
 var mixins = require('web.mixins');
 var fonts = require('wysiwyg.fonts');
@@ -50,13 +51,17 @@ renderer.createPalette = function ($container, options) {
                 const targetNode = r.sc;
                 const targetElement = targetNode.nodeType === Node.ELEMENT_NODE ? targetNode : targetNode.parentNode;
                 colorpicker = new ColorPaletteWidget(parent, {
-                    colorPrefix: eventName === "foreColor" ? 'text-' : 'bg-',
                     excluded: ['transparent_grayscale'],
                     $editable: rte.Class.prototype.editable(), // Our parent is the root widget, we can't retrieve the editable section from it...
                     selectedColor: $(targetElement).css(eventName === "foreColor" ? 'color' : 'backgroundColor'),
-                    targetClasses: [...targetElement.classList],
                 });
-                colorpicker.on('color_picked', null, ev => applyColor(ev.data.target, eventName, ev.data.cssColor));
+                colorpicker.on('color_picked', null, ev => {
+                    let color = ev.data.color;
+                    if (!ColorpickerDialog.isCSSColor(color)) {
+                        color = (eventName === "foreColor" ? 'text-' : 'bg-') + color;
+                    }
+                    applyColor(ev.data.target, eventName, color);
+                });
                 colorpicker.on('color_reset', null, ev => applyColor(ev.data.target, eventName, 'inherit'));
                 return colorpicker.replace(hookEl).then(() => {
                     if (oldColorpicker) {

--- a/addons/web_editor/static/src/js/editor/rte.summernote.js
+++ b/addons/web_editor/static/src/js/editor/rte.summernote.js
@@ -56,7 +56,7 @@ renderer.createPalette = function ($container, options) {
                     selectedColor: $(targetElement).css(eventName === "foreColor" ? 'color' : 'backgroundColor'),
                     targetClasses: [...targetElement.classList],
                 });
-                colorpicker.on('color_picked custom_color_picked', null, ev => applyColor(ev.data.target, eventName, ev.data.cssColor));
+                colorpicker.on('color_picked', null, ev => applyColor(ev.data.target, eventName, ev.data.cssColor));
                 colorpicker.on('color_reset', null, ev => applyColor(ev.data.target, eventName, 'inherit'));
                 return colorpicker.replace(hookEl).then(() => {
                     if (oldColorpicker) {

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -145,6 +145,15 @@ var SnippetEditor = Widget.extend({
     //--------------------------------------------------------------------------
 
     /**
+     * Checks whether the snippet options are shown or not.
+     *
+     * @returns {boolean}
+     */
+    areOptionsShown: function () {
+        const lastIndex = this._customize$Elements.length - 1;
+        return !!this._customize$Elements[lastIndex].parent().length;
+    },
+    /**
      * Notifies all the associated snippet options that the snippet has just
      * been dropped in the page.
      */
@@ -163,6 +172,17 @@ var SnippetEditor = Widget.extend({
         }
         _.each(this.styles, function (option) {
             option.cleanForSave();
+        });
+    },
+    /**
+     * Closes all widgets of all options.
+     */
+    closeWidgets: function () {
+        if (!this.areOptionsShown()) {
+            return;
+        }
+        Object.keys(this.styles).forEach(key => {
+            this.styles[key].closeWidgets();
         });
     },
     /**
@@ -288,9 +308,7 @@ var SnippetEditor = Widget.extend({
             return;
         }
 
-        var lastIndex = this._customize$Elements.length - 1;
-        var optionsAlreadyShown = !!this._customize$Elements[lastIndex].parent().length;
-        if (optionsAlreadyShown === show) {
+        if (this.areOptionsShown() === show) {
             return;
         }
         this.trigger_up('update_customize_elements', {
@@ -666,7 +684,6 @@ var SnippetsMenu = Widget.extend({
     id: 'oe_snippets',
     cacheSnippetTemplate: {},
     events: {
-        'click we-select': '_onOptionTogglerClick',
         'click .o_install_btn': '_onInstallBtnClick',
     },
     custom_events: {
@@ -684,6 +701,7 @@ var SnippetsMenu = Widget.extend({
         'hide_overlay': '_onHideOverlay',
         'block_preview_overlays': '_onBlockPreviewOverlays',
         'unblock_preview_overlays': '_onUnblockPreviewOverlays',
+        'user_value_widget_opening': '_onUserValueWidgetOpening',
     },
 
     /**
@@ -1669,21 +1687,6 @@ var SnippetsMenu = Widget.extend({
         this.cleanForSave();
     },
     /**
-     * @private
-     * @param {*} ev
-     */
-    _onOptionTogglerClick: function (ev) {
-        var togglerEl = ev.currentTarget;
-        if (togglerEl.tagName !== 'WE-TOGGLER') {
-            togglerEl = togglerEl.querySelector('we-toggler');
-        }
-
-        var $hierarchyTogglers = $(togglerEl).parents('we-select').children('we-toggler');
-        this.$('we-select').children('we-toggler').not($hierarchyTogglers).removeClass('active');
-        $hierarchyTogglers.not(togglerEl).addClass('active');
-        togglerEl.classList.toggle('active');
-    },
-    /**
      * Called when the overlay dimensions/positions should be recomputed.
      *
      * @private
@@ -1835,6 +1838,13 @@ var SnippetsMenu = Widget.extend({
         this.$('.o_we_add_snippet_btn').toggleClass('active', !customize);
         this.customizePanel.classList.toggle('d-none', !customize);
         this.$('.o_we_customize_snippet_btn').toggleClass('active', customize);
+    },
+    /**
+     * Called when an user value widget is being opened -> close all the other
+     * user value widgets of all editors.
+     */
+    _onUserValueWidgetOpening: function () {
+        this.snippetEditors.forEach(editor => editor.closeWidgets());
     },
 });
 

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -319,6 +319,7 @@ var SnippetEditor = Widget.extend({
             var styles = _.values(editor.styles);
             _.sortBy(styles, '__order').forEach(style => {
                 if (show) {
+                    style.updateUI();
                     style.onFocus();
                 } else {
                     style.onBlur();

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -581,6 +581,7 @@ const SelectUserValueWidget = UserValueWidget.extend({
                 return;
             }
         }
+        this._super(...arguments);
     },
 
     //--------------------------------------------------------------------------
@@ -845,15 +846,168 @@ const MultiUserValueWidget = UserValueWidget.extend({
     },
 });
 
+const ColorpickerUserValueWidget = SelectUserValueWidget.extend({ // FIXME should be reloaded on focus
+    custom_events: {
+        'color_picked': '_onColorPicked',
+        'color_hover': '_onColorHovered',
+        'color_leave': '_onColorLeft',
+        'color_reset': '_onColorReset',
+    },
+
+    /**
+     * @override
+     */
+    init: function () {
+        this._super(...arguments);
+        if (!this.title) {
+            this.title = ' ';
+        }
+    },
+    /**
+     * @override
+     */
+    start: async function () {
+        const _super = this._super.bind(this);
+        const args = arguments;
+
+        this.el.classList.add('o_we_so_color_palette');
+
+        // Pre-instanciate the color palette widget
+        await this._renderColorPalette();
+
+        // Build the select element with a custom span to hold the color preview
+        this.colorPreviewEl = document.createElement('span');
+        this.options.childNodes = [this.colorPalette.el];
+        this.options.valueEl = this.colorPreviewEl;
+
+        return _super(...args);
+    },
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    getMethodsParams: function () {
+        return _.extend(this._super(...arguments), {
+            colorNames: this.colorPalette.getColorNames(),
+        });
+    },
+    /**
+     * @override
+     */
+    getValue: function (methodName) {
+        return this._previewColor || this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    isContainer: function () {
+        return false;
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     * @returns {Promise}
+     */
+    _renderColorPalette: function () {
+        const options = {};
+        options.selectedColor = this._value;
+        if (this.options.dataAttributes.excluded) {
+            options.excluded = this.options.dataAttributes.excluded.replace(/ /g, '').split(',');
+        }
+        const oldColorPalette = this.colorPalette;
+        this.colorPalette = new ColorPaletteWidget(this, options);
+        if (oldColorPalette) {
+            return this.colorPalette.insertAfter(oldColorPalette.el).then(() => {
+                oldColorPalette.destroy();
+            });
+        }
+        return this.colorPalette.appendTo(document.createDocumentFragment());
+    },
+    /**
+     * Updates the color preview + re-render the whole color palette widget.
+     *
+     * @override
+     */
+    _updateUI: function (color) {
+        this._super(...arguments);
+
+        this.colorPreviewEl.classList.remove(...this.colorPalette.getColorNames().map(c => 'bg-' + c));
+        this.colorPreviewEl.style.removeProperty('backgroundColor');
+
+        if (this._value) {
+            if (ColorpickerDialog.isCSSColor(this._value)) {
+                this.colorPreviewEl.style.backgroundColor = this._value;
+            } else {
+                this.colorPreviewEl.classList.add('bg-' + this._value);
+            }
+        }
+
+        this._renderColorPalette(); // FIXME this is kinda async...
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Called when a color button is clicked -> confirms the preview.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onColorPicked: function (ev) {
+        this._previewColor = false;
+        this._value = ev.data.color;
+        this._notifyValueChange(false);
+    },
+    /**
+     * Called when a color button is entered -> previews the background color.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onColorHovered: function (ev) {
+        this._previewColor = ev.data.color;
+        this._notifyValueChange(true);
+    },
+    /**
+     * Called when a color button is left -> cancels the preview.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onColorLeft: function (ev) {
+        this._previewColor = false;
+        this._notifyValueChange('reset');
+    },
+    /**
+     * Called when the color reset button is clicked -> removes all color
+     * classes and color styles.
+     *
+     * @private
+     */
+    _onColorReset: function () {
+        this._value = '';
+        this._notifyValueChange(false);
+    },
+});
+
 const userValueWidgetsRegistry = {
     'we-button': ButtonUserValueWidget,
     'we-checkbox': CheckboxUserValueWidget,
     'we-select': SelectUserValueWidget,
     'we-input': InputUserValueWidget,
     'we-multi': MultiUserValueWidget,
+    'we-colorpicker': ColorpickerUserValueWidget,
 };
-
-//::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 /**
  * Handles a set of options for one snippet. The registry returned by this
@@ -1041,7 +1195,49 @@ const SnippetOptionWidget = Widget.extend({
      * @param {Object} params
      */
     selectStyle: function (previewMode, widgetValue, params) {
+        if (params.cssProperty === 'background-color') {
+            this.$target.trigger('background-color-event', previewMode);
+        }
+
         const cssProps = weUtils.CSS_SHORTHANDS[params.cssProperty] || [params.cssProperty];
+        for (const cssProp of cssProps) {
+            // Always reset the inline style first to not put inline style on an
+            // element which already have this style through css stylesheets.
+            this.$target[0].style.setProperty(cssProp, '');
+        }
+
+        // Only allow to use a color name as a className if we know about the
+        // other potential color names (to remove) and if we know about a prefix
+        // (otherwise we suppose that we should use the actual related color).
+        if (params.colorNames && params.colorPrefix) {
+            const classes = params.colorNames.map(c => params.colorPrefix + c);
+            this.$target[0].classList.remove(...classes);
+
+            if (params.colorNames.includes(widgetValue)) {
+                const originalCSSValue = window.getComputedStyle(this.$target[0])[cssProps[0]];
+                const className = params.colorPrefix + widgetValue;
+                this.$target[0].classList.add(className);
+                if (originalCSSValue !== window.getComputedStyle(this.$target[0])[cssProps[0]]) {
+                    // If applying the class did indeed changed the css
+                    // property we are editing, nothing more has to be done.
+                    return;
+                }
+                // Otherwise, it means that class probably does not exist,
+                // we remove it and continue. Especially useful for some
+                // prefixes which only work with some color names but not all.
+                this.$target[0].classList.remove(className);
+            }
+        }
+
+        // At this point, the widget value is either a property/color name or
+        // an actual css property value. If it is a property/color name, we will
+        // apply a css variable as style value.
+        const htmlStyle = window.getComputedStyle(document.documentElement);
+        const htmlPropValue = htmlStyle.getPropertyValue('--' + widgetValue);
+        if (htmlPropValue) {
+            widgetValue = `var(--${widgetValue})`;
+        }
+
         const values = widgetValue.split(/\s+/g);
         while (values.length < cssProps.length) {
             switch (values.length) {
@@ -1058,12 +1254,6 @@ const SnippetOptionWidget = Widget.extend({
                     values.push(values[values.length - 1]);
                 }
             }
-        }
-
-        for (const cssProp of cssProps) {
-            // Always reset the inline style first to not put inline style on an
-            // element which already have this style through css stylesheets.
-            this.$target[0].style.setProperty(cssProp, '');
         }
 
         const styles = window.getComputedStyle(this.$target[0]);
@@ -1172,6 +1362,14 @@ const SnippetOptionWidget = Widget.extend({
                 return dataValue || params.attributeDefaultValue || '';
             }
             case 'selectStyle': {
+                if (params.colorPrefix && params.colorNames) {
+                    for (const c of params.colorNames) {
+                        if (this.$target[0].classList.contains(params.colorPrefix + c)) {
+                            return c;
+                        }
+                    }
+                }
+
                 const styles = window.getComputedStyle(this.$target[0]);
                 const cssProps = weUtils.CSS_SHORTHANDS[params.cssProperty] || [params.cssProperty];
                 const cssValues = cssProps.map(cssProp => {
@@ -1210,7 +1408,7 @@ const SnippetOptionWidget = Widget.extend({
      * @returns {string}
      */
     _normalizeWidgetValue: function (value) {
-        value = `${value}`; // Force to string
+        value = `${value}`.trim(); // Force to a trimmed string
         value = ColorpickerDialog.normalizeCSSColor(value); // If is a css color, normalize it
         return value;
     },
@@ -1689,135 +1887,6 @@ registry['sizing_y'] = registry.sizing.extend({
             s: [grid.map(v => sClass + v), grid, sProp],
         };
         return this.grid;
-    },
-});
-
-/**
- * Handles the edition of snippet's background color classes.
- */
-registry.colorpicker = SnippetOptionWidget.extend({
-    xmlDependencies: ['/web_editor/static/src/xml/snippets.xml'],
-    custom_events: {
-        'color_picked': '_onColorPicked',
-        'color_hover': '_onColorHovered',
-        'color_leave': '_onColorLeft',
-        'color_reset': '_onColorReset',
-    },
-
-    /**
-     * @override
-     */
-    start: async function () {
-        const _super = this._super.bind(this);
-        const args = arguments;
-
-        // Pre-instanciate the color palette widget
-        const options = {
-            selectedColor: this.$target.css('background-color'),
-            targetClasses: [...this.$target[0].classList],
-        };
-        if (this.data.paletteExclude) {
-            options.excluded = this.data.paletteExclude.replace(/ /g, '').split(',');
-        }
-        if (this.data.colorPrefix) {
-            options.colorPrefix = this.data.colorPrefix;
-        }
-        this.colorPalette = new ColorPaletteWidget(this, options);
-        await this.colorPalette.appendTo(document.createDocumentFragment());
-
-        // Build the select element with a custom span to hold the color preview
-        this.colorPreviewEl = document.createElement('span');
-        const selectWidget = new SelectUserValueWidget(this, this.data.string, {
-            classes: ['o_we_so_color_palette'],
-            childNodes: [this.colorPalette.el],
-            valueEl: this.colorPreviewEl,
-        });
-        await selectWidget.appendTo(document.createDocumentFragment());
-
-        // Replace the colorpicker UI with the select element
-        this.$el.empty().append(selectWidget.el);
-        return _super(...args);
-    },
-    /**
-     * @override
-     */
-    onFocus: function () {
-        this.colorPalette.reloadColorPalette();
-    },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * Change the color of the targeted background
-     *
-     * @private
-     * @param {string} cssColor
-     * @param {boolean} isClass
-     */
-    _changeTargetColor: function (cssColor, isClass) {
-        this.$target[0].classList.remove(...this.colorPalette.getClasses());
-        if (isClass) {
-            this.$target.addClass(cssColor);
-        } else {
-            this.$target.css('background-color', cssColor);
-        }
-    },
-    /**
-     * @override
-     */
-    _updateUI: function () {
-        this._super.apply(this, arguments);
-        this.colorPreviewEl.style.backgroundColor = this.$target.css('background-color');
-    },
-
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * Called when a color button is clicked -> confirm the preview.
-     *
-     * @private
-     * @param {Event} ev
-     */
-    _onColorPicked: function (ev) {
-        this._changeTargetColor(ev.data.cssColor);
-        this._updateUI();
-        this.$target.closest('.o_editable').trigger('content_changed');
-        this.$target.trigger('background-color-event', false);
-    },
-    /**
-     * Called when a color button is entered -> preview the background color.
-     *
-     * @private
-     * @param {Event} ev
-     */
-    _onColorHovered: function (ev) {
-        this._changeTargetColor(ev.data.cssColor, ev.data.isClass);
-        this.$target.trigger('background-color-event', true);
-    },
-    /**
-     * Called when a color button is left -> cancel the preview.
-     *
-     * @private
-     * @param {Event} ev
-     */
-    _onColorLeft: function (ev) {
-        this._changeTargetColor(ev.data.cssColor, ev.data.isClass);
-        this.$target.trigger('background-color-event', 'reset');
-    },
-    /**
-     * Called when the color reset button is clicked -> remove all background
-     * color classes.
-     *
-     * @private
-     */
-    _onColorReset: function () {
-        this._changeTargetColor('');
-        this._updateUI();
-        this.$target.trigger('content_changed');
     },
 });
 

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -295,6 +295,27 @@ var SnippetOption = Widget.extend({
         }
     },
     /**
+     * Default option method which allows to select one and only one value in
+     * the option values set and set it on the associated snippet as a data
+     * attribute. The name of the data attribute is given by the closest
+     * ancestor's data value for 'attributeName'.
+     *
+     * @param {boolean} previewMode - @see this.selectClass
+     * @param {Object} value - the data attribute value to set
+     * @param {jQuery} $opt - the related DOMElement option
+     */
+    selectDataAttribute: function (previewMode, value, $opt) {
+        const $ancestor = $opt && $opt.closest('[data-attribute-name]');
+        if (!$ancestor || !$ancestor.length) {
+            return;
+        }
+        const dataName = $ancestor[0].dataset.attributeName;
+        if (!dataName) {
+            return;
+        }
+        this.$target[0].dataset[dataName] = value || '';
+    },
+    /**
      * Default option method which allows to select one or multiple classes in
      * the option classes set and set it on the associated snippet. The common
      * case is having a sub-collapse with each item having a `data-toggle-class`
@@ -527,6 +548,23 @@ var SnippetOption = Widget.extend({
                 .last()
                 .addClass('active');
         }
+
+        // --- SELECT DATA ATTRIBUTE ---
+
+        this.$el.find('[data-select-data-attribute]')
+            .removeClass('active')
+            .filter((i, el) => {
+                const ancestorEl = el.closest('[data-attribute-name]');
+                if (!ancestorEl) {
+                    return false;
+                }
+                const dataName = ancestorEl.dataset.attributeName;
+                const defaultValue = ancestorEl.dataset.attributeDefaultValue;
+                const dataValue = el.dataset.selectDataAttribute;
+                const targetValue = this.$target[0].dataset[dataName] || defaultValue;
+                return (!targetValue && !dataValue) || targetValue === dataValue;
+            })
+            .addClass('active');
 
         // --- SET DATA ATTRIBUTE --- (note: important to be done last because of active removal)
 

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2,6 +2,7 @@ odoo.define('web_editor.snippets.options', function (require) {
 'use strict';
 
 var core = require('web.core');
+const ColorpickerDialog = require('web.ColorpickerDialog');
 var Widget = require('web.Widget');
 var ColorPaletteWidget = require('web_editor.ColorPalette').ColorPaletteWidget;
 const weUtils = require('web_editor.utils');
@@ -1205,6 +1206,15 @@ const SnippetOptionWidget = Widget.extend({
         };
     },
     /**
+     * @param {*}
+     * @returns {string}
+     */
+    _normalizeWidgetValue: function (value) {
+        value = `${value}`; // Force to string
+        value = ColorpickerDialog.normalizeCSSColor(value); // If is a css color, normalize it
+        return value;
+    },
+    /**
      * @private
      * @param {string} widgetName
      * @param {UserValueWidget|this|null} parent
@@ -1377,7 +1387,8 @@ const SnippetOptionWidget = Widget.extend({
         this._userValueWidgets.forEach(widget => {
             widget.getMethodsNames().forEach(methodName => {
                 const value = this._computeWidgetState(methodName, widget.getMethodsParams(methodName));
-                widget.setValue(value, methodName);
+                const normalizedValue = this._normalizeWidgetValue(value);
+                widget.setValue(normalizedValue, methodName);
             });
         });
 
@@ -1688,7 +1699,6 @@ registry.colorpicker = SnippetOptionWidget.extend({
     xmlDependencies: ['/web_editor/static/src/xml/snippets.xml'],
     custom_events: {
         'color_picked': '_onColorPicked',
-        'custom_color_picked': '_onCustomColor',
         'color_hover': '_onColorHovered',
         'color_leave': '_onColorLeft',
         'color_reset': '_onColorReset',
@@ -1772,18 +1782,11 @@ registry.colorpicker = SnippetOptionWidget.extend({
      * @private
      * @param {Event} ev
      */
-    _onColorPicked: function () {
+    _onColorPicked: function (ev) {
+        this._changeTargetColor(ev.data.cssColor);
         this._updateUI();
         this.$target.closest('.o_editable').trigger('content_changed');
         this.$target.trigger('background-color-event', false);
-    },
-    /**
-     * Called when a custom color is selected
-     * @param {*} ev
-     */
-    _onCustomColor: function (ev) {
-        this._changeTargetColor(ev.data.cssColor);
-        this._onColorPicked();
     },
     /**
      * Called when a color button is entered -> preview the background color.

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2,73 +2,869 @@ odoo.define('web_editor.snippets.options', function (require) {
 'use strict';
 
 var core = require('web.core');
-var ColorPaletteWidget = require('web_editor.ColorPalette').ColorPaletteWidget;
 var Widget = require('web.Widget');
+var ColorPaletteWidget = require('web_editor.ColorPalette').ColorPaletteWidget;
+const weUtils = require('web_editor.utils');
 var weWidgets = require('wysiwyg.widgets');
 
 var qweb = core.qweb;
 var _t = core._t;
 
-/**
- * window.getComputedStyle cannot work properly with CSS shortcuts (like
- * 'border-width' which is a shortcut for the top + right + bottom + left border
- * widths. If an options wants to customize such a shortcut, it should be listed
- * here with the non-shortcuts property it stands for, in order.
- *
- * @type {Object<string[]>}
- */
-const CSS_SHORTHANDS = {
-    'border-width': ['border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width'],
-    'border-radius': ['border-top-left-radius', 'border-top-right-radius', 'border-bottom-right-radius', 'border-bottom-left-radius'],
-};
-/**
- * Key-value mapping to list converters from an unit A to an unit B.
- * - The key is a string in the format '$1-$2' where $1 is the CSS symbol of
- *   unit A and $2 is the CSS symbol of unit B.
- * - The value is a function that converts the received value (expressed in
- *   unit A) to another value expressed in unit B. Two other parameters is
- *   received: the css property on which the unit applies and the jQuery element
- *   on which that css property may change.
- */
-const CSS_UNITS_CONVERSION = {
-    's-ms': () => 1000,
-    'ms-s': () => 0.001,
-    'rem-px': () => _computePxByRem(),
-    'px-rem': () => _computePxByRem(true),
-};
 
 /**
- * Computes the number of "px" needed to make a "rem" unit. Subsequent calls
- * returns the cached computed value.
- *
- * @param {boolean} [toRem=false]
- * @returns {float} - number of px by rem if 'toRem' is false
- *                  - the inverse otherwise
+ * @param {HTMLElement} el
+ * @param {string} [title]
+ * @param {Object} [options]
+ * @param {string[]} [options.classes]
+ * @param {Object} [options.dataAttributes]
+ * @returns {HTMLElement} - the original 'el' argument
  */
-function _computePxByRem(toRem) {
-    if (_computePxByRem.PX_BY_REM === undefined) {
-        const htmlStyle = window.getComputedStyle(document.documentElement);
-        _computePxByRem.PX_BY_REM = parseFloat(htmlStyle['font-size']);
+function _addTitleAndAllowedAttributes(el, title, options) {
+    if (title) {
+        const titleEl = _buildTitleElement(title);
+        el.appendChild(titleEl);
     }
-    return toRem ? (1 / _computePxByRem.PX_BY_REM) : _computePxByRem.PX_BY_REM;
+
+    if (options && options.classes) {
+        el.classList.add(...options.classes);
+    }
+    if (options && options.dataAttributes) {
+        for (const key in options.dataAttributes) {
+            el.dataset[key] = options.dataAttributes[key];
+        }
+    }
+
+    return el;
 }
+/**
+ * @param {string} tagName
+ * @param {string} title - @see _addTitleAndAllowedAttributes
+ * @param {Object} options - @see _addTitleAndAllowedAttributes
+ * @returns {HTMLElement}
+ */
+function _buildElement(tagName, title, options) {
+    const el = document.createElement(tagName);
+    return _addTitleAndAllowedAttributes(el, title, options);
+}
+/**
+ * @param {string} title
+ * @returns {HTMLElement}
+ */
+function _buildTitleElement(title) {
+    const titleEl = document.createElement('we-title');
+    titleEl.textContent = title;
+    return titleEl;
+}
+/**
+ * Build the correct DOM for a we-row element.
+ *
+ * @param {string} [title] - @see _buildElement
+ * @param {Object} [options] - @see _buildElement
+ * @param {HTMLElement[]} [options.childNodes]
+ * @returns {HTMLElement}
+ */
+function _buildRowElement(title, options) {
+    const groupEl = _buildElement('we-row', title, options);
+
+    const rowEl = document.createElement('div');
+    groupEl.appendChild(rowEl);
+
+    if (options && options.childNodes) {
+        options.childNodes.forEach(node => rowEl.appendChild(node));
+    }
+
+    return groupEl;
+}
+
+//::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+/**
+ * Base class for components to be used in snippet options widgets to retrieve
+ * user values.
+ */
+const UserValueWidget = Widget.extend({
+    custom_events: {
+        'user_value_change': '_onUserValueNotification',
+        'user_value_preview': '_onUserValueNotification',
+        'user_value_reset': '_onUserValueNotification',
+    },
+
+    /**
+     * @constructor
+     */
+    init: function (parent, title, options, $target) {
+        this._super(...arguments);
+        this.title = title;
+        this.options = options;
+        this._userValueWidgets = [];
+        this._value = '';
+        this.$target = $target;
+    },
+    /**
+     * @override
+     */
+    _makeDescriptive: function () {
+        const $el = this._super(...arguments);
+        _addTitleAndAllowedAttributes($el[0], this.title, this.options);
+        return $el;
+    },
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Closes the widget (only meaningful for widgets that can be closed).
+     */
+    close: function () {
+        this._userValueWidgets.forEach(widget => widget.close());
+    },
+    /**
+     * If the widget is a container - @see isContainer -, returns the active
+     * subwidgets it contains (the one which is previewed or the one with an
+     * active value). Otherwise, returns itself.
+     *
+     * @returns {UserValueWidget}
+     */
+    getActiveWidget: function () {
+        const previewedSubWidget = this._userValueWidgets.find(widget => widget.isPreviewed());
+        if (previewedSubWidget) {
+            return previewedSubWidget;
+        }
+        const activeSubWidget = this._userValueWidgets.find(widget => !!widget.getValue());
+        if (activeSubWidget) {
+            return activeSubWidget;
+        }
+        return this;
+    },
+    /**
+     * Returns the names of the option methods associated to the widget. Those
+     * are loaded with @see loadMethodsData.
+     *
+     * @returns {string[]}
+     */
+    getMethodsNames: function () {
+        return this._methodsNames;
+    },
+    /**
+     * Returns the option parameters associated to the widget (for a given
+     * method name or not). Most are loaded with @see loadMethodsData.
+     *
+     * @param {string} [methodName]
+     * @returns {Object}
+     */
+    getMethodsParams: function (methodName) {
+        const params = _.extend({
+            widgetText: this.el.textContent,
+        }, this._methodsParams);
+        if (methodName) {
+            params.possibleValues = params.optionsPossibleValues[methodName] || [];
+            params.defaultValue = params.possibleValues[0] || '';
+        }
+        return params;
+    },
+    /**
+     * Returns the user value that the widget currently holds. The value is a
+     * string, this is the value that will be received in the option methods
+     * of SnippetOptionWidget instances.
+     *
+     * @param {string} [methodName]
+     * @returns {string}
+     */
+    getValue: function (methodName) {
+        const activeWidget = this.getActiveWidget();
+        if (activeWidget && activeWidget !== this) {
+            const value = activeWidget.getValue(methodName);
+            if (value) {
+                return value;
+            }
+        }
+
+        if (this._value) {
+            return this._value;
+        }
+        if (!methodName) {
+            return '';
+        }
+        return this.getMethodsParams(methodName).defaultValue;
+    },
+    /**
+     * Indicates if the widget can contain sub user value widgets or not.
+     *
+     * @returns {boolean}
+     */
+    isContainer: function () {
+        return false;
+    },
+    /**
+     * Indicates if the widget is being previewed or not.
+     *
+     * @returns {boolean}
+     */
+    isPreviewed: function () {
+        return this.el.classList.contains('o_we_preview');
+    },
+    /**
+     * Loads option method names and option method parameters.
+     *
+     * @param {string[]} validMethodNames
+     * @param {Object} extraParams
+     */
+    loadMethodsData: function (validMethodNames, extraParams) {
+        this._methodsNames = [];
+        this._methodsParams = _.extend({}, extraParams);
+        this._methodsParams.optionsPossibleValues = {};
+
+        for (const key in this.el.dataset) {
+            const dataValue = this.el.dataset[key];
+
+            if (validMethodNames.includes(key)) {
+                this._methodsNames.push(key);
+                this._methodsParams.optionsPossibleValues[key] = dataValue.split(/\s*\|\s*/g);
+            } else {
+                this._methodsParams[key] = dataValue;
+            }
+        }
+        this._userValueWidgets.forEach(widget => {
+            const inheritedParams = _.extend({}, this._methodsParams);
+            inheritedParams.optionsPossibleValues = null;
+            widget.loadMethodsData(validMethodNames, inheritedParams);
+            const subMethodsNames = widget.getMethodsNames();
+            const subMethodsParams = widget.getMethodsParams();
+
+            for (const methodName of subMethodsNames) {
+                if (!this._methodsNames.includes(methodName)) {
+                    this._methodsNames.push(methodName);
+                    this._methodsParams.optionsPossibleValues[methodName] = [];
+                }
+                for (const subPossibleValue of subMethodsParams.optionsPossibleValues[methodName]) {
+                    this._methodsParams.optionsPossibleValues[methodName].push(subPossibleValue);
+                }
+            }
+        });
+        for (const methodName of this._methodsNames) {
+            const arr = this._methodsParams.optionsPossibleValues[methodName];
+            const uniqArr = arr.filter((v, i, arr) => i === arr.indexOf(v));
+            this._methodsParams.optionsPossibleValues[methodName] = uniqArr;
+        }
+    },
+    /**
+     * Adds the given widget to the known list of user value sub-widgets (useful
+     * for container widgets).
+     *
+     * @param {UserValueWidget} widget
+     */
+    registerSubWidget: function (widget) {
+        this._userValueWidgets.push(widget);
+    },
+    /**
+     * Sets the user value that the widget should currently hold, for the
+     * given method name.
+     *
+     * Note: a widget typically only holds one value for the only method it
+     * supports. However, widgets can have several methods; in that case, the
+     * value is typically received for a first method and receiving the value
+     * for other ones should not affect the widget (otherwise, it means the
+     * methods are conflicting with each other).
+     *
+     * @param {string} value
+     * @param {string} [methodName]
+     */
+    setValue: function (value, methodName) {
+        this._value = value;
+    },
+    /**
+     * Updates the UI to match the user value the widget currently holds, only
+     * if the UI can currently be updated.
+     *
+     * Note: this method is only needed if @see setValue can make the widget
+     * hold a value which is not synchronized with its current UI (for focus
+     * reasons or other ones) or if the widget is not one capable of holding
+     * a value (but may have an UI which depends on other elements).
+     */
+    updateUI: function () {
+        if (this._canUpdateUI()) {
+            this._updateUI();
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Checks whether or not the UI can be updated. Base case: if an internal
+     * <input/> element is focused we prevent updating the UI.
+     *
+     * @private
+     * @param {*} previewMode
+     */
+    _canUpdateUI: function () {
+        const focusEl = document.activeElement;
+        if (focusEl && focusEl.tagName === 'INPUT'
+                && (this.el === focusEl || this.el.contains(focusEl))) {
+            return false;
+        }
+        return true;
+    },
+    /**
+     * @private
+     * @param {boolean} [previewMode=false]
+     */
+    _notifyValueChange: function (previewMode) {
+        const data = {
+            widget: this,
+        };
+        switch (previewMode) {
+            case undefined:
+            case false: {
+                this.trigger_up('user_value_change', data);
+                break;
+            }
+            case true: {
+                this.trigger_up('user_value_preview', data);
+                break;
+            }
+            default: {
+                this.trigger_up('user_value_reset', data);
+            }
+        }
+    },
+    /**
+     * Updates the UI to match the user value the widget currently holds (this
+     * method is called by @see updateUI and does not perform a check to verify
+     * if the UI can be updated).
+     *
+     * @private
+     */
+    _updateUI: function () {
+        this.el.classList.remove('o_we_preview');
+        this._userValueWidgets.forEach(widget => widget.updateUI());
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Should be called when an user event on the widget indicates a value
+     * change.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onUserValueChange: function (ev) {
+        if (ev.isDefaultPrevented()) {
+            return;
+        }
+
+        if (!this.isPreviewed()) {
+            this._onUserValuePreview(ev);
+        }
+
+        ev.preventDefault();
+        this._notifyValueChange(false);
+    },
+    /**
+     * Allows container widgets to add additional data if needed.
+     *
+     * @private
+     * @param {OdooEvent} ev
+     */
+    _onUserValueNotification: function (ev) {
+        ev.data.widget = this;
+    },
+    /**
+     * Should be called when an user event on the widget indicates a value
+     * preview.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onUserValuePreview: function (ev) {
+        if (ev.isDefaultPrevented()) {
+            return;
+        }
+
+        this.el.classList.add('o_we_preview');
+
+        ev.preventDefault();
+        this._notifyValueChange(true);
+    },
+    /**
+     * Should be called when an user event on the widget indicates a value
+     * reset.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onUserValueReset: function (ev) {
+        if (!this.isPreviewed()) {
+            return;
+        }
+        if (ev.isDefaultPrevented()) {
+            return;
+        }
+
+        this.el.classList.remove('o_we_preview');
+
+        ev.preventDefault();
+        this._notifyValueChange('reset');
+    },
+});
+
+const ButtonUserValueWidget = UserValueWidget.extend({
+    tagName: 'we-button',
+    events: {
+        'click': '_onUserValueChange',
+        'mouseenter': '_onUserValuePreview',
+        'mouseleave': '_onUserValueReset',
+    },
+
+    /**
+     * @override
+     */
+    start: function (parent, title, options) {
+        if (this.options && this.options.childNodes) {
+            this.options.childNodes.forEach(node => this.el.appendChild(node));
+        }
+
+        return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    getValue: function (methodName) {
+        const activeString = this._isActive() ? 'true' : '';
+        if (!methodName || !this._methodsNames.includes(methodName)) {
+            return activeString;
+        }
+        if (activeString) {
+            return this._getActiveValue(methodName);
+        }
+        return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    loadMethodsData: function (validMethodNames) {
+        this._super.apply(this, arguments);
+        for (const methodName of this._methodsNames) {
+            const possibleValues = this._methodsParams.optionsPossibleValues[methodName];
+            if (possibleValues.length <= 1) {
+                possibleValues.unshift('');
+            }
+        }
+    },
+    /**
+     * @override
+     */
+    setValue: function (value, methodName) {
+        let active = !!value;
+        if (methodName) {
+            if (!this._methodsNames.includes(methodName)) {
+                return;
+            }
+            active = (this._getActiveValue(methodName) === value);
+        }
+        this.el.classList.toggle('active', active);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     * @returns {boolean}
+     */
+    _isActive: function () {
+        return this.isPreviewed() || this.el.classList.contains('active');
+    },
+    /**
+     * @private
+     * @param {string} methodName
+     * @returns {string}
+     */
+    _getActiveValue: function (methodName) {
+        const possibleValues = this._methodsParams.optionsPossibleValues[methodName];
+        return possibleValues[possibleValues.length - 1] || '';
+    },
+});
+
+const CheckboxUserValueWidget = ButtonUserValueWidget.extend({
+    className: (ButtonUserValueWidget.prototype.className || '') + ' o_we_checkbox_wrapper',
+
+    /**
+     * @override
+     */
+    start: function () {
+        const checkboxEl = document.createElement('we-checkbox');
+        this.el.appendChild(checkboxEl);
+
+        return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _isActive: function () {
+        return this.isPreviewed() !== this.el.classList.contains('active');
+    },
+});
+
+const SelectUserValueWidget = UserValueWidget.extend({
+    tagName: 'we-select',
+    events: {
+        'click': '_onClick',
+    },
+
+    /**
+     * @override
+     */
+    start: function () {
+        if (this.options && this.options.valueEl) {
+            this.el.appendChild(this.options.valueEl);
+        }
+
+        this.menuTogglerEl = document.createElement('we-toggler');
+        this.el.appendChild(this.menuTogglerEl);
+
+        this.menuEl = document.createElement('we-select-menu');
+        if (this.options && this.options.childNodes) {
+            this.options.childNodes.forEach(node => this.menuEl.appendChild(node));
+        }
+        this.el.appendChild(this.menuEl);
+
+        return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    close: function () {
+        this._super(...arguments);
+        this.menuTogglerEl.classList.remove('active');
+    },
+    /**
+     * @override
+     */
+    isContainer: function () {
+        return true;
+    },
+    /**
+     * @override
+     */
+    setValue: function (value, methodName) {
+        this._userValueWidgets.forEach(widget => {
+            widget.setValue('', methodName);
+        });
+        for (const widget of [...this._userValueWidgets].reverse()) {
+            widget.setValue(value, methodName);
+            if (widget.getValue(methodName)) {
+                // Only one select item can be true at a time, we consider the
+                // last one if multiple would be active.
+                return;
+            }
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _updateUI: function () {
+        this._super(...arguments);
+        const activeSubWidget = this.getActiveWidget();
+        let str = "/";
+        if (activeSubWidget && activeSubWidget !== this) {
+            str = activeSubWidget.el.textContent;
+        }
+        this.menuTogglerEl.textContent = str;
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Called when the select is clicked anywhere -> open/close it.
+     *
+     * @private
+     */
+    _onClick: function () {
+        if (!this.menuTogglerEl.classList.contains('active')) {
+            this.trigger_up('user_value_widget_opening');
+        }
+        this.menuTogglerEl.classList.toggle('active');
+    },
+});
+
+const InputUserValueWidget = UserValueWidget.extend({
+    tagName: 'we-input',
+    events: {
+        'input input': '_onInputInput',
+        'blur input': '_onInputBlur',
+
+        'click': '_onInputClick',
+        'keydown input': '_onInputKeydown',
+    },
+
+    /**
+     * @override
+     */
+    start: function () {
+        const unit = this.el.dataset.unit || '';
+        this.el.dataset.unit = unit;
+        if (this.el.dataset.saveUnit === undefined) {
+            this.el.dataset.saveUnit = unit;
+        }
+
+        this.inputEl = document.createElement('input');
+        this.inputEl.setAttribute('type', 'text');
+        this.el.appendChild(this.inputEl);
+
+        var unitEl = document.createElement('span');
+        unitEl.textContent = unit;
+        this.el.appendChild(unitEl);
+
+        return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    getValue: function (methodName) {
+        const widgetValue = this._super(...arguments);
+
+        const params = this.getMethodsParams(methodName);
+        if (!params.unit) {
+            return widgetValue;
+        }
+
+        let defaultVal = weUtils.convertValueToUnit(params.defaultValue, params.saveUnit, params.cssProperty, this.$target);
+        defaultVal = isNaN(defaultVal) ? params.defaultValue : `${parseFloat(defaultVal.toFixed(3))}${params.saveUnit}`;
+
+        return widgetValue.split(/\s+/g).map(v => {
+            const numValue = parseFloat(v);
+            if (isNaN(numValue)) {
+                return defaultVal;
+            } else {
+                const value = weUtils.convertNumericToUnit(numValue, params.unit, params.saveUnit, params.cssProperty, this.$target);
+                return `${parseFloat(value.toFixed(3))}${params.saveUnit}`;
+            }
+        }).join(' ');
+    },
+    /**
+     * @override
+     */
+    loadMethodsData: function () {
+        this._super(...arguments);
+        let defaultVal = '';
+        for (const methodName of this._methodsNames) {
+            const params = this.getMethodsParams(methodName);
+            if (params.defaultValue && params.defaultValue !== 'true') {
+                defaultVal = weUtils.convertValueToUnit(params.defaultValue, params.saveUnit, params.cssProperty, this.$target);
+                defaultVal = isNaN(defaultVal) ? params.defaultValue : `${parseFloat(defaultVal.toFixed(3))}`;
+            }
+        }
+        this.inputEl.setAttribute('placeholder', defaultVal);
+    },
+    /**
+     * @override
+     */
+    setValue: function (value, methodName) {
+        const params = this.getMethodsParams(methodName);
+        if (!params.unit) {
+            return this._super(value, methodName);
+        }
+
+        const defaultValNum = weUtils.convertValueToUnit(params.defaultValue, params.unit, params.cssProperty, this.$target);
+
+        value = value.split(' ').map(v => {
+            const numValue = weUtils.convertValueToUnit(v, params.unit, params.cssProperty, this.$target);
+            if (isNaN(numValue) || Math.abs(numValue - defaultValNum) < Number.EPSILON) {
+                return ''; // Either equal to the default value and we don't want to display it, or something not supported
+            }
+            return `${parseFloat(numValue.toFixed(3))}`;
+        }).join(' ');
+
+        this._super(value, methodName);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _updateUI: function () {
+        this._super(...arguments);
+        this.inputEl.value = this._value;
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onInputInput: function (ev) {
+        this._value = this.inputEl.value;
+        this._onUserValuePreview(ev);
+    },
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onInputBlur: function (ev) {
+        // Sometimes, an input is focusout for internal reason (like an undo
+        // recording) then focused again manually in the same JS stack
+        // execution. In that case, the blur should not trigger an option
+        // selection as the user did not leave the input. We thus defer the blur
+        // handling to then check that the target is indeed still blurred before
+        // executing the actual option selection.
+        setTimeout(() => {
+            if (ev.currentTarget === document.activeElement) {
+                return;
+            }
+            this._onUserValueChange(ev);
+        });
+    },
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onInputClick: function (ev) {
+        const inputEl = ev.currentTarget.querySelector('input');
+        if (inputEl) {
+            inputEl.select();
+        }
+    },
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onInputKeydown: function (ev) {
+        const input = ev.currentTarget;
+        let value = parseFloat(input.value || input.placeholder);
+        if (isNaN(value)) {
+            return;
+        }
+
+        let step = parseFloat(input.parentNode.dataset.step);
+        if (isNaN(step)) {
+            step = 1.0;
+        }
+        switch (ev.which) {
+            case $.ui.keyCode.UP: {
+                value += step;
+                break;
+            }
+            case $.ui.keyCode.DOWN: {
+                value -= step;
+                break;
+            }
+            default: {
+                return;
+            }
+        }
+
+        input.value = `${parseFloat(value.toFixed(3))}`;
+        $(input).trigger('input');
+    },
+});
+
+const MultiUserValueWidget = UserValueWidget.extend({
+    tagName: 'we-multi',
+
+    /**
+     * @override
+     */
+    start: function () {
+        this.el.appendChild(_buildRowElement('', this.options));
+        return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    getValue: function (methodName) {
+        const value = this._userValueWidgets.map(widget => {
+            return widget.getValue(methodName);
+        }).join(' ').trim();
+
+        return value || this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    isContainer: function () {
+        return true;
+    },
+    /**
+     * @override
+     */
+    setValue: function (value, methodName) {
+        let values = value.split(/\s*\|\s*/g);
+        if (values.length === 1) {
+            values = value.split(/\s+/g);
+        }
+        for (let i = 0; i < this._userValueWidgets.length - 1; i++) {
+            this._userValueWidgets[i].setValue(values.shift() || '', methodName);
+        }
+        this._userValueWidgets[this._userValueWidgets.length - 1].setValue(values.join(' '), methodName);
+    },
+});
+
+const userValueWidgetsRegistry = {
+    'we-button': ButtonUserValueWidget,
+    'we-checkbox': CheckboxUserValueWidget,
+    'we-select': SelectUserValueWidget,
+    'we-input': InputUserValueWidget,
+    'we-multi': MultiUserValueWidget,
+};
+
+//::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 /**
  * Handles a set of options for one snippet. The registry returned by this
- * module contains the names of the specialized SnippetOption which can be
+ * module contains the names of the specialized SnippetOptionWidget which can be
  * referenced thanks to the data-js key in the web_editor options template.
  */
-var SnippetOption = Widget.extend({
+const SnippetOptionWidget = Widget.extend({
     tagName: 'we-customizeblock-option',
-    events: {
-        'mouseenter we-button': '_onOptionPreview',
-        'click we-button': '_onOptionSelection',
-        'mouseleave we-button': '_onOptionCancel',
-
-        'input we-input input': '_onOptionPreview',
-        'blur we-input input': '_onOptionInputBlur',
-        'click we-input': '_onOptionInputClick',
-        'keydown we-input input': '_onOptionInputKeydown',
+    custom_events: {
+        'user_value_change': '_onOptionSelection',
+        'user_value_preview': '_onOptionPreview',
+        'user_value_reset': '_onOptionCancel',
     },
     /**
      * Indicates if the option should be displayed in the button group at the
@@ -89,8 +885,7 @@ var SnippetOption = Widget.extend({
     init: function (parent, $uiElements, $target, $overlay, data, options) {
         this._super.apply(this, arguments);
 
-        this.uiFragment = document.createDocumentFragment();
-        $uiElements.clone(true).appendTo(this.uiFragment);
+        this.$originalUIElements = $uiElements;
 
         this.$target = $target;
         this.$overlay = $overlay;
@@ -100,41 +895,17 @@ var SnippetOption = Widget.extend({
         this.className = 'snippet-option-' + this.data.optionName;
 
         this.ownerDocument = this.$target[0].ownerDocument;
-        this.__methodNames = [];
+
+        this._userValueWidgets = [];
     },
     /**
      * @override
      */
-    willStart: function () {
-        // Build group first as their internal components will be built after
-        this.uiFragment.querySelectorAll('we-row').forEach(el => {
-            const infos = this._extraInfoFromDescriptionElement(el);
-            const groupEl = this._buildRowElement(infos.title, infos.options);
-            el.parentNode.insertBefore(groupEl, el);
-            el.parentNode.removeChild(el);
+    willStart: async function () {
+        await this._super(...arguments);
+        return this._renderOriginalXML().then(uiFragment => {
+            this.uiFragment = uiFragment;
         });
-
-        // Build standard components
-        this.uiFragment.querySelectorAll('we-select').forEach(el => {
-            const infos = this._extraInfoFromDescriptionElement(el);
-            const selectEl = this._buildSelectElement(infos.title, infos.options);
-            el.parentNode.insertBefore(selectEl, el);
-            el.parentNode.removeChild(el);
-        });
-        this.uiFragment.querySelectorAll('we-checkbox').forEach(el => {
-            const infos = this._extraInfoFromDescriptionElement(el);
-            const checkboxEl = this._buildCheckboxElement(infos.title, infos.options);
-            el.parentNode.insertBefore(checkboxEl, el);
-            el.parentNode.removeChild(el);
-        });
-        this.uiFragment.querySelectorAll('we-input').forEach(el => {
-            const infos = this._extraInfoFromDescriptionElement(el);
-            const inputEl = this._buildInputElement(infos.title, infos.options);
-            el.parentNode.insertBefore(inputEl, el);
-            el.parentNode.removeChild(el);
-        });
-
-        return this._super(...arguments);
     },
     /**
      * @override
@@ -142,6 +913,7 @@ var SnippetOption = Widget.extend({
     renderElement: function () {
         this._super(...arguments);
         this.el.appendChild(this.uiFragment);
+        this.uiFragment = null;
     },
     /**
      * Called when the option is initialized (i.e. the parent edition overlay is
@@ -212,176 +984,104 @@ var SnippetOption = Widget.extend({
     //--------------------------------------------------------------------------
 
     /**
-     * Default option method which allows to handle an user input and set the
-     * appropriate data attribute on the associated snippet.
+     * Default option method which allows to select one and only one class in
+     * the option classes set and set it on the associated snippet. The common
+     * case is having a select with each item having a `data-select-class`
+     * value allowing to choose the associated class, or simply an unique
+     * checkbox to allow toggling a unique class.
      *
-     * @param {boolean} previewMode - never 'reset' for this method (@see this.selectClass)
-     * @param {Object} dataName - the data name to customize
-     * @param {jQuery} $opt - the related DOMElement option
+     * @param {boolean|string} previewMode
+     *        - truthy if the option is enabled for preview or if leaving it (in
+     *          that second case, the value is 'reset')
+     *        - false if the option should be activated for good
+     * @param {string} widgetValue
+     * @param {Object} params
      */
-    setDataAttribute: function (previewMode, dataName, $opt) {
-        let hasUserValue = false;
-        const weInput = $opt[0];
-        const inputValue = weInput.querySelector('input').value.trim();
-        const inputUnit = weInput.dataset.unit;
-        const saveUnit = weInput.dataset.saveUnit;
-        const defaultValue = weInput.dataset.defaultValue;
-
-        let value;
-        if (inputValue) {
-            const numValue = parseFloat(inputValue);
-            if (!isNaN(numValue)) {
-                hasUserValue = true;
-                value = this._convertNumericToUnit(numValue, inputUnit, saveUnit);
+    selectClass: function (previewMode, widgetValue, params) {
+        for (const classNames of params.possibleValues) {
+            if (classNames) {
+                this.$target[0].classList.remove(...classNames.trim().split(/\s+/g));
             }
         }
-        if (value === undefined) {
-            value = this._convertValueToUnit(defaultValue, saveUnit);
-        }
-        this.$target[0].dataset[dataName] = isNaN(value) ? defaultValue : parseFloat(value.toFixed(3));
-
-        var extraClass = weInput.dataset.extraClass;
-        if (extraClass) {
-            this.$target.toggleClass(extraClass, hasUserValue);
+        if (widgetValue) {
+            this.$target[0].classList.add(...widgetValue.trim().split(/\s+/g));
         }
     },
     /**
-     * Default option method which allows to handle an user input and set the
-     * appropriate css style on the associated snippet.
+     * Default option method which allows to select a value and set it on the
+     * associated snippet as a data attribute. The name of the data attribute is
+     * given by the attributeName parameter.
      *
-     * @param {boolean} previewMode - never 'reset' for this method (@see this.selectClass)
-     * @param {Object} mainCssProp - the cssProp to customize
-     * @param {jQuery} $opt - the related DOMElement option
+     * @param {boolean} previewMode - @see this.selectClass
+     * @param {string} widgetValue
+     * @param {Object} params
      */
-    setStyle: function (previewMode, mainCssProp, $opt) {
-        let hasUserValue = false;
-        const cssProps = CSS_SHORTHANDS[mainCssProp] || [mainCssProp];
-
-        // Join all inputs controlling the same css property and split user
-        // input into sub-properties (note this code handles the two at the same
-        // time but should normally not be combined).
-        const $weInputs = this.$el.find(`[data-set-style=${mainCssProp}]`);
-        const subValuesByInput = _.map($weInputs, weInput => {
-            const inputValue = weInput.querySelector('input').value.trim();
-            const inputUnit = weInput.dataset.unit;
-            const saveUnit = weInput.dataset.saveUnit;
-            const defaultValue = weInput.dataset.defaultValue;
-            let convertedDefaultValue = this._convertValueToUnit(defaultValue, saveUnit, mainCssProp);
-            convertedDefaultValue = isNaN(convertedDefaultValue) ? defaultValue : (parseFloat(convertedDefaultValue.toFixed(3)) + saveUnit);
-
-            const values = inputValue.split(/\s+/g).map(v => {
-                const numValue = parseFloat(v);
-                if (isNaN(numValue)) {
-                    return convertedDefaultValue;
-                } else {
-                    hasUserValue = true;
-                    const value = this._convertNumericToUnit(numValue, inputUnit, saveUnit, mainCssProp);
-                    return parseFloat(value.toFixed(3)) + saveUnit;
+    selectDataAttribute: function (previewMode, widgetValue, params) {
+        const dataName = params.attributeName;
+        if (dataName) {
+            if (params.saveUnit && !params.withUnit) {
+                // Values that come with an unit are saved without unit as
+                // data-attribute unless told otherwise.
+                widgetValue = widgetValue.split(params.saveUnit).join('');
+            }
+            this.$target[0].dataset[dataName] = widgetValue;
+        }
+        if (params.extraClass) {
+            this.$target.toggleClass(params.extraClass, params.defaultValue !== widgetValue);
+        }
+    },
+    /**
+     * Default option method which allows to select a value and set it on the
+     * associated snippet as a css style. The name of the css property is
+     * given by the cssProperty parameter.
+     *
+     * @param {boolean} previewMode - @see this.selectClass
+     * @param {string} widgetValue
+     * @param {Object} params
+     */
+    selectStyle: function (previewMode, widgetValue, params) {
+        const cssProps = weUtils.CSS_SHORTHANDS[params.cssProperty] || [params.cssProperty];
+        const values = widgetValue.split(/\s+/g);
+        while (values.length < cssProps.length) {
+            switch (values.length) {
+                case 1:
+                case 2: {
+                    values.push(values[0]);
+                    break;
                 }
-            });
-            while (values.length < cssProps.length) {
-                switch (values.length) {
-                    case 1:
-                    case 2:
-                        values.push(values[0]);
-                        break;
-                    case 3:
-                        values.push(values[1]);
-                        break;
-                    default:
-                        values.push(values[values.length - 1]);
+                case 3: {
+                    values.push(values[1]);
+                    break;
+                }
+                default: {
+                    values.push(values[values.length - 1]);
                 }
             }
-            return values;
-        });
+        }
 
         for (const cssProp of cssProps) {
             // Always reset the inline style first to not put inline style on an
             // element which already have this style through css stylesheets.
             this.$target[0].style.setProperty(cssProp, '');
         }
+
         const styles = window.getComputedStyle(this.$target[0]);
-        cssProps.forEach((cssProp, i) => {
-            const cssValue = subValuesByInput.map(inputSubValues => inputSubValues[i]).join(' ');
+        let hasUserValue = false;
+        for (let i = cssProps.length - 1; i > 0; i--) {
+            hasUserValue = applyCSS.call(this, cssProps[i], values.pop(), styles) || hasUserValue;
+        }
+        hasUserValue = applyCSS.call(this, cssProps[0], values.join(' '), styles) || hasUserValue;
+
+        function applyCSS(cssProp, cssValue, styles) {
             if (styles[cssProp] !== cssValue) {
                 this.$target[0].style.setProperty(cssProp, cssValue, 'important');
+                return true;
             }
-        });
+            return false;
+        }
 
-        var extraClass = $opt[0].dataset.extraClass;
-        if (extraClass) {
-            this.$target.toggleClass(extraClass, hasUserValue);
-        }
-    },
-    /**
-     * Default option method which allows to select one and only one class in
-     * the option classes set and set it on the associated snippet. The common
-     * case is having a sub-collapse with each item having a `data-select-class`
-     * value allowing to choose the associated class.
-     *
-     * @param {boolean|string} previewMode
-     *        - truthy if the option is enabled for preview or if leaving it (in
-     *          that second case, the value is 'reset')
-     *        - false if the option should be activated for good
-     * @param {*} value - the class to activate ($opt.data('selectClass'))
-     * @param {jQuery} $opt - the related DOMElement option
-     */
-    selectClass: function (previewMode, value, $opt) {
-        var $group = $opt && $opt.parents('we-select').last();
-        if (!$group || !$group.length) {
-            $group = this.$el;
-        }
-        var $lis = $group.find('[data-select-class]');
-        var classes = $lis.map(function () {
-            return $(this).data('selectClass');
-        }).get().join(' ');
-
-        this.$target.removeClass(classes);
-        if (value) {
-            this.$target.addClass(value);
-        }
-    },
-    /**
-     * Default option method which allows to select one and only one value in
-     * the option values set and set it on the associated snippet as a data
-     * attribute. The name of the data attribute is given by the closest
-     * ancestor's data value for 'attributeName'.
-     *
-     * @param {boolean} previewMode - @see this.selectClass
-     * @param {Object} value - the data attribute value to set
-     * @param {jQuery} $opt - the related DOMElement option
-     */
-    selectDataAttribute: function (previewMode, value, $opt) {
-        const $ancestor = $opt && $opt.closest('[data-attribute-name]');
-        if (!$ancestor || !$ancestor.length) {
-            return;
-        }
-        const dataName = $ancestor[0].dataset.attributeName;
-        if (!dataName) {
-            return;
-        }
-        this.$target[0].dataset[dataName] = value || '';
-    },
-    /**
-     * Default option method which allows to select one or multiple classes in
-     * the option classes set and set it on the associated snippet. The common
-     * case is having a sub-collapse with each item having a `data-toggle-class`
-     * value allowing to toggle the associated class.
-     *
-     * @see this.selectClass
-     */
-    toggleClass: function (previewMode, value, $opt) {
-        const $opts = this.$el.find('[data-toggle-class]').not('[data-set-style]');
-        const classes = $opts.map(function () {
-            return $(this).data('toggleClass');
-        }).get().join(' ');
-        const activeClasses = $opts.filter('.active, :has(.active)').map(function () {
-            return $(this).data('toggleClass');
-        }).get().join(' ');
-
-        this.$target.removeClass(classes).addClass(activeClasses);
-        if (value && previewMode !== 'reset') {
-            this.$target.toggleClass(value);
+        if (params.extraClass) {
+            this.$target.toggleClass(params.extraClass, hasUserValue);
         }
     },
 
@@ -397,6 +1097,12 @@ var SnippetOption = Widget.extend({
      */
     $: function () {
         return this.$target.find.apply(this.$target, arguments);
+    },
+    /**
+     * Closes all user value widgets.
+     */
+    closeWidgets: function () {
+        this._userValueWidgets.forEach(widget => widget.close());
     },
     /**
      * Sometimes, options may need to notify other options, even in parent
@@ -430,191 +1136,61 @@ var SnippetOption = Widget.extend({
     //--------------------------------------------------------------------------
 
     /**
-     * Build the correct DOM for an element according to the given options.
+     * Returns the string value that should be hold by the widget which is
+     * related to the given method name.
      *
      * @private
-     * @param {string} tagName
-     * @param {string} [title]
-     * @param {Object} [options]
-     * @param {string[]} [options.classes]
-     * @param {Object} [options.dataAttributes]
-     * @returns {HTMLElement}
+     * @param {string} methodName
+     * @param {Object} params
+     * @returns {string}
      */
-    _buildElement: function (tagName, title, options) {
-        const el = document.createElement(tagName);
-
-        if (title) {
-            const titleEl = this._buildTitleElement(title);
-            el.appendChild(titleEl);
-        }
-
-        if (options && options.classes) {
-            el.classList.add(...options.classes);
-        }
-        if (options && options.dataAttributes) {
-            for (const key in options.dataAttributes) {
-                el.dataset[key] = options.dataAttributes[key];
+    _computeWidgetState: function (methodName, params) {
+        switch (methodName) {
+            case 'selectClass': {
+                let maxNbClasses = 0;
+                let activeClassNames = '';
+                params.possibleValues.forEach(classNames => {
+                    if (!classNames) {
+                        return;
+                    }
+                    const classes = classNames.split(/\s+/g);
+                    if (classes.length >= maxNbClasses
+                            && classes.every(className => this.$target[0].classList.contains(className))) {
+                        maxNbClasses = classes.length;
+                        activeClassNames = classNames;
+                    }
+                });
+                return activeClassNames;
+            }
+            case 'selectDataAttribute': {
+                const dataName = params.attributeName;
+                let dataValue = (this.$target[0].dataset[dataName] || '').trim();
+                if (params.saveUnit && !params.withUnit) {
+                    dataValue = dataValue.split(/\s+/g).map(v => v + params.saveUnit).join(' ');
+                }
+                return dataValue || params.attributeDefaultValue || '';
+            }
+            case 'selectStyle': {
+                const styles = window.getComputedStyle(this.$target[0]);
+                const cssProps = weUtils.CSS_SHORTHANDS[params.cssProperty] || [params.cssProperty];
+                const cssValues = cssProps.map(cssProp => {
+                    return styles[cssProp].trim();
+                });
+                if (cssValues.length === 4 && weUtils.areCssValuesEqual(cssValues[3], cssValues[1], params.cssProperty, this.$target)) {
+                    cssValues.pop();
+                }
+                if (cssValues.length === 3 && weUtils.areCssValuesEqual(cssValues[2], cssValues[0], params.cssProperty, this.$target)) {
+                    cssValues.pop();
+                }
+                if (cssValues.length === 2 && weUtils.areCssValuesEqual(cssValues[1], cssValues[0], params.cssProperty, this.$target)) {
+                    cssValues.pop();
+                }
+                return cssValues.join(' ');
             }
         }
-
-        return el;
     },
     /**
-     * Build the correct DOM for a we-checkbox element.
-     *
-     * @private
-     * @param {string} [title]
-     * @param {Object} [options] - @see this._buildElement
-     * @returns {HTMLElement}
-     */
-    _buildCheckboxElement: function (title, options) {
-        const buttonEl = this._buildElement('we-button', title, options);
-        buttonEl.classList.add('o_we_checkbox_wrapper');
-
-        const checkboxEl = document.createElement('we-checkbox');
-        buttonEl.appendChild(checkboxEl);
-
-        return buttonEl;
-    },
-    /**
-     * Build the correct DOM for a we-row element.
-     *
-     * @private
-     * @param {string} [title]
-     * @param {Object} [options] - @see this._buildElement
-     * @param {HTMLElement[]} [options.childNodes]
-     * @returns {HTMLElement}
-     */
-    _buildRowElement: function (title, options) {
-        const groupEl = this._buildElement('we-row', title, options);
-
-        const rowEl = document.createElement('div');
-        groupEl.appendChild(rowEl);
-
-        if (options && options.childNodes) {
-            options.childNodes.forEach(node => rowEl.appendChild(node));
-        }
-
-        return groupEl;
-    },
-    /**
-     * Build the correct DOM for a we-input element.
-     *
-     * @private
-     * @param {string} [title]
-     * @param {Object} [options] - @see this._buildElement
-     */
-    _buildInputElement: function (title, options) {
-        const inputWrapperEl = this._buildElement('we-input', title, options);
-
-        var unit = inputWrapperEl.dataset.unit;
-        if (unit === undefined) {
-            unit = 'px';
-        }
-        inputWrapperEl.dataset.unit = unit;
-        if (inputWrapperEl.dataset.saveUnit === undefined) {
-            inputWrapperEl.dataset.saveUnit = unit;
-        }
-
-        var defaultValue = inputWrapperEl.dataset.defaultValue;
-        if (defaultValue === undefined) {
-            defaultValue = ('0' + unit);
-        }
-        inputWrapperEl.dataset.defaultValue = defaultValue;
-
-        var inputEl = document.createElement('input');
-        inputEl.setAttribute('type', 'text');
-        inputEl.setAttribute('placeholder', defaultValue.replace(unit, ''));
-        inputWrapperEl.appendChild(inputEl);
-
-        var unitEl = document.createElement('span');
-        unitEl.textContent = unit;
-        inputWrapperEl.appendChild(unitEl);
-
-        return inputWrapperEl;
-    },
-    /**
-     * Build the correct DOM for a we-select element.
-     *
-     * @private
-     * @param {string} [title]
-     * @param {Object} [options] - @see this._buildElement
-     * @param {HTMLElement[]} [options.childNodes]
-     * @param {HTMLElement} [options.valueEl]
-     * @returns {HTMLElement}
-     */
-    _buildSelectElement: function (title, options) {
-        const selectEl = this._buildElement('we-select', title, options);
-
-        if (options && options.valueEl) {
-            selectEl.appendChild(options.valueEl);
-        }
-
-        const menuTogglerEl = document.createElement('we-toggler');
-        selectEl.appendChild(menuTogglerEl);
-
-        var menuEl = document.createElement('we-select-menu');
-        if (options && options.childNodes) {
-            options.childNodes.forEach(node => menuEl.appendChild(node));
-        }
-        selectEl.appendChild(menuEl);
-
-        return selectEl;
-    },
-    /**
-     * @private
-     * @param {string} title
-     * @returns {HTMLElement}
-     */
-    _buildTitleElement: function (title) {
-        const titleEl = document.createElement('we-title');
-        titleEl.textContent = title;
-        return titleEl;
-    },
-    /**
-     * Converts the given (value + unit) string to a numeric value expressed in
-     * the given css unit.
-     *
-     * e.g. fct('400ms', 's') -> 0.4
-     *
-     * @param {string} value
-     * @param {string} unitTo
-     * @param {string} [cssProp]
-     * @returns {number}
-     */
-    _convertValueToUnit: function (value, unitTo, cssProp) {
-        const m = value.trim().match(/^([0-9.]+)(\w*)$/);
-        if (!m) {
-            return NaN;
-        }
-        const numValue = parseFloat(m[1]);
-        const valueUnit = m[2];
-        return this._convertNumericToUnit(numValue, valueUnit, unitTo, cssProp);
-    },
-    /**
-     * Converts the given numeric value expressed in the given css unit into
-     * the corresponding numeric value expressed in the other given css unit.
-     *
-     * e.g. fct(400, 'ms', 's') -> 0.4
-     *
-     * @param {number} value
-     * @param {string} unitFrom
-     * @param {string} unitTo
-     * @param {string} [cssProp]
-     * @returns {number}
-     */
-    _convertNumericToUnit: function (value, unitFrom, unitTo, cssProp) {
-        if (Math.abs(value) < Number.EPSILON || unitFrom === unitTo) {
-            return value;
-        }
-        const converter = CSS_UNITS_CONVERSION[`${unitFrom}-${unitTo}`];
-        if (converter === undefined) {
-            throw new Error(`Cannot convert ${unitFrom} into ${unitTo} !`);
-        }
-        return value * converter(cssProp, this.$target);
-    },
-    /**
-     * @statis
+     * @static
      * @param {HTMLElement} el
      * @returns {Object}
      */
@@ -629,20 +1205,126 @@ var SnippetOption = Widget.extend({
         };
     },
     /**
+     * @private
+     * @param {string} widgetName
+     * @param {UserValueWidget|this|null} parent
+     * @param {string} title
+     * @param {Object} options
+     * @returns {UserValueWidget}
+     */
+    _registerUserValueWidget: function (widgetName, parent, title, options) {
+        const widget = new userValueWidgetsRegistry[widgetName](parent, title, options, this.$target);
+        if (!parent || parent === this) {
+            this._userValueWidgets.push(widget);
+        } else {
+            parent.registerSubWidget(widget);
+        }
+        return widget;
+    },
+    /**
+     * @private
+     * @param {HTMLElement} uiFragment
+     * @returns {Promise}
+     */
+    _renderCustomWidgets: function (uiFragment) {
+        return Promise.resolve();
+    },
+    /**
+     * @private
+     * @param {HTMLElement} uiFragment
+     * @returns {Promise}
+     */
+    _renderCustomXML: function (uiFragment) {
+        return Promise.resolve();
+    },
+    /**
+     * @private
+     * @param {jQuery} [$xml] - default to original xml content
+     * @returns {Promise}
+     */
+    _renderOriginalXML: async function ($xml) {
+        const uiFragment = document.createDocumentFragment();
+        ($xml || this.$originalUIElements).clone(true).appendTo(uiFragment);
+
+        // Build layouting components first
+        uiFragment.querySelectorAll('we-row').forEach(el => {
+            const infos = this._extraInfoFromDescriptionElement(el);
+            const groupEl = _buildRowElement(infos.title, infos.options);
+            el.parentNode.insertBefore(groupEl, el);
+            el.parentNode.removeChild(el);
+        });
+
+        // Load widgets
+        await this._renderCustomXML(uiFragment);
+        await this._renderXMLWidgets(uiFragment);
+        await this._renderCustomWidgets(uiFragment);
+
+        const validMethodNames = [];
+        for (const key in this) {
+            validMethodNames.push(key);
+        }
+        this._userValueWidgets.forEach(widget => {
+            widget.loadMethodsData(validMethodNames);
+        });
+
+        return uiFragment;
+    },
+
+    /**
+     * @private
+     * @param {HTMLElement} parentEl
+     * @param {SnippetOptionWidget|UserValueWidget} parentWidget
+     * @returns {Promise}
+     */
+    _renderXMLWidgets: function (parentEl, parentWidget) {
+        const proms = [...parentEl.children].map(el => {
+            const widgetName = el.tagName.toLowerCase();
+            if (!userValueWidgetsRegistry.hasOwnProperty(widgetName)) {
+                return this._renderXMLWidgets(el, parentWidget);
+            }
+
+            const infos = this._extraInfoFromDescriptionElement(el);
+            const widget = this._registerUserValueWidget(widgetName, parentWidget || this, infos.title, infos.options);
+            return widget.insertAfter(el).then(() => {
+                // Remove the original element afterwards as the insertion
+                // operation may move some of its inner content during
+                // widget start.
+                parentEl.removeChild(el);
+
+                if (widget.isContainer()) {
+                    return this._renderXMLWidgets(widget.el, widget);
+                }
+            });
+        });
+        return Promise.all(proms);
+    },
+    /**
+     * @private
+     * @param {function<Promise<jQuery>>} [callback]
+     * @returns {Promise}
+     */
+    _rerenderXML: async function (callback) {
+        this._userValueWidgets.forEach(widget => widget.destroy());
+        this._userValueWidgets = [];
+        this.$el.empty();
+
+        let $xml = undefined;
+        if (callback) {
+            $xml = await callback.call(this);
+        }
+
+        return this._renderOriginalXML($xml).then(uiFragment => {
+            this.$el.append(uiFragment);
+            this._updateUI();
+        });
+    },
+    /**
      * Reactivate the options that were activated before previews.
      */
     _reset: function () {
-        var self = this;
-        var $actives = this.$el.find('we-button.active');
-        _.each($actives, function (activeElement) {
-            var $activeElement = $(activeElement);
-            self.__methodNames = _.without.apply(_, [self.__methodNames].concat(_.keys($activeElement.data())));
-            self._select('reset', $activeElement);
+        this._userValueWidgets.forEach(widget => {
+            this._select('reset', widget);
         });
-        _.each(this.__methodNames, function (methodName) {
-            self[methodName]('reset');
-        });
-        this.__methodNames = [];
     },
     /**
      * Activates the option associated to the given DOM element.
@@ -652,11 +1334,12 @@ var SnippetOption = Widget.extend({
      *        - truthy if the option is enabled for preview or if leaving it (in
      *          that second case, the value is 'reset')
      *        - false if the option should be activated for good
-     * @param {jQuery} $opt - the related DOMElement option
+     * @param {UserValueWidget} widget - the widget which triggered the option change
      */
-    _select: function (previewMode, $opt) {
+    _select: function (previewMode, widget) {
         // Options can say they respond to strong choice
-        if (previewMode && ($opt.data('noPreview') || $opt.closest('[data-no-preview="true"]').length)) {
+        if (previewMode && (widget.$el.closest('[data-no-preview="true"]').length)) {
+            // TODO the no-preview flag should be retrieved through widget params
             return;
         }
         // If it is not preview mode, the user selected the option for good
@@ -666,33 +1349,9 @@ var SnippetOption = Widget.extend({
             this.trigger_up('request_history_undo_record', {$target: this.$target});
         }
 
-        // Search for methods (data-...) (i.e. data-toggle-class) on the
-        // selected (sub)option and its parents
-        var el = $opt[0];
-        var methods = [];
-        do {
-            methods.push([el, el.dataset]);
-            el = el.parentNode;
-        } while (this.$el.parent().has(el).length);
-
-        // Call the found method in the right order (parents -> child)
-        methods.reverse().forEach(data => {
-            var $el = $(data[0]);
-            var methods = data[1];
-
-            const isInput = $el.is('we-input');
-
-            Object.keys(methods).forEach(methodName => {
-                if (!this[methodName]) {
-                    return;
-                }
-                if (previewMode === true && !isInput) {
-                    this.__methodNames.push(methodName);
-                }
-                this[methodName](previewMode, methods[methodName], $el);
-            });
+        widget.getMethodsNames().forEach(methodName => {
+            this[methodName](previewMode, widget.getValue(methodName), widget.getMethodsParams(methodName));
         });
-        this.__methodNames = _.uniq(this.__methodNames);
 
         if (!previewMode) {
             this._updateUI();
@@ -701,173 +1360,31 @@ var SnippetOption = Widget.extend({
         this.$target.trigger('content_changed');
     },
     /**
-     * Tweaks the option DOM elements to show the selected value according to
-     * the state of the $target the option customizes.
-     *
-     * @todo should be extendable in a more easy way
      * @private
+     * @deprecated all implementation should use _computeWidgetState or _updateUI
+     *             methods, this method will be removed as soon as possible.
      */
-    _setActive: function () {
-        var self = this;
-
-        // --- TOGGLE CLASS ---
-
-        this.$el.find('[data-toggle-class]')
-            .removeClass('active')
-            .filter(function () {
-                var className = $(this).data('toggleClass');
-                return !className || self.$target.hasClass(className);
-            })
-            .addClass('active');
-
-        // --- SELECT CLASS ---
-
-        // Get submenus which are not inside submenus
-        var $submenus = this.$el.find('we-select')
-            .not('we-select *');
-
-        // Add unique active class for each submenu active item
-        _.each($submenus, function (submenu) {
-            var $elements = $(submenu).find('[data-select-class]');
-            _processSelectClassElements($elements);
-        });
-
-        // Add unique active class for out-of-submenu active item
-        var $externalElements = this.$el.find('[data-select-class]')
-            .not('we-select *');
-        _processSelectClassElements($externalElements);
-
-        function _processSelectClassElements($elements) {
-            var maxNbClasses = -1;
-            $elements.removeClass('active')
-                .filter(function () {
-                    var className = $(this).data('selectClass');
-                    var nbClasses = className ? className.split(' ').length : 0;
-                    if (nbClasses >= maxNbClasses && (!className || self.$target.hasClass(className))) {
-                        maxNbClasses = nbClasses;
-                        return true;
-                    }
-                    return false;
-                })
-                .last()
-                .addClass('active');
-        }
-
-        // --- SELECT DATA ATTRIBUTE ---
-
-        this.$el.find('[data-select-data-attribute]')
-            .removeClass('active')
-            .filter((i, el) => {
-                const ancestorEl = el.closest('[data-attribute-name]');
-                if (!ancestorEl) {
-                    return false;
-                }
-                const dataName = ancestorEl.dataset.attributeName;
-                const defaultValue = ancestorEl.dataset.attributeDefaultValue;
-                const dataValue = el.dataset.selectDataAttribute;
-                const targetValue = this.$target[0].dataset[dataName] || defaultValue;
-                return (!targetValue && !dataValue) || targetValue === dataValue;
-            })
-            .addClass('active');
-
-        // --- SET DATA ATTRIBUTE --- (note: important to be done last because of active removal)
-
-        this.el.querySelectorAll('[data-set-data-attribute]').forEach(el => {
-            el.classList.remove('active');
-            const inputEl = el.querySelector('input');
-            if (inputEl === document.activeElement) {
-                return;
-            }
-
-            const inputUnit = el.dataset.unit;
-            const saveUnit = el.dataset.saveUnit;
-            const defaultValue = el.dataset.defaultValue;
-            const convertedDefaultValue = this._convertValueToUnit(defaultValue, inputUnit);
-
-            let value = this.$target[0].dataset[el.dataset.setDataAttribute];
-            let numValue = parseFloat(value);
-            if (!isNaN(numValue)) {
-                numValue = this._convertNumericToUnit(numValue, saveUnit, inputUnit);
-            }
-            if (isNaN(numValue) || Math.abs(numValue - convertedDefaultValue) < Number.EPSILON) {
-                value = '';
-            } else {
-                value = parseFloat(numValue.toFixed(3));
-            }
-            inputEl.value = value;
-        });
-
-        // --- SET STYLE --- (note: important to be done last because of active removal)
-
-        let styles;
-        const seenSetStyles = [];
-        this.el.querySelectorAll('[data-set-style]').forEach(el => {
-            const mainCssProp = el.dataset.setStyle;
-            if (seenSetStyles.includes(mainCssProp)) {
-                return;
-            }
-            seenSetStyles.push(mainCssProp);
-
-            const $els = this.$el.find(`[data-set-style="${mainCssProp}"]`);
-            $els.removeClass('active');
-            const $inputs = $els.find('> input');
-            if (_.any($inputs, input => input === document.activeElement)) {
-                return;
-            }
-
-            styles = styles || window.getComputedStyle(this.$target[0]);
-            const cssProps = CSS_SHORTHANDS[mainCssProp] || [mainCssProp];
-
-            const valuesByProp = cssProps.map(cssProp => {
-                const cssValue = styles[cssProp];
-                if (!cssValue) {
-                    return [];
-                }
-
-                return cssValue.split(/\s+/).map((v, i) => {
-                    const inputUnit = $els[i].dataset.unit;
-                    const numValue = this._convertValueToUnit(v, inputUnit, mainCssProp);
-                    return isNaN(numValue) ? v : numValue;
-                });
-            });
-            _.each($els, (el, i) => {
-                let values = valuesByProp.map(propValues => propValues[i]);
-
-                if (values.length === 4 && Math.abs(values[3] - values[1]) < Number.EPSILON) {
-                    values.pop();
-                }
-                if (values.length === 3 && Math.abs(values[2] - values[0]) < Number.EPSILON) {
-                    values.pop();
-                }
-                if (values.length === 2 && Math.abs(values[1] - values[0]) < Number.EPSILON) {
-                    values.pop();
-                }
-
-                const inputUnit = el.dataset.unit;
-                const defaultValue = el.dataset.defaultValue;
-                const convertedDefaultValue = this._convertValueToUnit(defaultValue, inputUnit, mainCssProp);
-                if (values.length === 1 && Math.abs(values[0] - convertedDefaultValue) < Number.EPSILON) {
-                    values.pop();
-                }
-
-                values = values.filter(v => isFinite(v));
-                values = values.map(v => parseFloat(v.toFixed(3)));
-                $inputs[i].value = (values.length ? values.join(' ') : '');
-            });
-        });
-    },
+    _setActive: function () {},
     /**
      * @private
      */
     _updateUI: function () {
         this._setActive();
 
-        this.el.querySelectorAll('we-select').forEach(selectEl => {
-            const activeEl = selectEl.querySelector('we-button.active');
-            const valueEl = selectEl.querySelector('we-toggler');
-            if (valueEl) {
-                valueEl.textContent = activeEl ? activeEl.textContent : "/";
-            }
+        // For each widget, for each of their option method, notify to the
+        // widget the current value they should hold according to the $target's
+        // current state, related for that method.
+        this._userValueWidgets.forEach(widget => {
+            widget.getMethodsNames().forEach(methodName => {
+                const value = this._computeWidgetState(methodName, widget.getMethodsParams(methodName));
+                widget.setValue(value, methodName);
+            });
+        });
+
+        // Refresh the UI of all widgets (after all the current values they hold
+        // have been updated).
+        this._userValueWidgets.forEach(widget => {
+            widget.updateUI();
         });
     },
 
@@ -876,63 +1393,6 @@ var SnippetOption = Widget.extend({
     //--------------------------------------------------------------------------
 
     /**
-     * @private
-     * @param {Event} ev
-     */
-    _onOptionInputBlur: function (ev) {
-        // Sometimes, an input is focusout for internal reason (like an undo
-        // recording) then focused again manually in the same JS stack
-        // execution. In that case, the blur should not trigger an option
-        // selection as the user did not leave the input. We thus defer the blur
-        // handling to then check that the target is indeed still blurred before
-        // executing the actual option selection.
-        setTimeout(() => {
-            if (ev.currentTarget === document.activeElement) {
-                return;
-            }
-            this._onOptionSelection(ev);
-        });
-    },
-    /**
-     * @private
-     * @param {Event} ev
-     */
-    _onOptionInputClick: function (ev) {
-        const inputEl = ev.currentTarget.querySelector('input');
-        if (inputEl) {
-            inputEl.select();
-        }
-    },
-    /**
-     * @private
-     * @param {Event} ev
-     */
-    _onOptionInputKeydown: function (ev) {
-        const input = ev.currentTarget;
-        let value = parseFloat(input.value || input.placeholder);
-        if (isNaN(value)) {
-            return;
-        }
-
-        let step = parseFloat(input.parentNode.dataset.step);
-        if (isNaN(step)) {
-            step = 1.0;
-        }
-        switch (ev.which) {
-            case $.ui.keyCode.UP:
-                value += step;
-                break;
-            case $.ui.keyCode.DOWN:
-                value -= step;
-                break;
-            default:
-                return;
-        }
-
-        input.value = parseFloat(value.toFixed(3));
-        $(input).trigger('input');
-    },
-    /**
      * Called when a option link is entered or an option input content is being
      * modified -> activates the related option in preview mode.
      *
@@ -940,16 +1400,8 @@ var SnippetOption = Widget.extend({
      * @param {Event} ev
      */
     _onOptionPreview: function (ev) {
-        var $opt = $(ev.target).closest('we-button, we-input');
-        if (!$opt.length) {
-            return;
-        }
-
-        if (!$opt.is(':hasData')) {
-            return;
-        }
-        this.__click = false;
-        this._select(true, $opt);
+        ev.stopPropagation();
+        this._select(true, ev.data.widget);
         this.$target.trigger('snippet-option-preview', [this]);
     },
     /**
@@ -960,14 +1412,8 @@ var SnippetOption = Widget.extend({
      * @param {Event} ev
      */
     _onOptionSelection: function (ev) {
-        var $opt = $(ev.target).closest('we-button, we-input');
-        if (ev.isDefaultPrevented() || !$opt.length || !$opt.is(':hasData')) {
-            return;
-        }
-
-        ev.preventDefault();
-        this.__click = true;
-        this._select(false, $opt);
+        ev.stopPropagation();
+        this._select(false, ev.data.widget);
         this.$target.trigger('snippet-option-change', [this]);
     },
     /**
@@ -975,23 +1421,18 @@ var SnippetOption = Widget.extend({
      * were activated before previews.
      *
      * @private
+     * @param {Event} ev
      */
-    _onOptionCancel: function () {
-        if (this.__click) {
-            return;
-        }
+    _onOptionCancel: function (ev) {
+        ev.stopPropagation();
         this._reset();
     },
 });
+const registry = {};
 
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-/**
- * The registry object contains the list of available options.
- */
-var registry = {};
-
-registry.sizing = SnippetOption.extend({
+registry.sizing = SnippetOptionWidget.extend({
     /**
      * @override
      */
@@ -1243,7 +1684,7 @@ registry['sizing_y'] = registry.sizing.extend({
 /**
  * Handles the edition of snippet's background color classes.
  */
-registry.colorpicker = SnippetOption.extend({
+registry.colorpicker = SnippetOptionWidget.extend({
     xmlDependencies: ['/web_editor/static/src/xml/snippets.xml'],
     custom_events: {
         'color_picked': '_onColorPicked',
@@ -1276,14 +1717,15 @@ registry.colorpicker = SnippetOption.extend({
 
         // Build the select element with a custom span to hold the color preview
         this.colorPreviewEl = document.createElement('span');
-        const selectEl = this._buildSelectElement(this.data.string, {
+        const selectWidget = new SelectUserValueWidget(this, this.data.string, {
             classes: ['o_we_so_color_palette'],
             childNodes: [this.colorPalette.el],
             valueEl: this.colorPreviewEl,
         });
+        await selectWidget.appendTo(document.createDocumentFragment());
 
         // Replace the colorpicker UI with the select element
-        this.$el.empty().append(selectEl);
+        this.$el.empty().append(selectWidget.el);
         return _super(...args);
     },
     /**
@@ -1379,38 +1821,16 @@ registry.colorpicker = SnippetOption.extend({
 /**
  * Handles the edition of snippet's background image.
  */
-registry.background = SnippetOption.extend({
+registry.background = SnippetOptionWidget.extend({
     /**
      * @override
      */
     start: function () {
-        // Build option UI controls
-        const editBgEl = document.createElement('we-button');
-        editBgEl.dataset.chooseImage = 'true';
-        editBgEl.dataset.noPreview = 'true';
-        const iconEl = document.createElement('i');
-        iconEl.classList.add('fa', 'fa-fw', 'fa-pencil-square-o');
-        this.editBgTextEl = document.createElement('span');
-        editBgEl.appendChild(this.editBgTextEl);
-        editBgEl.appendChild(iconEl);
-
-        this.removeBgEl = document.createElement('we-button');
-        this.removeBgEl.classList.add('fa', 'fa-fw', 'fa-times');
-        this.removeBgEl.title = _t("Remove the background");
-        this.removeBgEl.dataset.background = '';
-        this.removeBgEl.dataset.noPreview = 'true';
-
-        this.$el.append(this._buildRowElement(this.data.string, {
-            childNodes: [editBgEl, this.removeBgEl],
-        }));
-
-        var res = this._super.apply(this, arguments);
-
         // Initialize background and events
         this.bindBackgroundEvents();
         this.__customImageSrc = this._getSrcFromCssValue();
 
-        return res;
+        return this._super(...arguments);
     },
 
     //--------------------------------------------------------------------------
@@ -1422,16 +1842,16 @@ registry.background = SnippetOption.extend({
      *
      * @see this.selectClass for parameters
      */
-    background: function (previewMode, value, $opt) {
-        if (previewMode === 'reset' && value === undefined) {
+    background: function (previewMode, widgetValue, params) {
+        if (previewMode === 'reset') {
             // No background has been selected and we want to reset back to the
             // original custom image
             this._setCustomBackground(this.__customImageSrc);
             return;
         }
 
-        if (value && value.length) {
-            this.$target.css('background-image', 'url(\'' + value + '\')');
+        if (widgetValue) {
+            this.$target.css('background-image', 'url(\'' + widgetValue + '\')');
             this.$target.removeClass('oe_custom_bg').addClass('oe_img_bg');
         } else {
             this.$target.css('background-image', '');
@@ -1439,18 +1859,11 @@ registry.background = SnippetOption.extend({
         }
     },
     /**
-     * @override
-     */
-    selectClass: function (previewMode, value, $opt) {
-        this.background(previewMode, '', $opt);
-        this._super(previewMode, value ? (value + ' oe_img_bg') : value, $opt);
-    },
-    /**
      * Opens a media dialog to add a custom background image.
      *
      * @see this.selectClass for parameters
      */
-    chooseImage: function (previewMode, value, $opt) {
+    chooseImage: function (previewMode, widgetValue, params) {
         var options = this._getMediaDialogOptions();
         var media = this._getEditableMedia();
 
@@ -1554,13 +1967,44 @@ registry.background = SnippetOption.extend({
     _updateUI: function () {
         this._super.apply(this, arguments);
         var src = this._getSrcFromCssValue();
-        this.removeBgEl.classList.toggle('d-none', !src);
+        this.removeBgWidget.el.classList.toggle('d-none', !src);
         if (src) {
             var split = src.split('/');
             this.editBgTextEl.textContent = split[split.length - 1];
         } else {
             this.editBgTextEl.textContent = this._getDefaultTextContent();
         }
+    },
+    /**
+     * @override
+     */
+    _renderCustomWidgets: async function (uiFragment) {
+        // Build option UI controls
+        this.editBgTextEl = document.createElement('span');
+        const iconEl = document.createElement('i');
+        iconEl.classList.add('fa', 'fa-fw', 'fa-pencil-square-o');
+        const editBgWidget = this._registerUserValueWidget('we-button', this, '', {
+            dataAttributes: {
+                chooseImage: 'true',
+                noPreview: 'true',
+            },
+            childNodes: [this.editBgTextEl, iconEl],
+        });
+        await editBgWidget.appendTo(document.createDocumentFragment());
+
+        this.removeBgWidget = this._registerUserValueWidget('we-button', this, '', {
+            classes: ['fa', 'fa-fw', 'fa-times'],
+            dataAttributes: {
+                background: '',
+                noPreview: 'true',
+            },
+        });
+        await this.removeBgWidget.appendTo(document.createDocumentFragment());
+        this.removeBgWidget.el.title = _t("Remove the background");
+
+        return uiFragment.appendChild(_buildRowElement(this.data.string, {
+            childNodes: [editBgWidget.el, this.removeBgWidget.el],
+        }));
     },
     /**
      * Sets the given value as custom background image.
@@ -1570,7 +2014,7 @@ registry.background = SnippetOption.extend({
      */
     _setCustomBackground: function (value) {
         this.__customImageSrc = value;
-        this.background(false, this.__customImageSrc);
+        this.background(false, this.__customImageSrc, {});
         this.$target.toggleClass('oe_custom_bg', !!value);
         this._updateUI();
         this.$target.trigger('snippet-option-change', [this]);
@@ -1616,7 +2060,7 @@ registry.background = SnippetOption.extend({
 /**
  * Handles the edition of snippets' background image position.
  */
-registry.BackgroundPosition = SnippetOption.extend({
+registry.BackgroundPosition = SnippetOptionWidget.extend({
     xmlDependencies: ['/web_editor/static/src/xml/editor.xml'],
 
     /**
@@ -1665,8 +2109,8 @@ registry.BackgroundPosition = SnippetOption.extend({
      *
      * @see this.selectClass for params
      */
-    backgroundType: function (previewMode, value, $opt) {
-        this.$target.toggleClass('o_bg_img_opt_repeat', value === 'repeat-pattern');
+    backgroundType: function (previewMode, widgetValue, params) {
+        this.$target.toggleClass('o_bg_img_opt_repeat', widgetValue === 'repeat-pattern');
         this.$target.css('background-position', '');
         this.$target.css('background-size', '');
     },
@@ -1675,7 +2119,7 @@ registry.BackgroundPosition = SnippetOption.extend({
      *
      * @see this.selectClass for params
      */
-    backgroundPositionOverlay: function (previewMode, value, $opt) {
+    backgroundPositionOverlay: function (previewMode, widgetValue, params) {
         const position = this.$target.css('background-position').split(' ').map(v => parseInt(v));
         // Convert % values to pixels (because mouse movement is in pixels)
         const delta = this._getBackgroundDelta();
@@ -1687,11 +2131,32 @@ registry.BackgroundPosition = SnippetOption.extend({
 
         this._toggleBgOverlay(true);
     },
+    /**
+     * @override
+     */
+    selectStyle: function (previewMode, widgetValue, params) {
+        if (params.cssProperty === 'background-size'
+                && !this.$target.hasClass('o_bg_img_opt_repeat')) {
+            // Disable the option when the image is in cover mode, otherwise
+            // the background-size: auto style may be forced.
+            return;
+        }
+        this._super(...arguments);
+    },
 
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
 
+    /**
+     * @override
+     */
+    _computeWidgetState: function (methodName, params) {
+        if (methodName === 'backgroundType') {
+            return this.$target.css('background-repeat') === 'repeat' ? 'repeat-pattern' : 'cover';
+        }
+        return this._super(...arguments);
+    },
     /**
      * Initializes the overlay, binds events to the buttons, inserts it in
      * the DOM.
@@ -1787,17 +2252,14 @@ registry.BackgroundPosition = SnippetOption.extend({
     },
     /**
      * Disables background position if no background image, disables size inputs
-     * in cover mode, and activates the proper select option.
+     * in cover mode.
      *
      * @override
      */
-    _setActive: function () {
+    _updateUI: function () {
+        this._super.apply(this, arguments);
         this.$el.toggleClass('d-none', this.$target.css('background-image') === 'none');
         this.$el.find('we-input').toggleClass('d-none', this.$target.css('background-repeat') !== 'repeat');
-        this.$el.find('[data-background-type]').removeClass('active')
-            .filter(`[data-background-type=${this.$target.css('background-repeat') === 'repeat' ? 'repeat-pattern' : 'cover'}]`).addClass('active');
-
-        this._super.apply(this, arguments);
     },
     /**
      * Returns the src value from a css value related to a background image
@@ -1914,7 +2376,7 @@ registry.BackgroundPosition = SnippetOption.extend({
  * Allows to replace a text value with the name of a database record.
  * @todo replace this mechanism with real backend m2o field ?
  */
-registry.many2one = SnippetOption.extend({
+registry.many2one = SnippetOptionWidget.extend({
     xmlDependencies: ['/web_editor/static/src/xml/snippets.xml'],
     /**
      * @override
@@ -2074,9 +2536,19 @@ registry.many2one = SnippetOption.extend({
 });
 
 return {
-    Class: SnippetOption,
+    SnippetOptionWidget: SnippetOptionWidget,
+    snippetOptionRegistry: registry,
+
+    UserValueWidget: UserValueWidget,
+    userValueWidgetsRegistry: userValueWidgetsRegistry,
+
+    addTitleAndAllowedAttributes: _addTitleAndAllowedAttributes,
+    buildElement: _buildElement,
+    buildTitleElement: _buildTitleElement,
+    buildRowElement: _buildRowElement,
+
+    // Other names for convenience
+    Class: SnippetOptionWidget,
     registry: registry,
-    CSS_SHORTHANDS: CSS_SHORTHANDS,
-    CSS_UNITS_CONVERSION: CSS_UNITS_CONVERSION,
 };
 });

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -2,6 +2,12 @@
 /// This file regroups basic style rules for web_editor enable page edition and backend utils.
 ///
 
+:root {
+    @each $color, $value in $grays {
+        --#{$color}: #{$value};
+    }
+}
+
 html, body {
     position: relative;
     width: 100%;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -296,26 +296,6 @@ body.editor_enable.editor_has_snippets {
                 @include we-icon-button('\f107');
             }
 
-            we-row {
-                display: block;
-
-                > div {
-                    display: flex;
-                    align-items: center;
-
-                    > * {
-                        flex: 1 1 auto;
-
-                        + * {
-                            margin-left: 0.5em;
-                        }
-                    }
-                    > .fa {
-                        flex: 0 0 auto;
-                    }
-                }
-            }
-
             we-select {
                 position: relative;
                 display: flex;
@@ -373,13 +353,8 @@ body.editor_enable.editor_has_snippets {
             }
 
             we-input {
-                display: flex;
-                align-items: center;
+                @extend we-row.o_we_inline;
 
-                > we-title {
-                    min-width: 60%;
-                    margin-right: 5%;
-                }
                 > input {
                     flex: 1 1 auto;
                     width: 0;
@@ -397,11 +372,47 @@ body.editor_enable.editor_has_snippets {
                 }
             }
 
-            we-row we-input {
-                flex-wrap: wrap;
+            we-row {
+                position: relative;
+                display: block;
 
-                > we-title {
-                    min-width: 95%;
+                > div {
+                    flex: 1 1 auto;
+                    display: flex;
+                    align-items: center;
+
+                    > * {
+                        flex: 1 1 auto;
+
+                        + * {
+                            margin-left: 0.5em;
+                        }
+                    }
+                    > .fa {
+                        flex: 0 0 auto;
+                    }
+                }
+
+                &.o_we_inline {
+                    display: flex;
+                    align-items: center;
+
+                    > we-title {
+                        min-width: 60%;
+                        margin-right: 5%;
+                    }
+                }
+
+                we-select {
+                    position: static;
+                }
+
+                we-input {
+                    flex-wrap: wrap;
+
+                    > we-title {
+                        min-width: 95%;
+                    }
                 }
             }
 

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -397,6 +397,14 @@ body.editor_enable.editor_has_snippets {
                 }
             }
 
+            we-row we-input {
+                flex-wrap: wrap;
+
+                > we-title {
+                    min-width: 95%;
+                }
+            }
+
             .dropdown-menu {
                 // FIXME temporary fix for m2o option for example
                 position: static !important;

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -31,9 +31,6 @@
             </we-title>
         </we-customizeblock-options>
     </t>
-    <t t-name="web_editor.customize_block_option">
-        <we-customizeblock-option/>
-    </t>
 
     <!-- options -->
     <div t-name="web_editor.snippet.option.colorpicker" class="colorpicker">

--- a/addons/web_editor/static/tests/test_utils.js
+++ b/addons/web_editor/static/tests/test_utils.js
@@ -78,7 +78,9 @@ MockServer.include({
                         '    <div data-js="content" data-selector=".s_hr, .test_option_all" ' +
                         'data-drop-in=".note-editable" data-drop-near="p, h1, h2, h3, blockquote, .s_hr"></div>' +
                         '    <div data-js="sizing_y" data-selector=".s_hr, .test_option_all"></div>' +
-                        '    <div data-js="colorpicker" string="Background Color" data-selector=".test_option_all"></div>' +
+                        '    <div data-selector=".test_option_all">' +
+                        '        <we-colorpicker string="Background Color" data-select-style="true" data-css-property="background-color" data-color-prefix="bg-"/>' +
+                        '    </div>' +
                         '    <div data-js="background" data-selector=".test_option_all">' +
                         '       <we-button data-choose-image="true" data-no-preview="true"><i class="fa fa-picture-o"/> Background Image</we-button>' +
                         '    </div>' +
@@ -245,7 +247,9 @@ function wysiwygData(data) {
                         '    <div data-js="content" data-selector=".s_hr, .test_option_all" ' +
                         'data-drop-in=".note-editable" data-drop-near="p, h1, h2, h3, blockquote, .s_hr"></div>' +
                         '    <div data-js="sizing_y" data-selector=".s_hr, .test_option_all"></div>' +
-                        '    <div data-js="colorpicker" string="Background Color" data-selector=".test_option_all"></div>' +
+                        '    <div data-selector=".test_option_all">' +
+                        '        <we-colorpicker string="Background Color" data-select-style="true" data-css-property="background-color" data-color-prefix="bg-"/>' +
+                        '    </div>' +
                         '    <div data-js="background" data-selector=".test_option_all">' +
                         '       <we-button data-choose-image="true" data-no-preview="true"><i class="fa fa-picture-o"/> Background Image</we-button>' +
                         '    </div>' +

--- a/addons/web_editor/views/editor.xml
+++ b/addons/web_editor/views/editor.xml
@@ -131,6 +131,7 @@
     <xpath expr="script[last()]" position="after">
         <script type="text/javascript" src="/web_editor/static/lib/vkbeautify/vkbeautify.0.99.00.beta.js"/>
         <script type="text/javascript" src="/web_editor/static/src/js/common/ace.js"/>
+        <script type="text/javascript" src="/web_editor/static/src/js/common/utils.js"/>
         <script type="text/javascript" src="/web_editor/static/src/js/wysiwyg/root.js"/>
     </xpath>
 </template>

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -381,11 +381,6 @@ class Website(Home):
 
         return True
 
-    @http.route(['/website/theme_customize_reload'], type='http', auth="public", website=True)
-    def theme_customize_reload(self, href, enable, disable, tab=0, **kwargs):
-        self.theme_customize(enable and enable.split(",") or [], disable and disable.split(",") or [])
-        return request.redirect(href + ("&theme=true" if "#" in href else "#theme=true") + ("&tab=" + tab))
-
     @http.route(['/website/make_scss_custo'], type='json', auth='user', website=True)
     def make_scss_custo(self, url, values):
         """

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -1,0 +1,48 @@
+odoo.define('website.snippet.editor', function (require) {
+'use strict';
+
+const weSnippetEditor = require('web_editor.snippet.editor');
+const ThemeCustomizationMenu = require('website.theme');
+
+weSnippetEditor.Class.include({
+    events: _.extend({}, weSnippetEditor.Class.prototype.events, {
+        'click .o_we_customize_theme_btn': '_onThemeTabClick',
+    }),
+
+    tabs: _.extend({}, weSnippetEditor.Class.prototype.tabs, {
+        THEME: 'theme',
+    }),
+
+    start: function () {
+        this.themeCustomizationMenu = new ThemeCustomizationMenu(this, {tab: false});
+        const _super = this._super;
+        return this.themeCustomizationMenu.appendTo($('<div>')).then(() => _super.apply(this, ...arguments));
+    },
+    /**
+     * @override
+     */
+    _updateLeftPanelContent: function ({content, tab}) {
+        this._super(...arguments);
+        this.$('.o_we_customize_theme_btn').toggleClass('active', tab === this.tabs.THEME);
+    },
+    /**
+     * Selects the theme customization tab
+     *
+     * @private
+     */
+    _showThemeCustomizationMenu: function () {
+        this._activateSnippet(false);
+        this._updateLeftPanelContent({
+            content: this.themeCustomizationMenu.$el,
+            tab: this.tabs.THEME,
+        });
+    },
+    /**
+     * @private
+     */
+    _onThemeTabClick: function (ev) {
+        this._showThemeCustomizationMenu();
+    },
+});
+});
+

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -106,7 +106,7 @@ options.registry.background.include({
             delete target.dataset.bgVideoSrc;
         }
         this._refreshPublicWidgets();
-        this._updateUI();
+        this.updateUI();
     },
     /**
      * Returns whether the current target has a background video or not.
@@ -348,12 +348,18 @@ options.registry.CarouselItem = options.Class.extend({
         this._super(...arguments);
         this.$carousel.off('.carousel_item_option');
     },
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
     /**
      * Updates the slide counter.
      *
      * @override
      */
-    onFocus: function () {
+    updateUI: function () {
+        this._super(...arguments);
         const $items = this.$carousel.find('.carousel-item');
         const $activeSlide = $items.filter('.active');
         const updatedText = ` (${$activeSlide.index() + 1}/${$items.length})`;
@@ -481,9 +487,21 @@ options.registry.navTabs = options.Class.extend({
             $activeLink.parent().remove();
             $activePane.remove();
             self._findLinksAndPanes();
-            self._updateUI(); // TODO forced to do this because we do not return deferred for options
+            self.updateUI(); // TODO forced to do this because we do not return deferred for options
         });
         $next.tab('show');
+    },
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    updateUI: function () {
+        this._super(...arguments);
+        this.$el.filter('[data-remove-tab]').toggleClass('d-none', this.$tabPanes.length <= 2);
     },
 
     //--------------------------------------------------------------------------
@@ -519,14 +537,6 @@ options.registry.navTabs = options.Class.extend({
                 'aria-labelledby': idLink,
             });
         }
-    },
-    /**
-     * @private
-     * @override
-     */
-    _updateUI: function () {
-        this._super.apply(this, arguments);
-        this.$el.filter('[data-remove-tab]').toggleClass('d-none', this.$tabPanes.length <= 2);
     },
 });
 
@@ -1118,7 +1128,7 @@ options.registry.gallery = options.Class.extend({
             }
             self._reset();
             self.trigger_up('cover_update');
-            this._updateUI();
+            this.updateUI();
         });
         dialog.open();
     },
@@ -1552,10 +1562,16 @@ options.registry.topMenuColor = options.Class.extend({
         });
         return def;
     },
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
     /**
      * @override
      */
-    onFocus: function () {
+    updateUI: function () {
+        this._super(...arguments);
         this.trigger_up('action_demand', {
             actionName: 'get_page_option',
             params: ['header_overlay'],
@@ -1778,7 +1794,7 @@ options.registry.CoverProperties = options.Class.extend({
             if (!this.$target.hasClass('o_record_has_cover')) {
                 this.$el.find('.o_record_cover_opt_size_default[data-select-class]').click();
             }
-            this._updateUI();
+            this.updateUI();
         });
     },
     /**

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -9,7 +9,27 @@ var options = require('web_editor.snippets.options');
 var _t = core._t;
 var qweb = core.qweb;
 
+// TODO should we refresh public widgets for all option changes by default ?
 options.Class.include({
+
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    setDataAttribute: function (previewMode, dataName, $opt) {
+        this._super(...arguments);
+        this._refreshPublicWidgets();
+    },
+    /**
+     * @override
+     */
+    selectDataAttribute: function (previewMode, value, $opt) {
+        this._super(...arguments);
+        this._refreshPublicWidgets();
+    },
 
     //--------------------------------------------------------------------------
     // Private
@@ -689,33 +709,6 @@ options.registry.parallax = options.Class.extend({
      */
     onMove: function () {
         this._refreshPublicWidgets();
-    },
-
-    //--------------------------------------------------------------------------
-    // Options
-    //--------------------------------------------------------------------------
-
-    /**
-     * Changes the scrolling speed of the parallax effect.
-     *
-     * @see this.selectClass for parameters
-     */
-    scroll: function (previewMode, value) {
-        this.$target.attr('data-scroll-background-ratio', value);
-        this._refreshPublicWidgets();
-    },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * @override
-     */
-    _setActive: function () {
-        this._super.apply(this, arguments);
-        this.$el.find('[data-scroll]').removeClass('active')
-            .filter('[data-scroll="' + (this.$target.attr('data-scroll-background-ratio') || 0) + '"]').addClass('active');
     },
 });
 

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -505,7 +505,7 @@ options.registry.navTabs = options.Class.extend({
      * @private
      */
     _generateUniqueIDs: function () {
-        for (var i = 0 ; i < this.$navLinks.length ; i++) {
+        for (var i = 0; i < this.$navLinks.length; i++) {
             var id = _.now() + '_' + _.uniqueId();
             var idLink = 'nav_tabs_link_' + id;
             var idContent = 'nav_tabs_content_' + id;
@@ -556,8 +556,8 @@ options.registry.sizing_x = options.registry.sizing.extend({
         var gridE = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
         var gridW = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
         this.grid = {
-            e: [_.map(gridE, function (v) { return 'col-lg-' + v; }), _.map(gridE, function (v) { return width/12*v; }), 'width'],
-            w: [_.map(gridW, function (v) { return 'offset-lg-' + v; }), _.map(gridW, function (v) { return width/12*v; }), 'margin-left'],
+            e: [_.map(gridE, v => ('col-lg-' + v)), _.map(gridE, v => width / 12 * v), 'width'],
+            w: [_.map(gridW, v => ('offset-lg-' + v)), _.map(gridW, v => width / 12 * v), 'margin-left'],
         };
         return this.grid;
     },
@@ -578,7 +578,7 @@ options.registry.sizing_x = options.registry.sizing.extend({
                 colSize = 1;
                 offset = beginOffset + beginCol - 1;
             }
-            this.$target.attr('class',this.$target.attr('class').replace(/\s*(offset-xl-|offset-lg-|col-lg-)([0-9-]+)/g, ''));
+            this.$target.attr('class', this.$target.attr('class').replace(/\s*(offset-xl-|offset-lg-|col-lg-)([0-9-]+)/g, ''));
 
             this.$target.addClass('col-lg-' + (colSize > 12 ? 12 : colSize));
             if (offset > 0) {
@@ -634,7 +634,7 @@ options.registry.layout_column = options.Class.extend({
 
         if (count > 0) {
             var $lastColumn = this.$target.children().last();
-            for (var i = 0 ; i < count ; i++) {
+            for (var i = 0; i < count; i++) {
                 $lastColumn.clone().insertAfter($lastColumn);
             }
         } else {
@@ -744,7 +744,7 @@ var FacebookPageDialog = weWidgets.Dialog.extend({
      */
     _renderPreview: function () {
         var self = this;
-        var match = this.fbData.href.match(/^(?:https?:\/\/)?(?:www\.)?(?:fb|facebook)\.com\/(?:([\w.]+)|[^/?#]+-([0-9]{15,16}))(?:$|[\/?# ])/);
+        var match = this.fbData.href.match(/^(?:https?:\/\/)?(?:www\.)?(?:fb|facebook)\.com\/(?:([\w.]+)|[^/?#]+-([0-9]{15,16}))(?:$|[/?# ])/);
         if (match) {
             // Check if the page exists on Facebook or not
             $.ajax({
@@ -799,7 +799,7 @@ var FacebookPageDialog = weWidgets.Dialog.extend({
     _onOptionChange: function () {
         var self = this;
         // Update values in fbData
-        this.fbData.tabs = _.map(this.$('.o_facebook_tabs input:checked'), function (tab) { return tab.name; }).join(',');
+        this.fbData.tabs = _.map(this.$('.o_facebook_tabs input:checked'), tab => tab.name).join(',');
         this.fbData.href = this.$('.o_facebook_page_url').val();
         _.each(this.$('.o_facebook_options input'), function (el) {
             self.fbData[el.name] = $(el).prop('checked');
@@ -936,8 +936,8 @@ options.registry.ul = options.Class.extend({
         this.$target.find('.o_ul_toggle_self, .o_ul_toggle_next').remove();
         this.$target.find('li:has(>ul,>ol)').map(function () {
             // get if the li contain a text label
-            var texts = _.filter(_.toArray(this.childNodes), function (a) { return a.nodeType === 3;});
-            if (!texts.length || !texts.reduce(function (a,b) { return a.textContent + b.textContent;}).match(/\S/)) {
+            var texts = _.filter(_.toArray(this.childNodes), a => (a.nodeType === 3));
+            if (!texts.length || !texts.reduce((a, b) => (a.textContent + b.textContent)).match(/\S/)) {
                 return;
             }
             $(this).children('ul,ol').addClass('o_close');
@@ -946,7 +946,7 @@ options.registry.ul = options.Class.extend({
         .prepend('<a href="#" class="o_ul_toggle_self fa" />');
         var $li = this.$target.find('li:has(+li:not(>.o_ul_toggle_self)>ul, +li:not(>.o_ul_toggle_self)>ol)');
         $li.css('list-style', this.$target.hasClass('o_ul_folded') ? 'none' : '');
-        $li.map(function () { return $(this).children()[0] || this; })
+        $li.map((i, el) => ($(el).children()[0] || el))
             .prepend('<a href="#" class="o_ul_toggle_next fa" />');
         $li.removeClass('o_open').next().addClass('o_close');
         this.$target.find('li').removeClass('o_open');
@@ -987,7 +987,7 @@ options.registry.collapse = options.Class.extend({
         var $panel = this.$target.find('.collapse').removeData('bs.collapse');
         if ($panel.attr('aria-expanded') === 'true') {
             $panel.closest('.accordion').find('.collapse[aria-expanded="true"]')
-                .filter(function () {return this !== $panel[0];})
+                .filter((i, el) => (el !== $panel[0]))
                 .collapse('hide')
                 .one('hidden.bs.collapse', function () {
                     $panel.trigger('shown.bs.collapse');
@@ -1015,20 +1015,20 @@ options.registry.collapse = options.Class.extend({
             tablist_id = 'myCollapse' + time;
             $tablist.attr('id', tablist_id);
         }
-        $tab.attr('data-parent', '#'+tablist_id);
-        $tab.data('parent', '#'+tablist_id);
+        $tab.attr('data-parent', '#' + tablist_id);
+        $tab.data('parent', '#' + tablist_id);
 
         // link to the collapse
         var $panel = this.$target.find('.collapse');
         var panel_id = $panel.attr('id');
         if (!panel_id) {
-            while ($('#'+(panel_id = 'myCollapseTab' + time)).length) {
+            while ($('#' + (panel_id = 'myCollapseTab' + time)).length) {
                 time++;
             }
             $panel.attr('id', panel_id);
         }
-        $tab.attr('data-target', '#'+panel_id);
-        $tab.data('target', '#'+panel_id);
+        $tab.attr('data-target', '#' + panel_id);
+        $tab.data('target', '#' + panel_id);
     },
 });
 
@@ -1109,7 +1109,7 @@ options.registry.gallery = options.Class.extend({
         var lastImage = _.last(this._getImages());
         var index = lastImage ? this._getIndex(lastImage) : -1;
         dialog.on('save', this, function (attachments) {
-            for (var i = 0 ; i < attachments.length; i++) {
+            for (var i = 0; i < attachments.length; i++) {
                 $('<img/>', {
                     class: 'img img-fluid',
                     src: attachments[i].image_src,
@@ -1278,10 +1278,10 @@ options.registry.gallery = options.Class.extend({
         });
         var currentInterval = this.$target.find('.carousel:first').attr('data-interval');
         var params = {
-            srcs : urls,
+            srcs: urls,
             index: 0,
             title: "",
-            interval : currentInterval || this.$target.data('interval') || 0,
+            interval: currentInterval || this.$target.data('interval') || 0,
             id: 'slideshow_' + new Date().getTime(),
             userStyle: imgStyle,
         },

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -329,6 +329,8 @@ options.registry.Carousel = options.Class.extend({
 });
 
 options.registry.CarouselItem = options.Class.extend({
+    isTopOption: true,
+
     /**
      * @override
      */
@@ -352,12 +354,6 @@ options.registry.CarouselItem = options.Class.extend({
     destroy: function () {
         this._super(...arguments);
         this.$carousel.off('.carousel_item_option');
-    },
-    /**
-     * @override
-     */
-    isTopOption: function () {
-        return true;
     },
     /**
      * Updates the slide counter.
@@ -1597,6 +1593,7 @@ options.registry.topMenuColor = options.registry.colorpicker.extend({
  */
 options.registry.anchor = options.Class.extend({
     xmlDependencies: ['/website/static/src/xml/website.editor.xml'],
+    isTopOption: true,
 
     //--------------------------------------------------------------------------
     // Public
@@ -1619,12 +1616,6 @@ options.registry.anchor = options.Class.extend({
         });
 
         return this._super.apply(this, arguments);
-    },
-    /**
-     * @override
-     */
-    isTopOption: function () {
-        return true;
     },
     /**
      * @override

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1540,7 +1540,7 @@ options.registry.topMenuTransparency = options.Class.extend({
     },
 });
 
-options.registry.topMenuColor = options.registry.colorpicker.extend({
+options.registry.topMenuColor = options.Class.extend({
     /**
      * @override
      */

--- a/addons/website/static/src/js/widgets/theme.js
+++ b/addons/website/static/src/js/widgets/theme.js
@@ -8,6 +8,7 @@ var Widget = require('web.Widget');
 var weWidgets = require('wysiwyg.widgets');
 var websiteNavbarData = require('website.navbar');
 var ColorPaletteDialog = require('web_editor.ColorPalette').ColorPaletteDialog;
+const ColorpickerDialog = require('web.ColorpickerDialog');
 
 var _t = core._t;
 
@@ -518,13 +519,14 @@ var ThemeCustomizeDialog = Dialog.extend({
             var colorpicker = new ColorPaletteDialog(self, {
                 resetButton: false,
                 defaultColor: $color.css('background-color'),
-                excluded: ['transparent_grayscale'],
-                excludeSectionOf: colorName,
             });
             var chosenColor = undefined;
             colorpicker.on('color_picked', self, function (ev) {
                 ev.stopPropagation();
-                chosenColor = ev.data.cssColor;
+                chosenColor = ev.data.color;
+                if (!ColorpickerDialog.isCSSColor(chosenColor)) {
+                    chosenColor = ColorpickerDialog.normalizeCSSColor(self.style.getPropertyValue('--' + chosenColor).trim());
+                }
                 colorpicker.close();
             });
             colorpicker.on('closed', self, function (ev) {

--- a/addons/website/static/src/js/widgets/theme.js
+++ b/addons/website/static/src/js/widgets/theme.js
@@ -522,7 +522,7 @@ var ThemeCustomizeDialog = Dialog.extend({
                 excludeSectionOf: colorName,
             });
             var chosenColor = undefined;
-            colorpicker.on('color_picked custom_color_picked', self, function (ev) {
+            colorpicker.on('color_picked', self, function (ev) {
                 ev.stopPropagation();
                 chosenColor = ev.data.cssColor;
                 colorpicker.close();

--- a/addons/website/static/src/js/widgets/theme.js
+++ b/addons/website/static/src/js/widgets/theme.js
@@ -6,7 +6,6 @@ var core = require('web.core');
 var Dialog = require('web.Dialog');
 var Widget = require('web.Widget');
 var weWidgets = require('wysiwyg.widgets');
-var websiteNavbarData = require('website.navbar');
 var ColorPaletteDialog = require('web_editor.ColorPalette').ColorPaletteDialog;
 const ColorpickerDialog = require('web.ColorpickerDialog');
 
@@ -107,11 +106,10 @@ var QuickEdit = Widget.extend({
     },
 });
 
-var ThemeCustomizeDialog = Dialog.extend({
-    xmlDependencies: (Dialog.prototype.xmlDependencies || [])
-        .concat(['/website/static/src/xml/website.editor.xml']),
+var ThemeCustomizationMenu = Widget.extend({
+    xmlDependencies: ['/website/static/src/xml/website.editor.xml'],
 
-    template: 'website.theme_customize',
+    className: 'd-flex flex-column align-items-start o_theme_customization_menu p-2',
     events: {
         'change .o_theme_customize_option_input': '_onChange',
         'click .checked .o_theme_customize_option_input[type="radio"]': '_onChange',
@@ -126,12 +124,8 @@ var ThemeCustomizeDialog = Dialog.extend({
      */
     init: function (parent, options) {
         options = options || {};
-        this._super(parent, _.extend({
-            title: _t("Customize Theme"),
-            buttons: [],
-        }, options));
+        this._super(parent, options);
 
-        this.defaultTab = options.tab || 0;
         this.fontVariables = [];
     },
     /**
@@ -156,66 +150,16 @@ var ThemeCustomizeDialog = Dialog.extend({
      * @override
      */
     start: function () {
-        var self = this;
-
         this.PX_BY_REM = parseFloat($(document.documentElement).css('font-size'));
-
-        this.$modal.addClass('o_theme_customize_modal');
-        this.$modal.find('.modal-footer').append($('<a/>', {
-            href: '/web#action=website.theme_install_kanban_action',
-            text: _t("Choose another theme..."),
-        }));
 
         this.style = window.getComputedStyle(document.documentElement);
         this.nbFonts = parseInt(this.style.getPropertyValue('--number-of-fonts'));
         var googleFontsProperty = this.style.getPropertyValue('--google-fonts').trim();
         this.googleFonts = googleFontsProperty ? googleFontsProperty.split(/\s*,\s*/g) : [];
 
-        var $tabs;
-        var loadDef = this._loadViews().then(function (data) {
-            self._generateDialogHTML(data);
-            $tabs = self.$('[data-toggle="tab"]');
-
-            // Hide the tab navigation if only one tab
-            if ($tabs.length <= 1) {
-                $tabs.closest('.nav').addClass('d-none');
-            }
-        });
-
-        // Enable the first option tab or the given default tab
-        this.opened().then(function () {
-            $tabs.eq(self.defaultTab).tab('show');
-
-            // Hack to hide primary/secondary if they are equal to alpha/beta
-            // (this is the case with default values but not in some themes).
-            var $primary = self.$('.o_theme_customize_color[data-color="primary"]');
-            var $alpha = self.$('.o_theme_customize_color[data-color="alpha"]');
-            var $secondary = self.$('.o_theme_customize_color[data-color="secondary"]');
-            var $beta = self.$('.o_theme_customize_color[data-color="beta"]');
-
-            var sameAlphaPrimary = $primary.css('background-color') === $alpha.css('background-color');
-            var sameBetaSecondary = $secondary.css('background-color') === $beta.css('background-color');
-
-            if (!sameAlphaPrimary) {
-                $alpha.prev().text(_t("Extra Color"));
-            }
-            if (!sameBetaSecondary) {
-                $beta.prev().text(_t("Extra Color"));
-            }
-
-            $primary = $primary.closest('.o_theme_customize_option');
-            $alpha = $alpha.closest('.o_theme_customize_option');
-            $secondary = $secondary.closest('.o_theme_customize_option');
-            $beta = $beta.closest('.o_theme_customize_option');
-
-            $primary.toggleClass('d-none', sameAlphaPrimary);
-            $secondary.toggleClass('d-none', sameBetaSecondary);
-
-            if (!sameAlphaPrimary && sameBetaSecondary) {
-                $beta.insertBefore($alpha);
-            } else if (sameAlphaPrimary && !sameBetaSecondary) {
-                $secondary.insertAfter($alpha);
-            }
+        var loadDef = this._loadViews().then((data) => {
+            this._generateDialogHTML(data);
+            this._removeDuplicateColors(this.$el);
         });
 
         return Promise.all([this._super.apply(this, arguments), loadDef]);
@@ -225,6 +169,42 @@ var ThemeCustomizeDialog = Dialog.extend({
     // Private
     //--------------------------------------------------------------------------
 
+    /**
+     * Hides primary/secondary if they are equal to alpha/beta
+     * (this is the case with default values but not in some themes).
+     *
+     * @private
+     */
+    _removeDuplicateColors: function ($target) {
+        var $primary = $target.find('.o_theme_customize_color[data-color="primary"]');
+        var $alpha = $target.find('.o_theme_customize_color[data-color="alpha"]');
+        var $secondary = $target.find('.o_theme_customize_color[data-color="secondary"]');
+        var $beta = $target.find('.o_theme_customize_color[data-color="beta"]');
+
+        var sameAlphaPrimary = $primary.css('background-color') === $alpha.css('background-color');
+        var sameBetaSecondary = $secondary.css('background-color') === $beta.css('background-color');
+
+        if (!sameAlphaPrimary) {
+            $alpha.prev().text(_t("Extra Color"));
+        }
+        if (!sameBetaSecondary) {
+            $beta.prev().text(_t("Extra Color"));
+        }
+
+        $primary = $primary.closest('.o_theme_customize_option');
+        $alpha = $alpha.closest('.o_theme_customize_option');
+        $secondary = $secondary.closest('.o_theme_customize_option');
+        $beta = $beta.closest('.o_theme_customize_option');
+
+        $primary.toggleClass('d-none', sameAlphaPrimary);
+        $secondary.toggleClass('d-none', sameBetaSecondary);
+
+        if (!sameAlphaPrimary && sameBetaSecondary) {
+            $beta.insertBefore($alpha);
+        } else if (sameAlphaPrimary && !sameBetaSecondary) {
+            $secondary.insertAfter($alpha);
+        }
+    },
     /**
      * @private
      */
@@ -270,38 +250,21 @@ var ThemeCustomizeDialog = Dialog.extend({
      */
     _generateDialogHTML: function (data) {
         var self = this;
-        var $contents = this.$el.children('content');
+        var $contents = $(core.qweb.render('website.theme_customize')).children('content');
         if ($contents.length === 0) {
             return;
         }
 
-        $contents.remove();
-        this.$el.append(core.qweb.render('website.theme_customize_modal_layout'));
-        var $navLinksContainer = this.$('.nav');
-        var $navContents = this.$('.tab-content');
-
         _.each($contents, function (content) {
-            var $content = $(content);
+            const $content = $(content);
+            const contentID = _.uniqueId('content-');
 
-            var contentID = _.uniqueId('content-');
-
-            // Build the nav tab for the content
-            $navLinksContainer.append($('<li/>', {
-                class: 'nav-item mb-1',
-            }).append($('<a/>', {
-                href: '#' + contentID,
-                class: 'nav-link',
-                'data-toggle': 'tab',
-                text: $content.attr('string'),
-            })));
-
-            // Build the tab pane for the content
-            var $navContent = $(core.qweb.render('website.theme_customize_modal_content', {
+            const $menuSection = $(core.qweb.render('website.theme_customize_section', {
                 id: contentID,
-                title: $content.attr('title'),
+                title: $content.attr('string'),
             }));
-            $navContents.append($navContent);
-            var $optionsContainer = $navContent.find('.o_options_container');
+            self.$el.append($menuSection);
+            var $optionsContainer = $menuSection.find('.o_options_container');
 
             // Process content items
             _processItems($content.children(), $optionsContainer, false);
@@ -350,7 +313,7 @@ var ThemeCustomizeDialog = Dialog.extend({
                         }
 
                         // Build the options template
-                        $element = $(core.qweb.render('website.theme_customize_modal_option', _.extend({
+                        $element = $(core.qweb.render('website.theme_customize_menu_option', _.extend({
                             alone: alone,
                             name: xmlid === undefined && widgetName !== 'auto' ? _.uniqueId('option-') : optionsName,
                             id: $item.attr('id') || _.uniqueId('o_theme_customize_input_id_'),
@@ -380,7 +343,7 @@ var ThemeCustomizeDialog = Dialog.extend({
                         break;
 
                     case 'LIST':
-                        $element = $('<div/>', {class: 'py-1 px-2 o_theme_customize_option_list'});
+                        $element = $('<div/>', {class: 'py-1 o_theme_customize_option_list'});
                         _processItems($item.children(), $element, false);
                         break;
 
@@ -418,6 +381,21 @@ var ThemeCustomizeDialog = Dialog.extend({
                         })));
                         break;
 
+                    case 'A':
+                        $element = $item.clone();
+                        $element.on('click', (ev) => {
+                            ev.preventDefault();
+                            Dialog.confirm(self, _t("Switching theme cannot be done directly from edit mode, click ok to save your current changes and go to the theme selection page."), {
+                                confirm_callback: () => self.trigger_up('request_save', {
+                                    reload: false,
+                                    onSuccess: function () {
+                                        window.location.href = ev.target.href;
+                                    },
+                                }),
+                            });
+                        });
+                        break;
+
                     default:
                         _processItems($item.children(), $container, false);
                         return;
@@ -425,7 +403,7 @@ var ThemeCustomizeDialog = Dialog.extend({
 
                 if ($container.hasClass('form-row')) {
                     var $col = $('<div/>', {
-                        class: _.str.sprintf('col-%s', $item.data('col') || 6),
+                        class: _.str.sprintf('col-%s', $item.data('col') || 12),
                     });
 
                     if (item.tagName === 'LIST') {
@@ -711,17 +689,36 @@ var ThemeCustomizeDialog = Dialog.extend({
     _updateStyle: function (enable, disable, reload) {
         var self = this;
 
-        var $loading = $('<i/>', {class: 'fa fa-refresh fa-spin'});
-        this.$modal.find('.modal-title').append($loading);
-
         if (reload || config.isDebug('assets')) {
-            window.location.href = $.param.querystring('/website/theme_customize_reload', {
-                href: window.location.href,
-                enable: (enable || []).join(','),
-                disable: (disable || []).join(','),
-                tab: this.$('.nav-link.active').parent().index(),
+            return new Promise((resolve, reject) => {
+                const confirm = Dialog.confirm(self, _t("This change needs to reload the page, this will save all your changes and reload the page, are you sure you want to proceed?") +
+                    (config.isDebug('assets') ? _t(" It appears you are in debug=assets mode, all theme customization options require a page reload in this mode.") : ''), {
+                    confirm_callback: () => resolve(true),
+                });
+                confirm.on('closed', self, () => resolve(false));
+            }).then((save) => {
+                if (save) {
+                    self.trigger_up('request_save', {
+                        reload: false,
+                        onSuccess: function () {
+                            this._rpc({
+                                route: '/website/theme_customize',
+                                params: {
+                                    'enable': enable,
+                                    'disable': disable,
+                                    'get_bundle': true,
+                                },
+                            }).then(() => {
+                                window.location.href = window.location.origin + window.location.pathname + '?enable_editor=1';
+                            });
+                        },
+                    });
+                } else {
+                    if (this.$lastToggled.attr('type') === 'checkbox') {
+                        this.$lastToggled.prop('checked', !this.$lastToggled.prop('checked'));
+                    }
+                }
             });
-            return Promise.resolve();
         }
 
         return this._rpc({
@@ -762,10 +759,8 @@ var ThemeCustomizeDialog = Dialog.extend({
                 return linksLoaded;
             });
             return Promise.all(defs).then(function () {
-                $loading.remove();
                 $allLinks.remove();
             }).guardedCatch(function () {
-                $loading.remove();
                 $allLinks.remove();
             });
         }).then(function () {
@@ -838,6 +833,7 @@ var ThemeCustomizeDialog = Dialog.extend({
      * @param {Event} ev
      */
     _onChange: function (ev) {
+        this.$lastToggled = $(ev.target);
         var self = this;
 
         // Checkout the option that changed
@@ -957,43 +953,5 @@ var ThemeCustomizeDialog = Dialog.extend({
     },
 });
 
-var ThemeCustomizeMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
-    actions: _.extend({}, websiteNavbarData.WebsiteNavbarActionWidget.prototype.actions || {}, {
-        'customize_theme': '_openThemeCustomizeDialog',
-    }),
-
-    /**
-     * Automatically opens the theme customization dialog if the corresponding
-     * hash is in the page URL.
-     *
-     * @override
-     */
-    start: function () {
-        if ((window.location.hash || '').indexOf('theme=true') > 0) {
-            var tab = window.location.hash.match(/tab=(\d+)/);
-            this._openThemeCustomizeDialog(tab ? tab[1] : false);
-            window.location.hash = '';
-        }
-        return this._super.apply(this, arguments);
-    },
-
-    //--------------------------------------------------------------------------
-    // Actions
-    //--------------------------------------------------------------------------
-
-    /**
-     * Instantiates and opens the theme customization dialog.
-     *
-     * @private
-     * @param {string} tab
-     * @returns {Promise}
-     */
-    _openThemeCustomizeDialog: function (tab) {
-        return new ThemeCustomizeDialog(this, {tab: tab}).open();
-    },
-});
-
-websiteNavbarData.websiteNavbarRegistry.add(ThemeCustomizeMenu, '#theme_customize');
-
-return ThemeCustomizeDialog;
+return ThemeCustomizationMenu;
 });

--- a/addons/website/static/src/scss/website.editor.ui.scss
+++ b/addons/website/static/src/scss/website.editor.ui.scss
@@ -4,48 +4,7 @@
     }
 }
 
-.modal.o_theme_customize_modal {
-    .modal-dialog {
-        @include o-position-absolute(0, 2%);
-        width: 96%;
-        max-width: 550px;
-    }
-    .modal-header {
-        background-color: $o-brand-odoo;
-        color: white;
-        border-radius: 0;
-
-        * {
-            color: inherit;
-        }
-    }
-
-    .close:hover, .close:focus {
-        color: white;
-    }
-
-    .nav {
-        padding: 0;
-
-        .nav-item {
-            background-color: $o-brand-lightsecondary;
-
-            .nav-link {
-                color: $o-main-text-color;
-
-                &.active {
-                    font-weight: bold;
-                    background-color: white;
-                    border: 1px solid #d9d7d7;
-                    border-left: 1px solid #333333;
-                }
-                &:hover, &:focus {
-                    text-decoration: none;
-                }
-            }
-        }
-    }
-
+.o_theme_customization_menu {
     .dropdown-menu {
         position: static !important;
         transform: none !important;
@@ -73,7 +32,6 @@
             width: 100%;
             min-height: 24px;
             margin: 0;
-            padding: 8px;
             text-align: center;
             font-size: 14px;
             line-height: 1;
@@ -90,14 +48,9 @@
                 justify-content: flex-start;
             }
         }
-        &:not(.dropdown-item) label {
-            border: 2px solid transparent;
-            background-color: $o-brand-lightsecondary;
-
-            &.checked {
-                border-color: $o-brand-odoo;
-                color: $o-brand-odoo;
-            }
+        &:not(.dropdown-item) label.checked {
+          border: 2px solid $o-brand-odoo;
+            color: $o-brand-odoo;
         }
 
         &.o_theme_customize_with_widget {
@@ -115,10 +68,9 @@
 
     .o_theme_customize_color {
         position: relative;
-        width: 30px;
-        height: 20px;
+        width: 1rem;
+        height: 1rem;
         margin-left: auto;
-        border: 1px solid black;
 
         &::before, &::after {
             content: "";
@@ -169,10 +121,6 @@
         position: absolute;
         clip: rect(0, 0, 0, 0);
         pointer-events: none;
-    }
-
-    .o_theme_customize_option_list {
-        box-shadow: 0 0 40px 0 rgba(0, 0, 0, 0.05);
     }
 
     .o_theme_customize_dropdown_btn {

--- a/addons/website/static/src/xml/website.editor.xml
+++ b/addons/website/static/src/xml/website.editor.xml
@@ -28,15 +28,11 @@
         </label>
     </t>
 
-    <div t-name="website.theme_customize_modal_layout" class="d-flex align-items-start">
-        <ul class="nav flex-column flex-shrink-0 w-25"/>
-        <div class="tab-content pl-3 pb-2 flex-grow-1"/>
-    </div>
-    <div t-name="website.theme_customize_modal_content" t-att-id="id" class="tab-pane">
+    <div t-name="website.theme_customize_section" t-att-id="id">
         <h5 class="mt-0"><t t-esc="title"/></h5>
         <div class="form-row justify-content-between o_options_container"/>
     </div>
-    <t t-name="website.theme_customize_modal_option">
+    <t t-name="website.theme_customize_menu_option">
         <div t-attf-class="o_theme_customize_option my-1 flex-grow-0 #{font ? 'o_theme_customize_option_font_' + font : ''} #{widget and widget != 'auto' ? 'o_theme_customize_with_widget' : ''}">
             <img t-if="icon" t-att-src="icon"/>
 

--- a/addons/website/views/snippets.xml
+++ b/addons/website/views/snippets.xml
@@ -883,6 +883,12 @@
 
 <!-- Snippets menu -->
 <template id="snippets" inherit_id="web_editor.snippets" primary="True">
+    <xpath expr="//div[@id='snippets_menu']" position="inside"> 
+        <button type="button" class="o_we_customize_theme_btn"
+                data-title="Customize your theme">
+            Theme
+        </button>
+    </xpath>
     <xpath expr="//div[@id='o_scroll']" position="replace">
         <div id="o_scroll">
             <div id="snippet_mega_menu" class="o_panel d-none">

--- a/addons/website/views/snippets.xml
+++ b/addons/website/views/snippets.xml
@@ -1244,15 +1244,15 @@
 
     <!-- Parallax -->
     <div data-js="parallax" data-selector=".parallax">
-        <we-select string="Scroll Speed">
-            <we-button data-scroll="0">No-scroll</we-button>
+        <we-select string="Scroll Speed" data-attribute-name="scrollBackgroundRatio" data-attribute-default-value="0">
+            <we-button data-select-data-attribute="0">No-scroll</we-button>
             <we-divider/>
-            <we-button data-scroll="1">Fixed</we-button>
+            <we-button data-select-data-attribute="1">Fixed</we-button>
             <we-divider/>
-            <we-button data-scroll="0.6">Very Slow</we-button>
-            <we-button data-scroll="1.2">Slow</we-button>
-            <we-button data-scroll="1.6">Fast</we-button>
-            <we-button data-scroll="2">Very Fast</we-button>
+            <we-button data-select-data-attribute="0.6">Very Slow</we-button>
+            <we-button data-select-data-attribute="1.2">Slow</we-button>
+            <we-button data-select-data-attribute="1.6">Fast</we-button>
+            <we-button data-select-data-attribute="2">Very Fast</we-button>
         </we-select>
     </div>
 

--- a/addons/website/views/snippets.xml
+++ b/addons/website/views/snippets.xml
@@ -982,25 +982,39 @@
     <t t-call="web_editor.snippet_options"/>
 
     <!-- COLOR | .s_three_columns | .s_comparisons -->
-    <div data-js="colorpicker" string="Color"
-        data-selector=".s_three_columns .row > div, .s_comparisons .row > div, .s_tabs .row > div"
-        data-target=".card"/>
+    <div data-selector=".s_three_columns .row > div, .s_comparisons .row > div, .s_tabs .row > div"
+         data-target=".card">
+        <we-colorpicker string="Color"
+            data-select-style="true"
+            data-css-property="background-color"
+            data-color-prefix="bg-"/>
+    </div>
 
     <!-- COLOR | .s_hr -->
-    <div data-js="colorpicker" string="Color"
-        data-selector=".s_hr"
-        data-target="hr"
-        data-color-prefix="border-"
-        data-palette-exclude="transparent_grayscale, common, custom"/>
+    <div data-selector=".s_hr"
+         data-target="hr">
+        <we-colorpicker string="Color"
+            data-select-style="true"
+            data-css-property="border-color"
+            data-color-prefix="border-"
+            data-excluded="transparent_grayscale"/>
+    </div>
 
     <!-- COLOR | .s_cards -->
-    <div data-js="colorpicker" string="Color"
-        data-selector=".s_card, .accordion .card"/>
+    <div data-selector=".s_card, .accordion .card">
+        <we-colorpicker string="Color"
+            data-select-style="true"
+            data-css-property="background-color"
+            data-color-prefix="bg-"/>
+    </div>
 
     <!-- COLOR | .s_alert -->
-    <div data-js="colorpicker" string="Color"
-        data-selector=".s_alert"
-        data-color-prefix="alert-"/>
+    <div data-selector=".s_alert">
+        <we-colorpicker string="Color"
+            data-select-style="true"
+            data-css-property="background-color"
+            data-color-prefix="alert-"/>
+    </div>
 
     <!-- STYLES | .s_title -->
     <div data-selector=".s_title" data-target="[class*='s_title_']">
@@ -1259,25 +1273,39 @@
     </div>
 
     <!-- Color | Section -->
-    <div id="so_main_colorpicker" string="Background Color"
-        data-js="colorpicker"
-        data-selector="section, .carousel-item"
-        data-exclude=".parallax, .o_gallery .carousel-item"/>
+    <div id="so_main_colorpicker"
+         data-selector="section, .carousel-item"
+         data-exclude=".parallax, .o_gallery .carousel-item">
+        <we-colorpicker string="Background Color"
+            data-select-style="true"
+            data-css-property="background-color"
+            data-color-prefix="bg-"/>
+    </div>
 
     <!-- FILTER | .s_parallax -->
-    <div data-js="colorpicker" string="Filter"
-        data-selector=".parallax"
-        data-palette-exclude="common, theme, custom"
-        data-palette-default="transparent_grayscale"/>
+    <div data-selector=".parallax">
+        <we-colorpicker string="Filter"
+            data-select-style="true"
+            data-css-property="background-color"
+            data-color-prefix="bg-"
+            data-excluded="common, theme, custom"/>
+    </div>
 
     <!-- Color | Columns -->
-    <div data-js="colorpicker" string="Background Color"
-        data-selector="section .row > div"
-        data-exclude=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .o_gallery .row > div"/>
+    <div data-selector="section .row > div"
+         data-exclude=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .o_gallery .row > div">
+        <we-colorpicker string="Background Color"
+            data-select-style="true"
+            data-css-property="background-color"
+            data-color-prefix="bg-"/>
+    </div>
 
     <div data-selector="section .row > div"
         data-exclude=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .o_gallery .row > div">
-        <we-input string="Border" data-select-style="0" data-css-property="border-width" data-unit="px" data-extra-class="border"/>
+        <we-row string="Border" class="o_we_inline">
+            <we-colorpicker data-select-style="true" data-css-property="border-color" data-color-prefix="border-"/>
+            <we-input data-select-style="0" data-css-property="border-width" data-unit="px" data-extra-class="border"/>
+        </we-row>
         <we-input string="Rounded" data-select-style="0" data-css-property="border-radius" data-unit="px" data-extra-class="rounded"/>
         <we-checkbox string="Shadow" data-select-class="shadow"/>
     </div>
@@ -1321,11 +1349,14 @@
         <we-checkbox string="Transparent" data-transparent="true" data-no-preview="true"/>
     </div>
 
-    <div data-js="topMenuColor" string="Background Color"
-        data-selector="[data-main-object^='website.page('] #wrapwrap > header"
-        data-palette-exclude="theme,common, custom"
-        data-palette-default="transparent_grayscale"
-        data-no-check="true">
+    <div data-js="topMenuColor"
+         data-selector="[data-main-object^='website.page('] #wrapwrap > header"
+         data-no-check="true">
+        <we-colorpicker string="Background Color"
+            data-select-style="true"
+            data-css-property="background-color"
+            data-color-prefix="bg-"
+            data-excluded="theme, common, custom"/>
     </div>
 
     <!-- Anchor Name -->

--- a/addons/website/views/snippets.xml
+++ b/addons/website/views/snippets.xml
@@ -1108,7 +1108,7 @@
             <we-divider/>
             <we-button data-select-class="s_carousel_default">Default</we-button>
         </we-select>
-        <we-input string="Speed" data-set-data-attribute="interval" data-unit="s" data-save-unit="ms" data-step="0.1"/>
+        <we-input string="Speed" data-select-data-attribute="0s" data-attribute-name="interval" data-unit="s" data-save-unit="ms" data-step="0.1"/>
     </div>
 
     <div data-js="CarouselItem"
@@ -1238,8 +1238,10 @@
             <we-button class="fa fa-fw fa-arrows" title="Background Position"
                        data-background-position-overlay="true" data-no-preview="true"/>
         </we-row>
-        <we-input string="Background width" data-set-style="background-size" data-default-value="auto"/>
-        <we-input string="Background height" data-set-style="background-size" data-default-value="auto"/>
+        <we-multi data-css-property="background-size">
+            <we-input string="Width" data-select-style="auto" data-unit="px"/>
+            <we-input string="Height" data-select-style="auto" data-unit="px"/>
+        </we-multi>
     </div>
 
     <!-- Parallax -->
@@ -1275,9 +1277,9 @@
 
     <div data-selector="section .row > div"
         data-exclude=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .o_gallery .row > div">
-        <we-input string="Border" data-set-style="border-width" data-extra-class="border"/>
-        <we-input string="Rounded" data-set-style="border-radius" data-extra-class="rounded"/>
-        <we-checkbox string="Shadow" data-toggle-class="shadow"/>
+        <we-input string="Border" data-select-style="0" data-css-property="border-width" data-unit="px" data-extra-class="border"/>
+        <we-input string="Rounded" data-select-style="0" data-css-property="border-radius" data-unit="px" data-extra-class="rounded"/>
+        <we-checkbox string="Shadow" data-select-class="shadow"/>
     </div>
 
     <div data-js="sizing_y"
@@ -1301,7 +1303,7 @@
 
     <div data-js="ul"
          data-selector=":not(li) > ul:has(ul,ol), :not(li) > ol:has(ul,ol)">
-        <we-checkbox string="Folded list" data-toggle-class="o_ul_folded"/>
+        <we-checkbox string="Folded list" data-select-class="o_ul_folded"/>
     </div>
 
     <div data-js="menu_data"
@@ -1391,7 +1393,7 @@
     <div data-js="SectionStretch"
         data-selector="section"
         data-target="> .container, > .container-fluid">
-        <we-checkbox string="Stretch" data-toggle-container-fluid=""/>
+        <we-checkbox string="Stretch" data-select-class="container|container-fluid" data-no-preview="true"/>
     </div>
 </template>
 </odoo>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -106,6 +106,7 @@
     <link rel="stylesheet" type="text/scss" href="/website/static/src/scss/website.edit_mode.scss"/>
 
     <script type="text/javascript" src="/website/static/src/js/editor/editor.js"/>
+    <script type="text/javascript" src="/website/static/src/js/editor/snippets.editor.js"/>
     <script type="text/javascript" src="/website/static/src/js/editor/rte.summernote.js"/>
     <script type="text/javascript" src="/website/static/src/js/editor/snippets.options.js"/>
 
@@ -523,6 +524,9 @@
         -> data-col (optional, default 6) = bootstrap column size for the option
                 (ignored for options in a <list/>)
 
+    <a>: Declares a link, because this leaves the page, it will prompt the user
+            to confirm that they're leaving.
+
     Other elements will be ignored and their children will be processed as if
     that element was omitted, except that those children will be considered as
     in a new set of option. That allows to wrap an option in a fake element to
@@ -533,8 +537,12 @@
 -->
 <template id="theme_customize">
     <div>
+        <!-- Switch theme button -->
+        <content id="theme_customize_content_switch_theme">
+             <a class="btn btn-primary" href="/web#action=website_theme_install.theme_install_kanban_action">Switch theme</a>
+        </content>
         <!-- Color options -->
-        <content id="theme_customize_content_colors" string="Colors" title="Choose the theme colors">
+        <content id="theme_customize_content_colors" string="Colors">
             <list string="Main">
                 <opt data-widget="color" data-color-type="theme" data-color="primary" string="Primary"/>
                 <opt data-widget="color" data-color-type="theme" data-color="secondary" string="Secondary"/>
@@ -567,7 +575,7 @@
         </content>
 
         <!-- Menu options -->
-        <content id="theme_customize_content_navbar" string="Navbar" title="Choose your navbar">
+        <content id="theme_customize_content_navbar" string="Navbar">
             <list string="Main Layout">
                 <checkbox><opt data-xmlid="website.affix_top_menu" data-reload="/"/></checkbox>
                 <checkbox><opt data-xmlid="portal.portal_show_sign_in" data-reload="/"/></checkbox>
@@ -580,7 +588,7 @@
         </content>
 
         <!-- Layout Options -->
-        <content id="theme_customize_content_layout" string="Layout" title="Choose your layout">
+        <content id="theme_customize_content_layout" string="Layout">
             <list string="Body">
                 <opt string="Full" data-xmlid="" data-icon="/website/static/src/img/options/layout-full.png"/>
                 <opt id="option_layout_boxed" string="Boxed" data-xmlid="website.option_layout_boxed_variables" data-icon="/website/static/src/img/options/layout-boxed.png"/>
@@ -593,7 +601,7 @@
         </content>
 
         <!-- Font options -->
-        <content id="theme_customize_content_fonts" string="Fonts" title="Choose your fonts">
+        <content id="theme_customize_content_fonts" string="Fonts">
             <list string="Title">
                 <fontselection data-variable="headings-font-number"/>
             </list>

--- a/addons/website_blog/static/src/js/s_latest_posts_editor.js
+++ b/addons/website_blog/static/src/js/s_latest_posts_editor.js
@@ -1,45 +1,8 @@
 odoo.define('website_blog.s_latest_posts_editor', function (require) {
 'use strict';
 
-var core = require('web.core');
 var sOptions = require('web_editor.snippets.options');
 var wUtils = require('website.utils');
-
-var _t = core._t;
-
-sOptions.registry.js_get_posts_limit = sOptions.Class.extend({
-
-    //--------------------------------------------------------------------------
-    // Options
-    //--------------------------------------------------------------------------
-
-    /**
-     * @see this.selectClass for parameters
-     */
-    postsLimit: function (previewMode, value, $opt) {
-        value = parseInt(value);
-        this.$target.attr('data-posts-limit', value).data('postsLimit', value);
-        this.trigger_up('widgets_start_request', {
-            editableMode: true,
-            $target: this.$target,
-        });
-    },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * @override
-     */
-    _setActive: function () {
-        this._super.apply(this, arguments);
-        var activeLimit = this.$target.data('postsLimit') || 3;
-
-        this.$el.find('[data-posts-limit]').removeClass('active');
-        this.$el.find('[data-posts-limit=' + activeLimit + ']').addClass('active');
-    },
-});
 
 sOptions.registry.js_get_posts_selectBlog = sOptions.Class.extend({
     /**

--- a/addons/website_blog/static/src/js/s_latest_posts_editor.js
+++ b/addons/website_blog/static/src/js/s_latest_posts_editor.js
@@ -35,8 +35,8 @@ sOptions.registry.js_get_posts_selectBlog = sOptions.Class.extend({
     /**
      * @see this.selectClass for parameters
      */
-    filterByBlogId: function (previewMode, value, $opt) {
-        value = parseInt(value);
+    filterByBlogId: function (previewMode, widgetValue, params) {
+        const value = parseInt(widgetValue);
         this.$target.attr('data-filter-by-blog-id', value).data('filterByBlogId', value);
         this.trigger_up('widgets_start_request', {
             editableMode: true,

--- a/addons/website_blog/static/src/js/s_latest_posts_editor.js
+++ b/addons/website_blog/static/src/js/s_latest_posts_editor.js
@@ -22,7 +22,6 @@ sOptions.registry.js_get_posts_selectBlog = sOptions.Class.extend({
                 el.textContent = blog.name;
                 menuEl.appendChild(el);
             }
-            this._updateUI();
         });
 
         return Promise.all([this._super.apply(this, arguments), def]);

--- a/addons/website_blog/static/src/js/website_blog.editor.js
+++ b/addons/website_blog/static/src/js/website_blog.editor.js
@@ -111,7 +111,7 @@ options.registry.CoverProperties.include({
     /**
      * @override
      */
-    _updateUI: function () {
+    updateUI: function () {
         this._super(...arguments);
         var isRegularCover = this.$target.is('.o_wblog_post_page_cover_regular');
         var $coverFull = this.$el.find('[data-select-class*="cover_full"]');

--- a/addons/website_blog/views/snippets.xml
+++ b/addons/website_blog/views/snippets.xml
@@ -17,18 +17,18 @@
             </we-select>
         </div>
 
-        <div data-js="js_get_posts_limit" data-selector=".s_latest_posts, .s_latest_posts_big_picture" data-target=".js_get_posts" data-no-check="true">
-            <we-select string="Posts limit" data-no-preview="true">
-                <we-button data-posts-limit="1">1 post max</we-button>
-                <we-button data-posts-limit="2">2 posts max</we-button>
-                <we-button data-posts-limit="3">3 posts max</we-button>
-                <we-button data-posts-limit="4">4 posts max</we-button>
-                <we-button data-posts-limit="5">5 posts max</we-button>
-                <we-button data-posts-limit="6">6 posts max</we-button>
-                <we-button data-posts-limit="7">7 posts max</we-button>
-                <we-button data-posts-limit="8">8 posts max</we-button>
-                <we-button data-posts-limit="9">9 posts max</we-button>
-                <we-button data-posts-limit="10">10 posts max</we-button>
+        <div data-selector=".s_latest_posts, .s_latest_posts_big_picture" data-target=".js_get_posts" data-no-check="true">
+            <we-select string="Posts limit" data-no-preview="true" data-attribute-name="postsLimit" data-attribute-default-value="3">
+                <we-button data-select-data-attribute="1">1 post max</we-button>
+                <we-button data-select-data-attribute="2">2 posts max</we-button>
+                <we-button data-select-data-attribute="3">3 posts max</we-button>
+                <we-button data-select-data-attribute="4">4 posts max</we-button>
+                <we-button data-select-data-attribute="5">5 posts max</we-button>
+                <we-button data-select-data-attribute="6">6 posts max</we-button>
+                <we-button data-select-data-attribute="7">7 posts max</we-button>
+                <we-button data-select-data-attribute="8">8 posts max</we-button>
+                <we-button data-select-data-attribute="9">9 posts max</we-button>
+                <we-button data-select-data-attribute="10">10 posts max</we-button>
             </we-select>
         </div>
     </xpath>

--- a/addons/website_form/static/src/js/website_form_editor.js
+++ b/addons/website_form/static/src/js/website_form_editor.js
@@ -91,7 +91,7 @@ odoo.define('website_form_editor', function (require) {
         },
 
         // Choose a model modal
-        website_form_model_modal: function (previewMode, value, $li) {
+        website_form_model_modal: function (previewMode, widgetValue, params) {
             var self = this;
             this._rpc({
                 model: "ir.model",
@@ -224,7 +224,7 @@ odoo.define('website_form_editor', function (require) {
         },
 
         // Choose a field modal
-        website_form_field_modal: function (previewMode, value, $li) {
+        website_form_field_modal: function (previewMode, widgetValue, params) {
             var self = this;
 
             this.fields().then(function (fields) {
@@ -261,13 +261,13 @@ odoo.define('website_form_editor', function (require) {
         },
 
         // Create a custom field
-        website_form_custom_field: function (previewMode, value, $li) {
-            var default_field_name = 'Custom ' + $li.text();
+        website_form_custom_field: function (previewMode, widgetValue, params) {
+            var default_field_name = 'Custom ' + params.widgetText;
             this.append_field({
                 name: default_field_name,
                 string: default_field_name,
                 custom: true,
-                type: value,
+                type: widgetValue,
                 // Default values for x2many fields
                 records: [
                     {
@@ -302,7 +302,7 @@ odoo.define('website_form_editor', function (require) {
         },
 
         // Re-render the field and replace the current one
-        // website_form_editor_field_reset: function(previewMode, value, $li) {
+        // website_form_editor_field_reset: function(previewMode, widgetValue, params) {
         //     var self = this;
         //     var target_field_name = this.$target.find('.col-form-label').attr('for');
         //     this.fields().then(function(fields){
@@ -476,9 +476,9 @@ odoo.define('website_form_editor', function (require) {
         /**
          * @see this.selectClass for parameters
          */
-        website_form_choice_field_display: function (previewMode, value, $opt) {
-            this.$target.toggleClass('o_website_form_flex_fw', value === 'vertical');
-            this.$target[0].dataset.display = value;
+        website_form_choice_field_display: function (previewMode, widgetValue, params) {
+            this.$target.toggleClass('o_website_form_flex_fw', widgetValue === 'vertical');
+            this.$target[0].dataset.display = widgetValue;
         },
 
         //----------------------------------------------------------------------
@@ -502,7 +502,7 @@ odoo.define('website_form_editor', function (require) {
         xmlDependencies: ['/website_form/static/src/xml/website_form_editor.xml'],
 
         // Option to toggle inputs required attribute
-        website_form_field_require: function (previewMode, value, $li) {
+        website_form_field_require: function (previewMode, widgetValue, params) {
             this.$target.find('.o_website_form_input').each(function (index, input) {
                 input.required = !input.required;
             });

--- a/addons/website_form/static/tests/tours/website_form_editor.js
+++ b/addons/website_form/static/tests/tours/website_form_editor.js
@@ -115,7 +115,7 @@ odoo.define('website_form_editor.tour', function(require) {
         },
         {
             content:  "Click on Hidden",
-            trigger:  "[data-toggle-class='o_website_form_field_hidden']"
+            trigger:  "[data-select-class='o_website_form_field_hidden']"
         },
         {
             content:  "Check the resulting field",

--- a/addons/website_form/views/snippets.xml
+++ b/addons/website_form/views/snippets.xml
@@ -51,7 +51,7 @@
               <!-- Field -->
               <div data-js='website_form_editor' data-selector=".form-field" data-drop-near=".form-field">
                     <we-checkbox string="Hidden" data-no-preview="true"
-                                 data-toggle-class="o_website_form_field_hidden"/>
+                                 data-select-class="o_website_form_field_hidden"/>
               </div>
 
               <!-- Add an option to display radio buttons / checkboxes horizontally or vertically -->
@@ -72,7 +72,7 @@
               <div data-js='website_form_editor_field' data-selector=".form-field:not(.o_website_form_required)">
                   <we-checkbox string="Required" data-no-preview="true"
                                data-website_form_field_require=""
-                               data-toggle-class="o_website_form_required_custom"/>
+                               data-select-class="o_website_form_required_custom"/>
               </div>
 
               <!-- Remove the duplicate options of model fields -->

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -217,6 +217,27 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
     },
 
     //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    updateUI: function () {
+        this._super.apply(this, arguments);
+
+        var sizeX = parseInt(this.$target.attr('colspan') || 1);
+        var sizeY = parseInt(this.$target.attr('rowspan') || 1);
+
+        var $size = this.$el.find('.o_wsale_soptions_menu_sizes');
+        $size.find('tr:nth-child(-n + ' + sizeY + ') td:nth-child(-n + ' + sizeX + ')')
+             .addClass('selected');
+
+        // Adapt size array preview to fit ppr
+        $size.find('tr td:nth-child(n + ' + parseInt(this.ppr + 1) + ')').hide();
+    },
+
+    //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
 
@@ -245,22 +266,6 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
                 menuEl.appendChild(checkbox.el);
             }
         });
-    },
-    /**
-     * @override
-     */
-    _updateUI: function () {
-        this._super.apply(this, arguments);
-
-        var sizeX = parseInt(this.$target.attr('colspan') || 1);
-        var sizeY = parseInt(this.$target.attr('rowspan') || 1);
-
-        var $size = this.$el.find('.o_wsale_soptions_menu_sizes');
-        $size.find('tr:nth-child(-n + ' + sizeY + ') td:nth-child(-n + ' + sizeX + ')')
-             .addClass('selected');
-
-        // Adapt size array preview to fit ppr
-        $size.find('tr td:nth-child(n + ' + parseInt(this.ppr + 1) + ')').hide();
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -184,7 +184,7 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
         }).then(data => {
             var $menu = this.$el.find('[name="style"]');
             for (var k in data) {
-                $menu.append(this.buildCheckboxElement(data[k]['name'], {
+                $menu.append(this._buildCheckboxElement(data[k]['name'], {
                     dataAttributes: {
                         'style': data[k]['id'],
                         'toggleClass': data[k]['html_class'],

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -113,8 +113,8 @@ options.registry.WebsiteSaleGridLayout = options.Class.extend({
     /**
      * @see this.selectClass for params
      */
-    setPpg: function (previewMode, value, $opt) {
-        const ppg = parseInt($opt.find('input').val());
+    setPpg: function (previewMode, widgetValue, params) {
+        const ppg = parseInt(widgetValue);
         if (!ppg || ppg < 1) {
             return false;
         }
@@ -129,12 +129,12 @@ options.registry.WebsiteSaleGridLayout = options.Class.extend({
     /**
      * @see this.selectClass for params
      */
-    setPpr: function (previewMode, value, $opt) {
-        this.ppr = parseInt(value);
+    setPpr: function (previewMode, widgetValue, params) {
+        this.ppr = parseInt(widgetValue);
         this._rpc({
             route: '/shop/change_ppr',
             params: {
-                'ppr': value,
+                'ppr': this.ppr,
             },
         }).then(reload);
     },
@@ -172,29 +172,11 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
     /**
      * @override
      */
-    start: function () {
+    willStart: function () {
         this.ppr = this.$target.closest('[data-ppr]').data('ppr');
         this.productTemplateID = parseInt(this.$target.find('[data-oe-model="product.template"]').data('oe-id'));
 
-        var defs = [this._super.apply(this, arguments)];
-
-        defs.push(this._rpc({
-            model: 'product.style',
-            method: 'search_read',
-        }).then(data => {
-            var $menu = this.$el.find('[name="style"]');
-            for (var k in data) {
-                $menu.append(this._buildCheckboxElement(data[k]['name'], {
-                    dataAttributes: {
-                        'style': data[k]['id'],
-                        'toggleClass': data[k]['html_class'],
-                    },
-                }));
-            }
-            this._updateUI();
-        }));
-
-        return $.when.apply($, defs);
+        return this._super(...arguments);
     },
     /**
      * @override
@@ -212,24 +194,24 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
     /**
      * @see this.selectClass for params
      */
-    style: function (previewMode, value, $opt) {
+    style: function (previewMode, widgetValue, params) {
         this._rpc({
             route: '/shop/change_styles',
             params: {
                 'id': this.productTemplateID,
-                'style_id': value,
+                'style_id': params.possibleValues[params.possibleValues.length - 1],
             },
         });
     },
     /**
      * @see this.selectClass for params
      */
-    changeSequence: function (previewMode, value, $opt) {
+    changeSequence: function (previewMode, widgetValue, params) {
         this._rpc({
             route: '/shop/change_sequence',
             params: {
                 id: this.productTemplateID,
-                sequence: value,
+                sequence: widgetValue,
             },
         }).then(reload);
     },
@@ -238,6 +220,32 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
     // Private
     //--------------------------------------------------------------------------
 
+    /**
+     * @override
+     */
+    _renderCustomWidgets: async function (uiFragment) {
+        const checkboxes = [];
+        return this._rpc({
+            model: 'product.style',
+            method: 'search_read',
+        }).then(async data => {
+            for (var k in data) {
+                const checkboxWidget = this._registerUserValueWidget('we-checkbox', this, data[k]['name'], {
+                    dataAttributes: {
+                        'style': data[k]['id'],
+                        'selectClass': data[k]['html_class'],
+                    },
+                });
+                checkboxes.push(checkboxWidget);
+                await checkboxWidget.appendTo(document.createDocumentFragment());
+            }
+        }).then(() => {
+            const menuEl = uiFragment.querySelector('[name="style"]');
+            for (const checkbox of checkboxes) {
+                menuEl.appendChild(checkbox.el);
+            }
+        });
+    },
     /**
      * @override
      */
@@ -277,8 +285,8 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
     _onTableItemMouseEnter: function (ev) {
         var $td = $(ev.currentTarget);
         var $table = $td.closest("table");
-        var x = $td.index()+1;
-        var y = $td.parent().index()+1;
+        var x = $td.index() + 1;
+        var y = $td.parent().index() + 1;
 
         var tr = [];
         for (var yi = 0; yi < y; yi++) {
@@ -334,7 +342,7 @@ options.registry.ProductsSearchBar = options.Class.extend({
     /**
      * @see this.selectClass for parameters
      */
-    openSearchbarSettings: function (previewMode, value, $opt) {
+    openSearchbarSettings: function (previewMode, widgetValue, params) {
         var self = this;
         new Dialog(this, {
             title: _t("Products Search Bar"),

--- a/addons/website_sale/views/snippets.xml
+++ b/addons/website_sale/views/snippets.xml
@@ -60,7 +60,7 @@
         <div data-js="WebsiteSaleGridLayout"
             data-selector="#products_grid .o_wsale_products_grid_table_wrapper > table"
             data-no-check="true">
-            <we-input string="Number of products" data-set-ppg="" data-unit="" data-no-preview="true"/>
+            <we-input string="Number of products" data-set-ppg="" data-no-preview="true"/>
             <we-select string="Number of Columns" class="o_wsale_ppr_submenu" data-no-preview="true">
                 <we-button data-set-ppr="2">2</we-button>
                 <we-button data-set-ppr="3">3</we-button>


### PR DESCRIPTION
Previously, theme customization was done through a modal dialog in the
website module, this was not very user friendly since the rest of the
customization for the website was done from edit mode, meaning the user
had to exit edit mode to customize things such as theme colors or fonts.
It was also rather confusing to have these seemingly related things in
completely unrelated places.

This commit moves all of the options that used to be in the theme
customization modal into a new tab in the editor's left panel.

task ID: 2088298