### PR TITLE
[FIX] mail: TAB makes cycling between chatWindows and focus them

### DIFF
--- a/addons/mail/static/src/messaging/component/chat_window/chat_window.js
+++ b/addons/mail/static/src/messaging/component/chat_window/chat_window.js
@@ -130,9 +130,9 @@ class ChatWindow extends Component {
      * @private
      */
     _update() {
-        if (this.chatWindow.doIsFocus) {
+        if (this.chatWindow.isDoFocus) {
             this._focus();
-            this.chatWindow.update({ doIsFocus: false });
+            this.chatWindow.update({ isDoFocus: false });
         }
         if (this.props.isDocked) {
             this._applyVisibleOffset();

--- a/addons/mail/static/src/messaging/entity/chat_window/chat_window.js
+++ b/addons/mail/static/src/messaging/entity/chat_window/chat_window.js
@@ -50,14 +50,18 @@ function ChatWindowFactory({ Entity }) {
         }
 
         focusNextVisibleUnfoldedChatWindow() {
-            const nextVisibleUnfoldedChatWindow = this._cycleNextVisibleUnfoldedChatWindow();
-            nextVisibleUnfoldedChatWindow.focus();
+            const nextVisibleUnfoldedChatWindow = this._getNextVisibleUnfoldedChatWindow();
+            if (nextVisibleUnfoldedChatWindow) {
+                nextVisibleUnfoldedChatWindow.focus();
+            }
         }
 
         focusPreviousVisibleUnfoldedChatWindow() {
             const previousVisibleUnfoldedChatWindow =
-                this._cycleNextVisibleUnfoldedChatWindow({ reverse: true });
-            previousVisibleUnfoldedChatWindow.focus();
+                this._getNextVisibleUnfoldedChatWindow({ reverse: true });
+            if (previousVisibleUnfoldedChatWindow) {
+                previousVisibleUnfoldedChatWindow.focus();
+            }
         }
 
         /**
@@ -175,13 +179,10 @@ function ChatWindowFactory({ Entity }) {
          * @private
          * @param {Object} [param0={}]
          * @param {boolean} [param0.reverse=false]
+         * @returns {mail.messaging.entity.ChatWindow|undefined}
          */
-        _cycleNextVisibleUnfoldedChatWindow({ reverse = false } = {}) {
+        _getNextVisibleUnfoldedChatWindow({ reverse = false } = {}) {
             const orderedVisible = this.manager.allOrderedVisible;
-            if (orderedVisible.length <= 1) {
-                return;
-            }
-
             /**
              * Return index of next visible chat window of a given visible chat
              * window index. The direction of "next" chat window depends on
@@ -209,7 +210,7 @@ function ChatWindowFactory({ Entity }) {
                 nextIndex = _getNextIndex(nextIndex);
                 nextToFocus = orderedVisible[nextIndex];
             }
-            nextToFocus.focus();
+            return nextToFocus;
         }
 
         /**


### PR DESCRIPTION
Before this commit there was a crash when circling through chat windows with the tab key

After this commit, there is no problem, the chat windows focus when arriving on them
while the previous unfocus

The cursor is ser inside the composer