### PR TITLE
[FIX] mail: prevent attachment count loading to be shown when not needed

### DIFF
--- a/addons/mail/static/src/messaging/component/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/messaging/component/chatter_topbar/chatter_topbar.xml
@@ -35,7 +35,7 @@
                     </t>
                     <button class="btn btn-link o_ChatterTopbar_buttonAttachments" type="button" t-att-disabled="chatter.isDisabled" t-on-click="_onClickAttachments">
                         <i class="fa fa-paperclip"/>
-                        <t t-if="chatter.isDisabled or chatter.thread and chatter.thread.areAttachmentsLoaded">
+                        <t t-if="chatter.isDisabled or !chatter.isShowingAttachmentsLoading">
                             <span class="o_ChatterTopbar_buttonCount o_ChatterTopbar_buttonAttachmentsCount" t-esc="chatter.thread ? chatter.thread.allAttachments.length : 0"/>
                         </t>
                         <t t-else="">

--- a/addons/mail/static/src/messaging/messaging_env.js
+++ b/addons/mail/static/src/messaging/messaging_env.js
@@ -33,6 +33,7 @@ async function addMessagingToEnv(env) {
             }
             return this.messaging.isInitialized;
         },
+        loadingBaseDelayDuration: 400,
         messaging: undefined,
         messagingBus: new EventBus(),
         store,

--- a/addons/mail/static/src/messaging/test_utils.js
+++ b/addons/mail/static/src/messaging/test_utils.js
@@ -93,6 +93,7 @@ const MockMailService = Class.extend({
         Object.assign(testEnv, {
             autofetchPartnerImStatus: false,
             disableAnimation: true,
+            loadingBaseDelayDuration: 0,
         });
         return MessagingService.extend({
             env: testEnv,


### PR DESCRIPTION
This commit adds a timer so that the loading is not shown if the time
needed to load attachment count is not > 400ms. This commit also remove
tests that were checking the loading mechanic as it now depends on a
timeout.

task-2243531