### PR TITLE
[FIX] mail: remove __owl__.refs

### DIFF
--- a/addons/mail/static/src/owl/components/chat_window_manager/chat_window_manager.js
+++ b/addons/mail/static/src/owl/components/chat_window_manager/chat_window_manager.js
@@ -3,6 +3,7 @@ odoo.define('mail.component.ChatWindowManager', function (require) {
 
 const ChatWindow = require('mail.component.ChatWindow');
 const HiddenMenu = require('mail.component.ChatWindowHiddenMenu');
+const useRefs = require('mail.hooks.useRefs');
 
 const { Component } = owl;
 const { useDispatch, useStore } = owl.hooks;
@@ -16,6 +17,7 @@ class ChatWindowManager extends Component {
     constructor(...args) {
         super(...args);
         this.TEXT_DIRECTION = this.env._t.database.parameters.direction;
+        this._getRefs = useRefs();
         this.storeDispatch = useDispatch();
         this.storeProps = useStore(state => {
             const {
@@ -106,7 +108,7 @@ class ChatWindowManager extends Component {
      * should be recovered.
      */
     saveChatWindowsScrollTops() {
-        const chatWindowsWithThreadRefs = Object.entries(this.__owl__.refs)
+        const chatWindowsWithThreadRefs = Object.entries(this._getRefs())
             .filter(([refId, ref]) => refId.startsWith('chatWindow_'))
             .map(([refId, ref]) => ref);
         for (const chatWindowRef of chatWindowsWithThreadRefs) {
@@ -126,7 +128,7 @@ class ChatWindowManager extends Component {
      * @return {mail.component.ChatWindow}
      */
     _getChatWindowRef(chatWindowLocalId) {
-        return this.__owl__.refs[`chatWindow_${chatWindowLocalId}`];
+        return this._getRefs()[`chatWindow_${chatWindowLocalId}`];
     }
 
     /**

--- a/addons/mail/static/src/owl/components/message_list/message_list.js
+++ b/addons/mail/static/src/owl/components/message_list/message_list.js
@@ -2,6 +2,7 @@ odoo.define('mail.component.MessageList', function (require) {
 'use strict';
 
 const Message = require('mail.component.Message');
+const useRefs = require('mail.hooks.useRefs');
 
 const { Component } = owl;
 const { useDispatch, useRef, useStore } = owl.hooks;
@@ -14,6 +15,7 @@ class MessageList extends Component {
      */
     constructor(...args) {
         super(...args);
+        this._getRefs = useRefs();
         this.storeDispatch = useDispatch();
         this.storeProps = useStore((state, props) => {
             const threadCache = state.threadCaches[props.threadCacheLocalId];
@@ -159,7 +161,7 @@ class MessageList extends Component {
      * @return {mail.component.Message[]}
      */
     get messageRefs() {
-        return Object.entries(this.__owl__.refs)
+        return Object.entries(this._getRefs())
             .filter(([refId, ref]) => refId.indexOf('mail.message') !== -1)
             .map(([refId, ref]) => ref)
             .sort((ref1, ref2) => (ref1.storeProps.message.id < ref2.storeProps.message.id ? -1 : 1));
@@ -386,7 +388,7 @@ class MessageList extends Component {
      */
     async _scrollToMessage(messageLocalId) {
         this._isAutoLoadOnScrollActive = false;
-        await this.__owl__.refs[messageLocalId].scrollIntoView({
+        await this._getRefs()[messageLocalId].scrollIntoView({
             block: 'nearest',
         });
         if (!this.el) {

--- a/addons/mail/static/src/owl/hooks/use_refs.js
+++ b/addons/mail/static/src/owl/hooks/use_refs.js
@@ -1,0 +1,21 @@
+odoo.define('mail.hooks.useRefs', function (require) {
+'use strict';
+
+const { Component } = owl;
+
+/**
+ * This hook provides support for dynamic-refs.
+ *
+ * @return {function} returns object whose keys are t-ref values of active refs.
+ *   and values are refs.
+ */
+function useRefs() {
+    const component = Component.current;
+    return function () {
+        return component.__owl__.refs;
+    };
+}
+
+return useRefs;
+
+});

--- a/addons/mail/views/mail_templates.xml
+++ b/addons/mail/views/mail_templates.xml
@@ -140,6 +140,7 @@
                 <script type="text/javascript" src="/mail/static/src/owl/components/thread_preview/thread_preview.js"></script>
                 <script type="text/javascript" src="/mail/static/src/owl/components/thread_preview_list/thread_preview_list.js"></script>
                 <script type="text/javascript" src="/mail/static/src/owl/hooks/use_drag_visible_dropzone.js"></script>
+                <script type="text/javascript" src="/mail/static/src/owl/hooks/use_refs.js"></script>
                 <script type="text/javascript" src="/mail/static/src/owl/services/chat_window_service.js"></script>
                 <script type="text/javascript" src="/mail/static/src/owl/services/dialog_service.js"></script>
                 <script type="text/javascript" src="/mail/static/src/owl/store/messaging_actions.js"></script>


### PR DESCRIPTION
OWL made use of refs by means of `this.refs` in a prior version.
However, with the introduction of hooks, `this.refs` has replaced
with `useRef()`.

Some `this.refs` cannot use `useRef()`, like filtered refs.
This commit solves the issue by implementing a new hook `useRefs()`,
which enables registering refs of components.