### PR TITLE
[IMP] portal: menu's divider design + presets compatibility

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -63,7 +63,9 @@ header {
     ul.nav > li {
         &.divider {
             display: none;
-            border-right: 1px solid $nav-divider-color;
+            border-right: 1px solid;
+            opacity: 0.25;
+            margin: $nav-link-padding-y $nav-link-padding-x*0.5;
         }
 
         &.active + .divider {


### PR DESCRIPTION
Set the divider color to match the text color. Decrease the
opacity to  half the link one (normally 50%).
Adjust horizontal margin, resize the divider height to match the text.