### PR TITLE
[FIX] mail: follower names are now correct even if partner

### DIFF
--- a/addons/mail/static/src/messaging/component/chatter_topbar/chatter_topbar_tests.js
+++ b/addons/mail/static/src/messaging/component/chatter_topbar/chatter_topbar_tests.js
@@ -8,7 +8,6 @@ const {
     afterEach: utilsAfterEach,
     afterNextRender,
     beforeEach: utilsBeforeEach,
-    pause,
     start: utilsStart,
 } = require('mail.messaging.testUtils');
 
@@ -391,6 +390,156 @@ QUnit.test('attachment counter with attachments', async function (assert) {
         document.querySelector(`.o_ChatterTopbar_buttonAttachmentsCount`).textContent,
         '2',
         'attachment counter should contain "2"'
+    );
+});
+
+QUnit.test('rendering with multiple partner followers', async function (assert) {
+    assert.expect(7);
+
+    await this.start();
+    this.data['res.partner'].records = [{
+        id: 100,
+        message_follower_ids: [1, 2],
+    }];
+    this.data['mail.followers'].records = [
+        {
+            // simulate real return from RPC
+            // (the presence of the key and the falsy value need to be handled correctly)
+            channel_id: false,
+            id: 1,
+            name: "Jean Michang",
+            partner_id: 12,
+        }, {
+            // simulate real return from RPC
+            // (the presence of the key and the falsy value need to be handled correctly)
+            channel_id: false,
+            id: 2,
+            name: "Eden Hazard",
+            partner_id: 11,
+        },
+    ];
+    const chatter = this.env.entities.Chatter.create({
+        followerIds: [1, 2],
+        threadId: 100,
+        threadModel: 'res.partner',
+    });
+    await this.createChatterTopbarComponent(chatter);
+
+    assert.containsOnce(
+        document.body,
+        '.o_FollowerListMenu',
+        "should have followers menu component"
+    );
+    assert.containsOnce(
+        document.body,
+        '.o_FollowerListMenu_buttonFollowers',
+        "should have followers button"
+    );
+
+    await afterNextRender(() => {
+        document.querySelector('.o_FollowerListMenu_buttonFollowers').click();
+    });
+    assert.containsOnce(
+        document.body,
+        '.o_FollowerListMenu_dropdown',
+        "followers dropdown should be opened"
+    );
+    assert.containsN(
+        document.body,
+        '.o_Follower',
+        2,
+        "exactly two followers should be listed"
+    );
+    assert.containsN(
+        document.body,
+        '.o_Follower_name',
+        2,
+        "exactly two follower names should be listed"
+    );
+    assert.strictEqual(
+        document.querySelectorAll('.o_Follower_name')[0].textContent.trim(),
+        "Jean Michang",
+        "first follower is 'Jean Michang'"
+    );
+    assert.strictEqual(
+        document.querySelectorAll('.o_Follower_name')[1].textContent.trim(),
+        "Eden Hazard",
+        "second follower is 'Eden Hazard'"
+    );
+});
+
+QUnit.test('rendering with multiple channel followers', async function (assert) {
+    assert.expect(7);
+
+    this.data['res.partner'].records = [{
+        id: 100,
+        message_follower_ids: [1, 2],
+    }];
+    await this.start();
+    this.data['mail.followers'].records = [
+        {
+            channel_id: 11,
+            id: 1,
+            name: "channel numero 5",
+            // simulate real return from RPC
+            // (the presence of the key and the falsy value need to be handled correctly)
+            partner_id: false,
+        }, {
+            channel_id: 12,
+            id: 2,
+            name: "channel armstrong",
+            // simulate real return from RPC
+            // (the presence of the key and the falsy value need to be handled correctly)
+            partner_id: false,
+        },
+    ];
+    const chatter = this.env.entities.Chatter.create({
+        followerIds: [1, 2],
+        threadId: 100,
+        threadModel: 'res.partner',
+    });
+    await this.createChatterTopbarComponent(chatter);
+
+    assert.containsOnce(
+        document.body,
+        '.o_FollowerListMenu',
+        "should have followers menu component"
+    );
+    assert.containsOnce(
+        document.body,
+        '.o_FollowerListMenu_buttonFollowers',
+        "should have followers button"
+    );
+
+    await afterNextRender(() => {
+        document.querySelector('.o_FollowerListMenu_buttonFollowers').click();
+    });
+    assert.containsOnce(
+        document.body,
+        '.o_FollowerListMenu_dropdown',
+        "followers dropdown should be opened"
+    );
+    assert.containsN(
+        document.body,
+        '.o_Follower',
+        2,
+        "exactly two followers should be listed"
+    );
+    assert.containsN(
+        document.body,
+        '.o_Follower_name',
+        2,
+        "exactly two follower names should be listed"
+    );
+    assert.strictEqual(
+        document.querySelectorAll('.o_Follower_name')[0].textContent.trim(),
+        "channel numero 5",
+        "first follower is 'channel numero 5'"
+    );
+    assert.strictEqual(
+        document.querySelectorAll('.o_Follower_name')[1].textContent.trim(),
+        "channel armstrong",
+        "second follower is 'channel armstrong'"
     );
 });
 

--- a/addons/mail/static/src/messaging/component/follower/follower.scss
+++ b/addons/mail/static/src/messaging/component/follower/follower.scss
@@ -7,7 +7,6 @@
     flex-flow: row;
     justify-content: space-between;
     padding: map-get($spacers, 0);
-    padding-inline-start: map-get($spacers, 2);
 }
 
 .o_Follower_avatar {
@@ -20,6 +19,8 @@
     align-items: center;
     display: flex;
     flex: 1;
+    padding-left: map-get($spacers, 3);
+    padding-right: map-get($spacers, 3);
 }
 
 // ------------------------------------------------------------------
@@ -30,15 +31,21 @@
     border-radius: 50%;
 }
 
-.o_Follower_button:hover {
-    opacity: 0.6;
+.o_Follower_button {
+    border-radius: 0;
+
+    &:hover {
+        background: gray('400');
+        color: $black;
+    }
 }
 
 .o_Follower_details {
     color: gray('700');
 
     &:hover {
-        opacity: 0.6;
+        background: gray('400');
+        color: $black;
     }
 
     &.o-inactive {

--- a/addons/mail/static/src/messaging/component/follower_list_menu/follower_list_menu_tests.js
+++ b/addons/mail/static/src/messaging/component/follower_list_menu/follower_list_menu_tests.js
@@ -94,6 +94,7 @@ QUnit.test('base rendering editable', async function (assert) {
         model: 'res.partner',
     });
     await this.createFollowerListMenuComponent(thread);
+
     assert.containsOnce(
         document.body,
         '.o_FollowerListMenu',
@@ -190,6 +191,7 @@ QUnit.test('click on "add followers" button', async function (assert) {
         model: 'res.partner',
     });
     await this.createFollowerListMenuComponent(thread);
+
     assert.containsOnce(
         document.body,
         '.o_FollowerListMenu',
@@ -320,6 +322,7 @@ QUnit.test('click on "add channels" button', async function (assert) {
         model: 'res.partner',
     });
     await this.createFollowerListMenuComponent(thread);
+
     assert.containsOnce(
         document.body,
         '.o_FollowerListMenu',

--- a/addons/mail/static/src/messaging/entity/follower/follower.js
+++ b/addons/mail/static/src/messaging/entity/follower/follower.js
@@ -20,11 +20,16 @@ function FollowerFactory({ Entity }) {
         static convertData(data) {
             const data2 = {};
             if ('channel_id' in data) {
-                const channelData = { id: data.channel_id, model: 'mail.channel' };
-                if ('name' in data) {
-                    channelData.name = data.name;
+                if (!data.channel_id) {
+                    data2.channel = [['unlink-all']];
+                } else {
+                    const channelData = {
+                        id: data.channel_id,
+                        model: 'mail.channel',
+                        name: data.name,
+                    };
+                    data2.channel = [['insert', channelData]];
                 }
-                data2.channel = [['insert', channelData]];
             }
             if ('id' in data) {
                 data2.id = data.id;
@@ -36,14 +41,16 @@ function FollowerFactory({ Entity }) {
                 data2.isEditable = data.is_editable;
             }
             if ('partner_id' in data) {
-                const partnerData = { id: data.partner_id };
-                if ('email' in data) {
-                    partnerData.email = data.email;
+                if (!data.partner_id) {
+                    data2.partner = [['unlink-all']];
+                } else {
+                    const partnerData = {
+                        email: data.email,
+                        id: data.partner_id,
+                        name: data.name,
+                    };
+                    data2.partner = [['insert', partnerData]];
                 }
-                if ('name' in data) {
-                    partnerData.name = data.name;
-                }
-                data2.partner = [['insert', partnerData]];
             }
             return data2;
         }

--- a/addons/mail/static/src/messaging/test_utils.js
+++ b/addons/mail/static/src/messaging/test_utils.js
@@ -439,7 +439,31 @@ function beforeEach(self) {
                 },
             },
         },
-        'mail.followers': { fields: {} },
+        'mail.followers': {
+            fields: {
+                channel_id: {
+                    type: 'integer',
+                },
+                email: {
+                    type: 'string',
+                },
+                id: {
+                    type: 'integer',
+                },
+                is_active: {
+                    type: 'boolean',
+                },
+                is_editable: {
+                    type: 'boolean',
+                },
+                name: {
+                    type: 'string',
+                },
+                partner_id: {
+                    type: 'integer',
+                },
+            },
+        },
         'mail.message': {
             fields: {
                 attachment_ids: {
@@ -550,6 +574,11 @@ function beforeEach(self) {
                 im_status: {
                     string: "status",
                     type: 'char',
+                },
+                message_follower_ids: {
+                    relation: 'follower',
+                    string: "Followers",
+                    type: "one2many",
                 },
             },
             records: [],

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -48,6 +48,18 @@ MockServer.include({
         });
         return previews;
     },
+
+    /**
+     * Simulate the '/mail/read_followers' route
+     *
+     * @private
+     * @return {Object} list of followers
+     */
+    async _mockFollowersRead(args) {
+        const ids = args.follower_ids; // list of followers IDs to read
+        const followers = this._getRecords('mail.followers', [['id', 'in', ids]]);
+        return { followers };
+    },
     /**
      * Simulate the 'get_activity_method' on 'mail.activity'
      *
@@ -282,7 +294,7 @@ MockServer.include({
     /**
      * @override
      */
-    _performRpc: function (route, args) {
+    async _performRpc(route, args) {
         // routes
         if (route === '/mail/init_messaging') {
             return Promise.resolve(this._mockInitMessaging(args));
@@ -314,6 +326,9 @@ MockServer.include({
         }
         if (args.method === 'message_post') {
             return Promise.resolve(this._mockMessagePost(args));
+        }
+        if (route === '/mail/read_followers') {
+            return this._mockFollowersRead(args);
         }
         if (args.method === 'activity_format') {
             var res = this._mockRead(args.model, args.args, args.kwargs);


### PR DESCRIPTION
Previous version was creating a 'false' channel with the name of the
first follower which was used for all followers.
This commit also improve hover on follower (easier to know what will be
clicked)
https://www.odoo.com/web#id=2244215&action=3206&active_id=1519&model=project.task&view_type=form&cids=1&menu_id=4720
task-2244215