### PR TITLE
[FIX] mail: unescape channel name in the sidebar

### DIFF
--- a/addons/mail/static/src/components/discuss/discuss.xml
+++ b/addons/mail/static/src/components/discuss/discuss.xml
@@ -103,18 +103,4 @@
         </t>
     </t>
 
-    <!--
-        @param {string} searchVal
-    -->
-    <t t-name="mail.Discuss.AutocompleteChannelPrivateItem" owl="1">
-        <strong>Create <em><span class="fa fa-lock"/><t t-esc="searchVal"/></em></strong>
-    </t>
-
-    <!--
-        @param {string} searchVal
-    -->
-    <t t-name="mail.Discuss.AutocompleteChannelPublicItem" owl="1">
-        <strong>Create <em><span class="fa fa-hashtag"/><t t-esc="searchVal"/></em></strong>
-    </t>
-
 </templates>


### PR DESCRIPTION
- Use not escaped value in all communication with server to fix :
  - channel search : now channel with & will be foundable
  - channel create : now channel is created with right name
- Don't use renderToString and owl templates to render autocomplete
  items in order to avoid double escaping
- Remove no more used templates

task-2273527