### PR TITLE
[IMP] mail: create messaging env outside of MessagingService

### DIFF
--- a/addons/calendar/static/tests/systray_activity_menu_tests.js
+++ b/addons/calendar/static/tests/systray_activity_menu_tests.js
@@ -1,9 +1,8 @@
 odoo.define('calendar.systray.ActivityMenuTests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 var ActivityMenu = require('mail.systray.ActivityMenu');
-var mailUtils = require('mail.testUtils');
 
 var testUtils = require('web.test_utils');
 
@@ -12,9 +11,7 @@ QUnit.module('calendar', {}, function () {
 
 QUnit.module('ActivityMenu', {
     beforeEach: function () {
-        this.services = mailUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
         this.data = {
             'calendar.event': {
                 records: [{
@@ -38,9 +35,6 @@ QUnit.module('ActivityMenu', {
             },
         };
     },
-    afterEach() {
-        this.unpatchMessagingService();
-    }
 });
 
 QUnit.test('activity menu widget:today meetings', async function (assert) {

--- a/addons/im_support/static/tests/helpers/test_utils.js
+++ b/addons/im_support/static/tests/helpers/test_utils.js
@@ -1,15 +1,15 @@
 odoo.define('im_support.test_utils', function (require) {
 "use strict";
 
-var mailTestUtils = require('mail.testUtils');
+const { MockMailService } = require('mail.messaging.testUtils');
 var supportSession = require('im_support.SupportSession');
 
 var testUtils = require('web.test_utils');
 
 
-mailTestUtils.MockMailService.include({
-    getServices: function () {
-        return _.extend(this._super(), {
+MockMailService.include({
+    getServices: function (...args) {
+        return _.extend(this._super(...args), {
             support_bus_service: this.bus_service(),
         });
     },

--- a/addons/im_support/static/tests/systray_no_support_tests.js
+++ b/addons/im_support/static/tests/systray_no_support_tests.js
@@ -6,15 +6,14 @@ odoo.define('im_support.systray_no_support_tests', function (require) {
  * on the webclient when the support is not available.
  */
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
-var mailTestUtils = require('mail.testUtils');
+const { getMailServices, MockMailService } = require('mail.messaging.testUtils');
 var MessagingMenu = require('mail.systray.MessagingMenu');
 
 var testUtils = require('web.test_utils');
 
-mailTestUtils.MockMailService.include({
-    getServices: function () {
-        return _.extend(this._super(), {
+MockMailService.include({
+    getServices: function (...args) {
+        return _.extend(this._super(...args), {
             support_bus_service: this.bus_service(),
         });
     },
@@ -29,12 +28,7 @@ QUnit.module('systray', {
                 fields: {},
             },
         };
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
-    },
-    afterEach() {
-        this.unpatchMessagingService();
+        this.services = getMailServices({ hasLegacyMail: true });
     },
 });
 

--- a/addons/im_support/static/tests/systray_tests.js
+++ b/addons/im_support/static/tests/systray_tests.js
@@ -3,8 +3,7 @@ odoo.define('im_support.systray_tests', function (require) {
 
 var imSupportTestUtils = require('im_support.test_utils');
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
-var mailTestUtils = require('mail.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 var MessagingMenu = require('mail.systray.MessagingMenu');
 
 var testUtils = require('web.test_utils');
@@ -20,18 +19,13 @@ QUnit.module('systray', {
                 fields: {},
             },
         };
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
 
         this.supportParams = {
             db_uuid: 'some_uuid',
             support_token: 'ABCDEFGHIJ',
             support_origin: 'something.com',
         };
-    },
-    afterEach() {
-        this.unpatchMessagingService();
     },
 });
 

--- a/addons/mail/static/src/messaging/component/chat_window_manager/chat_window_manager_tests.js
+++ b/addons/mail/static/src/messaging/component/chat_window_manager/chat_window_manager_tests.js
@@ -19,10 +19,11 @@ QUnit.module('ChatWindowManager', {
     beforeEach() {
         utilsBeforeEach(this);
         this.start = async params => {
-            let { env, widget } = await utilsStart(Object.assign({}, params, {
-                data: this.data,
+            let { env, widget } = await utilsStart(Object.assign({
                 hasChatWindow: true,
                 hasMessagingMenu: true,
+            }, params, {
+                data: this.data,
             }));
             this.env = env;
             this.widget = widget;
@@ -696,8 +697,11 @@ QUnit.test('open 2 different chat windows: enough screen width', async function 
         },
     });
     await this.start({
-        device: {
-            isMobile: false
+        env: {
+            window: {
+                innerHeight: 1080,
+                innerWidth: 1920,
+            },
         },
         async mockRPC(route, args) {
             if (args.method === 'channel_fetch_preview') {
@@ -727,8 +731,6 @@ QUnit.test('open 2 different chat windows: enough screen width', async function 
             }
             return this._super(...arguments);
         },
-        'window.innerHeight': 1080,
-        'window.innerWidth': 1920,
     });
     document.querySelector(`.o_MessagingMenu_toggler`).click();
     await afterNextRender();
@@ -849,8 +851,11 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
         },
     });
     await this.start({
-        device: {
-            isMobile: false
+        env: {
+            window: {
+                innerHeight: 900,
+                innerWidth: 900,
+            },
         },
         async mockRPC(route, args) {
             if (args.method === 'channel_fetch_preview') {
@@ -858,8 +863,6 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
             }
             return this._super(...arguments);
         },
-        'window.innerHeight': 900,
-        'window.innerWidth': 900,
     });
 
     // open, from systray menu, chat windows of channels with Id 1, 2, then 3

--- a/addons/mail/static/src/messaging/component/composer/composer_tests.js
+++ b/addons/mail/static/src/messaging/component/composer/composer_tests.js
@@ -472,9 +472,6 @@ QUnit.test('composer text input cleared on message post', async function (assert
             }
             return this._super(...arguments);
         },
-        session: {
-            partner_id: 3,
-        },
     });
     const thread = this.env.entities.Thread.channelFromId(20);
     await this.createComposerComponent(thread.composer);

--- a/addons/mail/static/src/messaging/component/discuss/discuss_tests.js
+++ b/addons/mail/static/src/messaging/component/discuss/discuss_tests.js
@@ -5,7 +5,7 @@ const {
     afterEach: utilsAfterEach,
     afterNextRender,
     beforeEach: utilsBeforeEach,
-    getServices,
+    getMailServices,
     inputFiles,
     pause,
     start: utilsStart,
@@ -1516,9 +1516,6 @@ QUnit.test('inbox messages are never squashed', async function (assert) {
             }
             return this._super(...arguments);
         },
-        session: {
-            partner_id: 3,
-        },
     });
     assert.strictEqual(
         document.querySelectorAll(`
@@ -2418,9 +2415,6 @@ QUnit.test('redirect to author (open chat)', async function (assert) {
             }
             return this._super(...arguments);
         },
-        session: {
-            partner_id: 3,
-        },
     });
     assert.ok(
         document.querySelector(`
@@ -2702,9 +2696,6 @@ QUnit.test('inbox: mark all messages as read', async function (assert) {
             }
             return this._super(...arguments);
         },
-        session: {
-            partner_id: 3,
-        },
     });
     assert.strictEqual(
         document.querySelector(`
@@ -2823,9 +2814,6 @@ QUnit.test('starred: unstar all', async function (assert) {
 
             }
             return this._super(...arguments);
-        },
-        session: {
-            partner_id: 3,
         },
     });
     assert.strictEqual(
@@ -3244,9 +3232,6 @@ QUnit.test('post a simple message', async function (assert) {
             }
             return this._super(...arguments);
         },
-        session: {
-            partner_id: 3,
-        },
     });
     assert.strictEqual(
         document.querySelectorAll(`.o_MessageList_empty`).length,
@@ -3325,9 +3310,6 @@ QUnit.test('rendering of inbox message', async function (assert) {
                 }];
             }
             return this._super(...arguments);
-        },
-        session: {
-            partner_id: 44,
         },
     });
     assert.strictEqual(
@@ -3449,9 +3431,6 @@ QUnit.test('receive new needaction messages', async function (assert) {
                 return [];
             }
             return this._super(...arguments);
-        },
-        session: {
-            partner_id: 3,
         },
     });
     assert.ok(
@@ -3646,9 +3625,6 @@ QUnit.test('reply to message from inbox (message linked to document)', async fun
             }
             return this._super(...arguments);
         },
-        session: {
-            partner_id: 3,
-        },
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Message').length,
@@ -3813,9 +3789,6 @@ QUnit.skip('load recent messages from thread (already loaded some old messages)'
             }
             return this._super(...arguments);
         },
-        session: {
-            partner_id: 3,
-        },
     });
     assert.verifySteps(
         ['message_fetch:load_inbox'],
@@ -3929,9 +3902,6 @@ QUnit.test('messages marked as read move to "History" mailbox', async function (
                 return 3;
             }
             return this._super(...arguments);
-        },
-        session: {
-            partner_id: 3,
         },
     });
     assert.ok(
@@ -4149,7 +4119,7 @@ QUnit.test('receive new channel message: out of odoo focus (notification, channe
             }],
         },
     });
-    const services = getServices();
+    const services = getMailServices();
     services.bus_service = services.bus_service.extend({
         isOdooFocused: () => false,
     });
@@ -4219,7 +4189,7 @@ QUnit.test('receive new channel message: out of odoo focus (notification, chat)'
             }],
         },
     });
-    const services = getServices();
+    const services = getMailServices();
     services.bus_service = services.bus_service.extend({
         isOdooFocused: () => false,
     });
@@ -4296,7 +4266,7 @@ QUnit.test('receive new channel messages: out of odoo focus (tab title)', async 
             }],
         },
     });
-    const services = getServices();
+    const services = getMailServices();
     services.bus_service = services.bus_service.extend({
         isOdooFocused: () => false,
     });
@@ -5227,9 +5197,6 @@ QUnit.test('moderation: send message in moderated channel', async function (asse
             }
             return this._super(...arguments);
         },
-        session: {
-            partner_id: 13,
-        },
     });
 
     // go to channel 'general'
@@ -5298,11 +5265,7 @@ QUnit.test('moderation: sent message accepted in moderated channel', async funct
         res_id: 20,
     }];
 
-    await this.start({
-        session: {
-            partner_id: 13,
-        },
-    });
+    await this.start();
 
     const channel = document.querySelector(`
         .o_DiscussSidebar_item[data-thread-local-id="${
@@ -5386,11 +5349,7 @@ QUnit.test('moderation: sent message rejected in moderated channel', async funct
         res_id: 20,
     }];
 
-    await this.start({
-        session: {
-            partner_id: 13,
-        },
-    });
+    await this.start();
 
     const channel = document.querySelector(`
         .o_DiscussSidebar_item[data-thread-local-id="${

--- a/addons/mail/static/src/messaging/component/message/message.js
+++ b/addons/mail/static/src/messaging/component/message/message.js
@@ -111,7 +111,7 @@ class Message extends Component {
         ) {
             return '/mail/static/src/img/odoobot.png';
         } else if (this.message.author) {
-            // TODO FIXME for public user this might not be accessible
+            // TODO FIXME for public user this might not be accessible. task-2223236
             // we should probably use the correspondig attachment id + access token
             // or create a dedicated route to get message image, checking the access right of the message
             return `/web/image/res.partner/${this.message.author.id}/image_128`;

--- a/addons/mail/static/src/messaging/entity/device/device.js
+++ b/addons/mail/static/src/messaging/entity/device/device.js
@@ -24,8 +24,8 @@ function DeviceFactory({ Entity }) {
          * Called when messaging is started.
          */
         start() {
-            // not using this.env.window because it's proxified, and
-            // addEventListener does not work on proxified window
+            // TODO FIXME Not using this.env.window because it's proxified, and
+            // addEventListener does not work on proxified window. task-2234596
             window.addEventListener('resize', this._onResize);
         }
 

--- a/addons/mail/static/src/messaging/entity/message/message_tests.js
+++ b/addons/mail/static/src/messaging/entity/message/message_tests.js
@@ -38,11 +38,7 @@ QUnit.module('Message', {
 QUnit.test('create', async function (assert) {
     assert.expect(31);
 
-    await this.start({
-        session: {
-            partner_id: 3,
-        },
-    });
+    await this.start();
     assert.notOk(this.env.entities.Partner.fromId(5));
     assert.notOk(this.env.entities.Thread.channelFromId(100));
     assert.notOk(this.env.entities.Attachment.fromId(750));

--- a/addons/mail/static/src/messaging/entity/messaging/messaging_tests.js
+++ b/addons/mail/static/src/messaging/entity/messaging/messaging_tests.js
@@ -34,36 +34,32 @@ QUnit.module('Messaging', {
     },
 });
 
-QUnit.test('currentPartner', async function (assert) {
-    assert.expect(7);
+QUnit.test('currentPartner initialized from session', async function (assert) {
+    assert.expect(5);
 
-    await this.start({
-        session: {
-            name: "Admin",
-            partner_id: 3,
-            partner_display_name: "Your Company, Admin",
-            uid: 2,
-        },
-    });
+    await this.start();
+
     assert.ok(this.env.messaging.currentPartner);
     assert.strictEqual(
-        this.env.messaging.currentPartner,
-        this.env.entities.Partner.fromId(3)
+        this.env.messaging.currentPartner.id,
+        this.env.session.partner_id
+    );
+    assert.strictEqual(
+        this.env.messaging.currentPartner.name,
+        this.env.session.name
     );
     assert.strictEqual(
         this.env.messaging.currentPartner.display_name,
-        "Your Company, Admin"
+        this.env.session.partner_display_name
     );
-    assert.strictEqual(this.env.messaging.currentPartner.id, 3);
-    assert.strictEqual(this.env.messaging.currentPartner.name, "Admin");
     assert.strictEqual(
-        this.env.messaging.currentPartner.user,
-        this.env.entities.User.fromId(2)
+        this.env.messaging.currentPartner.user.id,
+        this.env.session.uid
     );
-    assert.strictEqual(this.env.messaging.currentPartner.user.id, 2);
 });
 
 });
 });
 });
+
 });

--- a/addons/mail/static/src/messaging/messaging_env.js
+++ b/addons/mail/static/src/messaging/messaging_env.js
@@ -1,0 +1,114 @@
+odoo.define('mail.messaging.messaging_env', function (require) {
+'use strict';
+
+const {
+    checkRelations,
+    generateEntities,
+} = require('mail.messaging.entity.core');
+
+const { Store } = owl;
+const { EventBus } = owl.core;
+
+/**
+ * Adds messaging features to the given env.
+ * Note: some features will become available asynchronously, which will be
+ * notified with the resolution of `env.messagingCreatedPromise`.
+ *
+ * @param {Object} env
+ */
+function addMessagingToEnv(env) {
+    /**
+     * Messaging store
+     */
+    const store = new Store({
+        env,
+        state: {
+            entities: {},
+            __classEntityObservables: {},
+        },
+    });
+    /**
+     * Environment keys used in messaging.
+     */
+    Object.assign(env, {
+        autofetchPartnerImStatus: true,
+        disableAnimation: false,
+        entities: undefined,
+        isMessagingInitialized() {
+            if (!this.messaging) {
+                return false;
+            }
+            return this.messaging.isInitialized;
+        },
+        messaging: undefined,
+        messagingBus: new EventBus(),
+        store,
+    });
+    /**
+     * Messaging entities.
+     */
+    let messagingCreatedPromise;
+    if (env.generateEntitiesImmediately) {
+        _addMessagingEntities(env);
+        messagingCreatedPromise = Promise.resolve();
+    } else {
+        messagingCreatedPromise = new Promise(resolve => {
+            /**
+             * Called when all JS resources are loaded. This is useful in order
+             * to do some processing after other JS files have been parsed, for
+             * example new Entities or patched Entities that are coming from
+             * other modules, because some of those patches might need to be
+             * applied before messaging initialization.
+             */
+            window.addEventListener('load', resolve);
+        }).then(async () => {
+            /**
+             * All JS resources are loaded, but not necessarily processed.
+             * We assume no messaging-related modules return any Promise,
+             * therefore they should be processed *at most* asynchronously at
+             * "Promise time".
+             */
+            await new Promise(resolve => setTimeout(resolve));
+            _addMessagingEntities(env);
+        });
+    }
+    Object.assign(env, { messagingCreatedPromise });
+}
+
+/**
+ * Adds the messaging entities to the given env.
+ *
+ * @private
+ * @param {Object} env
+ */
+function _addMessagingEntities(env) {
+    /**
+     * Generate the entities.
+     */
+    env.entities = generateEntities();
+    /**
+     * Make environment accessible from Entities. Note that getter is used
+     * to prevent cyclic data structure.
+     */
+    for (const Entity of Object.values(env.entities)) {
+        Object.defineProperty(Entity, 'env', {
+            get: () => env,
+        });
+    }
+    /**
+     * Check that all entity relations are correct, notably one relation
+     * should have matching reversed relation.
+     */
+    checkRelations(env.entities);
+    for (const Entity of Object.values(env.entities)) {
+        Entity.init();
+    }
+    /**
+     * Create the messaging singleton entity.
+     */
+    env.messaging = env.entities.Messaging.create();
+}
+
+return { addMessagingToEnv };
+
+});

--- a/addons/mail/static/src/messaging/service/messaging_service/messaging_service.js
+++ b/addons/mail/static/src/messaging/service/messaging_service/messaging_service.js
@@ -1,52 +1,42 @@
 odoo.define('mail.messaging.service.Messaging', function (require) {
 'use strict';
 
-const {
-    checkRelations,
-    generateEntities,
-} = require('mail.messaging.entity.core');
+const { addMessagingToEnv } = require('mail.messaging.messaging_env');
 
 const AbstractService = require('web.AbstractService');
 const { serviceRegistry } = require('web.core');
 const env = require('web.env');
 
-const { Store } = owl;
-const { EventBus } = owl.core;
+addMessagingToEnv(env);
 
 const MessagingService = AbstractService.extend({
     env,
-    messagingEnvExtension: undefined,
     /**
      * @override {web.AbstractService}
      */
     start() {
         this._super(...arguments);
 
-        this._onGlobalLoad = this._onGlobalLoad.bind(this);
-        this._listenGlobalWindowLoad();
-
-        /**
-         * Environment of the messaging store (messaging env. without store)
-         */
         Object.assign(this.env, {
-            autofetchPartnerImStatus: true,
-            disableAnimation: false,
             call: (...args) => this.call(...args),
             do_action: (...args) => this.do_action(...args),
             do_notify: (...args) => this.do_notify(...args),
             do_warn: (...args) => this.do_warn(...args),
-            entities: undefined,
-            isMessagingInitialized() {
-                if (!this.messaging) {
-                    return false;
-                }
-                return this.messaging.isInitialized;
-            },
-            messaging: undefined,
-            messagingBus: new EventBus(),
             rpc: (...args) => this._rpc(...args),
             trigger_up: (...args) => this.trigger_up(...args),
-        }, this.messagingEnvExtension);
+        });
+
+        /**
+         * Messaging initialization.
+         */
+        const messagingInitializedPromise = this.env.messagingCreatedPromise.then(async () => {
+            // TODO FIXME The method uses service specific env keys so it can
+            // only be called after a service has properly set up those keys.
+            await this.env.messaging.start();
+        });
+        Object.assign(this.env, {
+            messagingInitializedPromise,
+        });
 
         /**
          * Components cannot use web.bus, because they cannot use
@@ -76,22 +66,6 @@ const MessagingService = AbstractService.extend({
             this,
             () => this.env.messagingBus.trigger('will_show_home_menu')
         );
-
-        /**
-         * Messaging store
-         */
-        const store = new Store({
-            env: this.env,
-            state: {
-                entities: {},
-                __classEntityObservables: {},
-            },
-        });
-
-        /**
-         * Environment of messaging components (messaging env. with store)
-         */
-        Object.assign(this.env, { store });
     },
     /**
      * @override
@@ -116,103 +90,6 @@ const MessagingService = AbstractService.extend({
      */
     getEnv() {
         return this.env;
-    },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     */
-    _listenGlobalWindowLoad() {
-        window.addEventListener('load', this._onGlobalLoad);
-    },
-
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * Called when all JS resources are loaded. This is useful in order to do
-     * some processing after other JS have been parsed, e.g. new Entities,
-     * patched Entities, etc.
-     *
-     * @private
-     * @returns {Object}
-     */
-    _onGlobalLoad() {
-        let messagingCreatedPromiseResolve;
-        let messagingInitializedPromiseResolve;
-        const messagingCreatedPromise = new Promise(resolve => {
-            messagingCreatedPromiseResolve = resolve;
-        });
-        const messagingInitializedPromise = new Promise(resolve => {
-            messagingInitializedPromiseResolve = resolve;
-        });
-        this._onGlobalLoad2({
-            messagingCreatedPromiseResolve,
-            messagingInitializedPromiseResolve,
-        });
-        return {
-            messagingCreatedPromise,
-            messagingInitializedPromise,
-        };
-    },
-    /**
-     * Continuation of handling global `load` event. This is isolated in another
-     * function so that we can make use of `async/await` without making original
-     * handler function blocking. This is useful in tests, in order to simulate
-     * state of application when messaging has to become initialized or is not
-     * yet initialized.
-     *
-     * @private
-     * @param {Object} param0
-     * @param {function} param0.messagingCreatedPromiseResolve function which,
-     *   when called, notifies that the messaging global entity has been
-     *   created, but not necessarily initialized. Useful in tests to start
-     *   making assertions at least at this moment. UI has to display something
-     *   when messaging has not yet been initialized, usually just a loading
-     *   spinner, because this process may take some time.
-     * @param {function} param0.messagingInitializedPromiseResolve function
-     *   which, when called, notifies that the messaging global entity has been
-     *   fully initialized. Useful in most tests that require messaging to
-     *   be initialized.
-     */
-    async _onGlobalLoad2({
-        messagingCreatedPromiseResolve,
-        messagingInitializedPromiseResolve,
-    }) {
-        /**
-         * All JS resources are loaded, but not necessarily processed. We assume
-         * no messaging-related modules do not return any Promise, therefore
-         * they should be processed *at most* asynchronously at "Promise time".
-         */
-        await new Promise(resolve => setTimeout(resolve));
-
-        this.env.entities = generateEntities();
-        /**
-         * Make environment accessible from Entities. Note that getter is used
-         * to prevent recursive data structure.
-         */
-        for (const Entity of Object.values(this.env.entities)) {
-            Object.defineProperty(Entity, 'env', {
-                get: () => this.env,
-            });
-        }
-        /**
-         * Check that all entity relations are correct, notably one relation
-         * should have matching reversed relation.
-         */
-        checkRelations(this.env.entities);
-        for (const Entity of Object.values(this.env.entities)) {
-            Entity.init();
-        }
-
-        this.env.messaging = this.env.entities.Messaging.create();
-        messagingCreatedPromiseResolve();
-        await this.env.messaging.start();
-        messagingInitializedPromiseResolve();
     },
 });
 

--- a/addons/mail/static/tests/chatter_tests.js
+++ b/addons/mail/static/tests/chatter_tests.js
@@ -1,8 +1,7 @@
 odoo.define('mail.chatter_tests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
-var mailTestUtils = require('mail.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 
 var core = require('web.core');
 var FormView = require('web.FormView');
@@ -26,9 +25,7 @@ QUnit.module('Chatter', {
         _.debounce = _.identity;
         _.throttle = _.identity;
 
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices();
         this.data = {
             'res.partner': {
                 fields: {
@@ -199,7 +196,6 @@ QUnit.module('Chatter', {
         // unpatch _.debounce and _.throttle
         _.debounce = this.underscoreDebounce;
         _.throttle = this.underscoreThrottle;
-        this.unpatchMessagingService();
     }
 });
 

--- a/addons/mail/static/tests/discuss_seen_indicator_tests.js
+++ b/addons/mail/static/tests/discuss_seen_indicator_tests.js
@@ -1,8 +1,9 @@
 odoo.define('mail.discuss_seen_indicator_tests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 var mailTestUtils = require('mail.testUtils');
+
 var testUtils = require('web.test_utils');
 
 var createDiscuss = mailTestUtils.createDiscuss;
@@ -45,9 +46,7 @@ QUnit.module('Discuss (Seen Indicator)', {
                 },
             },
         };
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
 
         /**
          * Simulate that someone received message on channel
@@ -69,9 +68,6 @@ QUnit.module('Discuss (Seen Indicator)', {
             params.widget.call('bus_service', 'trigger', 'notification', [notification]);
             return testUtils.nextTick();
         };
-    },
-    afterEach() {
-        this.unpatchMessagingService();
     },
 });
 

--- a/addons/mail/static/tests/discuss_tests.js
+++ b/addons/mail/static/tests/discuss_tests.js
@@ -2,7 +2,7 @@ odoo.define('mail.discuss_test', function (require) {
 "use strict";
 
 const Discuss = require('mail.Discuss');
-const { patchMessagingService } = require('mail.messaging.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 var mailTestUtils = require('mail.testUtils');
 
 var testUtils = require('web.test_utils');
@@ -90,15 +90,12 @@ QUnit.module('Discuss', {
                 },
             },
         };
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
     },
     afterEach: function () {
         // unpatch _.debounce and _.throttle
         _.debounce = this.underscoreDebounce;
         _.throttle = this.underscoreThrottle;
-        this.unpatchMessagingService();
     },
 });
 

--- a/addons/mail/static/tests/discuss_typing_notification_tests.js
+++ b/addons/mail/static/tests/discuss_typing_notification_tests.js
@@ -1,7 +1,7 @@
 odoo.define('mail.discuss_typing_notification_test', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 var Timer = require('mail.model.Timer');
 var CCThrottleFunctionObject = require('mail.model.CCThrottleFunctionObject');
 var mailTestUtils = require('mail.testUtils');
@@ -113,9 +113,7 @@ QUnit.module('Discuss (Typing Notifications)', {
                 }],
             },
         };
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
 
         /**
          * Simulate that someone typing something (or stops typing)
@@ -145,7 +143,6 @@ QUnit.module('Discuss (Typing Notifications)', {
         // unpatch Timer and CCThrottleFunction to re-enable timers
         // with the Thread Typing Mixin
         this.unpatch();
-        this.unpatchMessagingService();
     },
 });
 

--- a/addons/mail/static/tests/document_thread_window_tests.js
+++ b/addons/mail/static/tests/document_thread_window_tests.js
@@ -1,8 +1,7 @@
 odoo.define('mail.documentThreadWindowTests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
-var mailTestUtils = require('mail.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 var MessagingMenu = require('mail.systray.MessagingMenu');
 
 var testUtils = require('web.test_utils');
@@ -76,12 +75,7 @@ QUnit.module('Document Thread', {
         this.session = {
             partner_id: partnerID, // so that needaction messages are treated as needactions
         };
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
-    },
-    afterEach() {
-        this.unpatchMessagingService();
+        this.services = getMailServices({ hasLegacyMail: true });
     },
 });
 

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -1,15 +1,8 @@
 odoo.define('mail.testUtils', function (require) {
 "use strict";
 
-var BusService = require('bus.BusService');
-
 var Discuss = require('mail.Discuss');
-const MessagingService = require('mail.messaging.service.Messaging');
-var MailService = require('mail.Service');
 
-var AbstractStorageService = require('web.AbstractStorageService');
-var Class = require('web.Class');
-var RamStorage = require('web.RamStorage');
 var testUtils = require('web.test_utils');
 var Widget = require('web.Widget');
 
@@ -53,52 +46,8 @@ async function createDiscuss(params) {
     });
 }
 
-
-var MockMailService = Class.extend({
-    bus_service: function () {
-        return BusService.extend({
-            _poll: function () {}, // Do nothing
-            _registerWindowUnload: function () {}, // Do nothing
-            isOdooFocused: function () { return true; },
-            updateOption: function () {},
-        });
-    },
-    mail_service: function () {
-        return MailService;
-    },
-    messaging() {
-        return MessagingService.extend();
-    },
-    local_storage: function () {
-        return AbstractStorageService.extend({
-            storage: new RamStorage(),
-        });
-    },
-    getServices: function () {
-        return {
-            mail_service: this.mail_service(),
-            messaging: this.messaging(),
-            bus_service: this.bus_service(),
-            local_storage: this.local_storage(),
-        };
-    },
-});
-
-/**
- * Returns the list of mail services required by the mail components: a
- * mail_service, and its two dependencies bus_service and local_storage.
- *
- * @return {AbstractService[]} an array of 3 services: mail_service, bus_service
- * and local_storage, in that order
- */
-function getMailServices() {
-    return new MockMailService().getServices();
-}
-
 return {
-    MockMailService: MockMailService,
     createDiscuss: createDiscuss,
-    getMailServices: getMailServices,
 };
 
 });

--- a/addons/mail/static/tests/systray/systray_activity_menu_tests.js
+++ b/addons/mail/static/tests/systray/systray_activity_menu_tests.js
@@ -1,18 +1,15 @@
 odoo.define('mail.systray.ActivityMenuTests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 var ActivityMenu = require('mail.systray.ActivityMenu');
-var mailTestUtils = require('mail.testUtils');
 
 var testUtils = require('web.test_utils');
 
 QUnit.module('mail', {}, function () {
 QUnit.module('ActivityMenu', {
     beforeEach: function () {
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
         this.data = {
             'mail.activity.menu': {
                 fields: {
@@ -80,9 +77,6 @@ QUnit.module('ActivityMenu', {
         this.session = {
             uid: 10,
         };
-    },
-    afterEach() {
-        this.unpatchMessagingService();
     },
 });
 

--- a/addons/mail/static/tests/systray/systray_messaging_menu_mail_failure_tests.js
+++ b/addons/mail/static/tests/systray/systray_messaging_menu_mail_failure_tests.js
@@ -1,9 +1,8 @@
 odoo.define('mail.systray.MessagingMenuMailFailureTests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 var MessagingMenu = require('mail.systray.MessagingMenu');
-var mailTestUtils = require('mail.testUtils');
 
 var testUtils = require('web.test_utils');
 
@@ -50,15 +49,12 @@ QUnit.module('MessagingMenu (Mail Failures)', {
             }
         };
 
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
     },
     afterEach: function () {
         // unpatch _.debounce and _.throttle
         _.debounce = this.underscoreDebounce;
         _.throttle = this.underscoreThrottle;
-        this.unpatchMessagingService();
     },
 });
 

--- a/addons/mail/static/tests/systray/systray_messaging_menu_tests.js
+++ b/addons/mail/static/tests/systray/systray_messaging_menu_tests.js
@@ -1,10 +1,9 @@
 odoo.define('mail.systray.MessagingMenuTests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 var DocumentThread = require('mail.model.DocumentThread');
 var MessagingMenu = require('mail.systray.MessagingMenu');
-var mailTestUtils = require('mail.testUtils');
 
 var testUtils = require('web.test_utils');
 
@@ -85,15 +84,12 @@ QUnit.module('MessagingMenu', {
                 },
             },
         };
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
     },
     afterEach: function () {
         // unpatch _.debounce and _.throttle
         _.debounce = this.underscoreDebounce;
         _.throttle = this.underscoreThrottle;
-        this.unpatchMessagingService();
     },
 });
 
@@ -1072,11 +1068,10 @@ QUnit.test('messaging menu widget: click twice preview on slow message_fetch sho
             if (args.method === 'channel_minimize') {
                 // called to detach thread in chat window
                 // simulate longpolling response with new chat window state
-                const channelInfo = {
-                    ...self.data['mail.channel'].records[0],
+                const channelInfo = Object.assign({}, self.data['mail.channel'].records[0],{
                     is_minimized: true,
                     state: 'open',
-                };
+                });
                 const notifications = [ [['myDB', 'res.partner'], channelInfo] ];
                 messagingMenu.call('bus_service', 'trigger', 'notification', notifications);
             }

--- a/addons/mail/static/tests/thread_window/basic_thread_window_tests.js
+++ b/addons/mail/static/tests/thread_window/basic_thread_window_tests.js
@@ -1,8 +1,7 @@
 odoo.define('mail.basicThreadWindowTests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
-var mailTestUtils = require('mail.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 
 var FormView = require('web.FormView');
 var framework = require('web.framework');
@@ -54,9 +53,7 @@ QUnit.module('Basic', {
                 },
             },
         };
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
 
         this.ORIGINAL_THREAD_WINDOW_APPENDTO = this.services.mail_service.prototype.THREAD_WINDOW_APPENDTO;
 
@@ -79,7 +76,6 @@ QUnit.module('Basic', {
     afterEach: function () {
         // reset thread window append to body
         this.services.mail_service.prototype.THREAD_WINDOW_APPENDTO = 'body';
-        this.unpatchMessagingService();
     },
 });
 

--- a/addons/mail/static/tests/thread_window/blank_thread_window_tests.js
+++ b/addons/mail/static/tests/thread_window/blank_thread_window_tests.js
@@ -2,8 +2,7 @@ odoo.define('mail.blankThreadWindowTests', function (require) {
 "use strict";
 
 var AbstractThreadWindow = require('mail.AbstractThreadWindow');
-const { patchMessagingService } = require('mail.messaging.testUtils');
-var mailTestUtils = require('mail.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 
 var testUtils = require('web.test_utils');
 var Widget = require('web.Widget');
@@ -30,9 +29,7 @@ QUnit.module('Blank', {
                 },
             },
         };
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
         this.ORIGINAL_THREAD_WINDOW_APPENDTO = this.services.mail_service.prototype.THREAD_WINDOW_APPENDTO;
 
         this.createParent = function (params) {
@@ -87,7 +84,6 @@ QUnit.module('Blank', {
     afterEach: function () {
         // reset thread window append to body
         this.services.mail_service.prototype.THREAD_WINDOW_APPENDTO = 'body';
-        this.unpatchMessagingService();
     },
 });
 

--- a/addons/mail/static/tests/thread_window/hidden_thread_window_tests.js
+++ b/addons/mail/static/tests/thread_window/hidden_thread_window_tests.js
@@ -1,8 +1,7 @@
 odoo.define('mail.hiddenThreadWindowTests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
-var mailTestUtils = require('mail.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 
 var testUtils = require('web.test_utils');
 var Widget = require('web.Widget');
@@ -29,9 +28,7 @@ QUnit.module('Hidden', {
                 },
             },
         };
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
         this.ORIGINAL_THREAD_WINDOW_APPENDTO = this.services.mail_service.prototype.THREAD_WINDOW_APPENDTO;
 
         this.createParent = function (params) {
@@ -56,7 +53,6 @@ QUnit.module('Hidden', {
         $target.find('.o_thread_window_dropdown').remove();
         // reset thread window append to body
         this.services.mail_service.prototype.THREAD_WINDOW_APPENDTO = 'body';
-        this.unpatchMessagingService();
     },
 });
 

--- a/addons/mail/static/tests/thread_window/typing_thread_window_tests.js
+++ b/addons/mail/static/tests/thread_window/typing_thread_window_tests.js
@@ -1,8 +1,7 @@
 odoo.define('mail.typingThreadWindowTests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
-var mailTestUtils = require('mail.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 
 var testUtils = require('web.test_utils');
 var Widget = require('web.Widget');
@@ -29,9 +28,7 @@ QUnit.module('Typing', {
                 },
             },
         };
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
         this.ORIGINAL_THREAD_WINDOW_APPENDTO = this.services.mail_service.prototype.THREAD_WINDOW_APPENDTO;
 
         /**
@@ -73,7 +70,6 @@ QUnit.module('Typing', {
     afterEach: function () {
         // reset thread window append to body
         this.services.mail_service.prototype.THREAD_WINDOW_APPENDTO = 'body';
-        this.unpatchMessagingService();
     },
 });
 

--- a/addons/mail/views/mail_templates.xml
+++ b/addons/mail/views/mail_templates.xml
@@ -172,6 +172,7 @@
                 <script type="text/javascript" src="/mail/static/src/messaging/entity/thread_cache/thread_cache.js"></script>
                 <script type="text/javascript" src="/mail/static/src/messaging/entity/thread_viewer/thread_viewer.js"></script>
                 <script type="text/javascript" src="/mail/static/src/messaging/entity/user/user.js"></script>
+                <script type="text/javascript" src="/mail/static/src/messaging/messaging_env.js"></script>
                 <script type="text/javascript" src="/mail/static/src/messaging/service/chat_window_service/chat_window_service.js"></script>
                 <script type="text/javascript" src="/mail/static/src/messaging/service/dialog_service/dialog_service.js"></script>
                 <script type="text/javascript" src="/mail/static/src/messaging/service/messaging_service/messaging_service.js"></script>

--- a/addons/mail_bot/static/src/messaging/component/messaging_menu/messaging_menu_tests.js
+++ b/addons/mail_bot/static/src/messaging/component/messaging_menu/messaging_menu_tests.js
@@ -35,14 +35,18 @@ QUnit.test('rendering with OdooBot has a request (default)', async function (ass
     assert.expect(4);
 
     await this.start({
+        env: {
+            window: {
+                Notification: {
+                    permission: 'default',
+                },
+            },
+        },
         async mockRPC(route, args) {
             if (args.method === 'channel_fetch_preview') {
                 return [];
             }
             return this._super(...arguments);
-        },
-        'window.Notification': {
-            permission: 'default',
         },
     });
 
@@ -74,14 +78,18 @@ QUnit.test('rendering without OdooBot has a request (denied)', async function (a
     assert.expect(2);
 
     await this.start({
+        env: {
+            window: {
+                Notification: {
+                    permission: 'denied',
+                },
+            },
+        },
         async mockRPC(route, args) {
             if (args.method === 'channel_fetch_preview') {
                 return [];
             }
             return this._super(...arguments);
-        },
-        'window.Notification': {
-            permission: 'denied',
         },
     });
 
@@ -104,14 +112,18 @@ QUnit.test('rendering without OdooBot has a request (accepted)', async function 
     assert.expect(2);
 
     await this.start({
+        env: {
+            window: {
+                Notification: {
+                    permission: 'granted',
+                },
+            },
+        },
         async mockRPC(route, args) {
             if (args.method === 'channel_fetch_preview') {
                 return [];
             }
             return this._super(...arguments);
-        },
-        'window.Notification': {
-            permission: 'granted',
         },
     });
 
@@ -134,18 +146,22 @@ QUnit.test('respond to notification prompt (denied)', async function (assert) {
     assert.expect(3);
 
     await this.start({
+        env: {
+            window: {
+                Notification: {
+                    permission: 'default',
+                    async requestPermission() {
+                        this.permission = 'denied';
+                        return this.permission;
+                    },
+                },
+            },
+        },
         async mockRPC(route, args) {
             if (args.method === 'channel_fetch_preview') {
                 return [];
             }
             return this._super(...arguments);
-        },
-        'window.Notification': {
-            permission: 'default',
-            async requestPermission() {
-                this.permission = 'denied';
-                return this.permission;
-            },
         },
     });
 

--- a/addons/mail_bot/static/src/messaging/widget/notification_alert/notification_alert_tests.js
+++ b/addons/mail_bot/static/src/messaging/widget/notification_alert/notification_alert_tests.js
@@ -47,8 +47,12 @@ QUnit.test('notification_alert widget: display blocked notification alert', asyn
 
     await afterNextRender(async () => {
         await this.start({
-            'window.Notification': {
-                permission: 'denied',
+            env: {
+                window: {
+                    Notification: {
+                        permission: 'denied',
+                    },
+                },
             },
         });
     });
@@ -65,8 +69,12 @@ QUnit.test('notification_alert widget: no notification alert when granted', asyn
 
     await afterNextRender(async () => {
         await this.start({
-            'window.Notification': {
-                permission: 'granted',
+            env: {
+                window: {
+                    Notification: {
+                        permission: 'granted',
+                    },
+                },
             },
         });
     });
@@ -83,8 +91,12 @@ QUnit.test('notification_alert widget: no notification alert when default', asyn
 
     await afterNextRender(async () => {
         await this.start({
-            'window.Notification': {
-                permission: 'default',
+            env: {
+                window: {
+                    Notification: {
+                        permission: 'default',
+                    },
+                },
             },
         });
     });

--- a/addons/note/static/tests/systray_activity_menu_tests.js
+++ b/addons/note/static/tests/systray_activity_menu_tests.js
@@ -1,9 +1,8 @@
 odoo.define('note.systray.ActivityMenuTests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 var ActivityMenu = require('mail.systray.ActivityMenu');
-var mailTestUtils = require('mail.testUtils');
 
 var testUtils = require('web.test_utils');
 
@@ -11,9 +10,7 @@ QUnit.module('note', {}, function () {
 
 QUnit.module("ActivityMenu", {
     beforeEach: function () {
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
         this.data = {
             'mail.activity.menu': {
                 fields: {
@@ -35,9 +32,6 @@ QUnit.module("ActivityMenu", {
             }
         };
     },
-    afterEach() {
-        this.unpatchMessagingService();
-    }
 });
 
 QUnit.test('note activity menu widget: create note from activity menu', async function (assert) {

--- a/addons/snailmail/static/tests/chatter_snailmail_tests.js
+++ b/addons/snailmail/static/tests/chatter_snailmail_tests.js
@@ -1,8 +1,7 @@
 odoo.define('snailmail.chatter_snailmail_tests', function (require) {
 "use strict";
 
-const { patchMessagingService } = require('mail.messaging.testUtils');
-var mailTestUtils = require('mail.testUtils');
+const { getMailServices } = require('mail.messaging.testUtils');
 var ThreadWidget = require('mail.widget.Thread');
 
 var FormView = require('web.FormView');
@@ -24,9 +23,7 @@ var getArch = function () {
 QUnit.module('snailmail', {}, function () {
 QUnit.module('Chatter', {
     before: function () {
-        this.services = mailTestUtils.getMailServices();
-        const { unpatch: unpatchMessagingService } = patchMessagingService(this.services.messaging);
-        this.unpatchMessagingService = unpatchMessagingService;
+        this.services = getMailServices({ hasLegacyMail: true });
         this.data = {
             'account.move': {
                 fields: {
@@ -105,7 +102,6 @@ QUnit.module('Chatter', {
     afterEach: function () {
         $('.popover').remove();
         $('.modal').remove();
-        this.unpatchMessagingService();
     }
 });
 


### PR DESCRIPTION
There should be no patch in tests, only a different env. This commit is a step
in that direction.

It also allows to use messaging env without MessagingService, which will be
needed on the public part.

Enterprise: https://github.com/odoo-dev/enterprise/pull/31