### PR TITLE
[FIX] mail: chatter message list autoscroll

### DIFF
--- a/addons/mail/static/src/messaging/component/message_list/message_list.js
+++ b/addons/mail/static/src/messaging/component/message_list/message_list.js
@@ -166,23 +166,12 @@ class MessageList extends Component {
     /**
      * @returns {mail.messaging.component.Message|undefined}
      */
-    get lastCurrentPartnerMessageRef() {
-        const currentPartnerMessageRefs = this.messageRefs.filter(messageRef =>
-            (
-                messageRef.message.author &&
-                messageRef.message.author === this.env.messaging.currentPartner
-            )
-        );
-        const { length: l, [l - 1]: lastCurrentPartnerMessageRefs } = currentPartnerMessageRefs;
-        return lastCurrentPartnerMessageRefs;
-    }
-
-    /**
-     * @returns {mail.messaging.component.Message|undefined}
-     */
-    get lastMessageRef() {
-        const { length: l, [l - 1]: lastMessageRef } = this.messageRefs;
-        return lastMessageRef;
+    get mostRecentMessageRef() {
+        if (this.props.order === 'desc') {
+            return this.messageRefs[0];
+        }
+        const { length: l, [l - 1]: mostRecentMessageRef } = this.messageRefs;
+        return mostRecentMessageRef;
     }
 
     /**
@@ -328,7 +317,7 @@ class MessageList extends Component {
             } else {
                 const lastMessage = threadCache.lastMessage;
                 if (this.messageRefFromId(lastMessage.id)) {
-                    await this._scrollToLastMessage();
+                    await this._scrollToMostRecentMessage();
                     isProcessed = true;
                 }
             }
@@ -385,12 +374,12 @@ class MessageList extends Component {
         if (threadCache.messages.length === 0) {
             return;
         }
-        if (!this.lastMessageRef) {
+        if (!this.mostRecentMessageRef) {
             return;
         }
         if (
             threadCache === thread.mainCache &&
-            this.lastMessageRef.isPartiallyVisible()
+            this.mostRecentMessageRef.isPartiallyVisible()
         ) {
             thread.markAsSeen();
         }
@@ -422,12 +411,12 @@ class MessageList extends Component {
      * @private
      * @returns {Promise}
      */
-    async _scrollToLastMessage() {
-        if (!this.lastMessageRef) {
+    async _scrollToMostRecentMessage() {
+        if (!this.mostRecentMessageRef) {
             return;
         }
         this._isAutoLoadOnScrollActive = false;
-        await this.lastMessageRef.scrollIntoView();
+        await this.mostRecentMessageRef.scrollIntoView();
         if (!this.el) {
             this._isAutoLoadOnScrollActive = true;
             return;

--- a/addons/mail/static/src/messaging/entity/composer/composer.js
+++ b/addons/mail/static/src/messaging/entity/composer/composer.js
@@ -131,7 +131,7 @@ function ComposerFactory({ Entity }) {
                     subtype_id,
                     subtype_xmlid: isLog ? 'mail.mt_note' : 'mail.mt_comment',
                 });
-                const messageId = await this.env.rpc({
+                messageId = await this.env.rpc({
                     model: thread.model,
                     method: 'message_post',
                     args: [thread.id],


### PR DESCRIPTION
The autoscroll should not be triggered if the message order is 'desc'.
Also, when posting a new message in chatter, message list should scroll
to newly posted message.

That's what this commit is doing.

Task #2244216