### PR TITLE
[ADD] website_{event_meet,jitsi}: allow the visitors to meet at online events

### DIFF
--- a/addons/website_event_meet/__manifest__.py
+++ b/addons/website_event_meet/__manifest__.py
@@ -11,11 +11,21 @@
     'website': 'https://www.odoo.com/page/events',
     'description': "",
     'depends': [
+        # STD-TODO: remove 'website_event_track'
+        # we just need it to be able to use 'website.event.menu'
+        # which is defined in 'website_event_track'
         'website_event_online',
+        'website_event_track',
+        'website_jitsi',
     ],
+    'demo': ['data/website_event_meet_demo.xml'],
     'data': [
-    ],
-    'demo': [
+        'security/ir.model.access.csv',
+        'views/assets.xml',
+        'views/event_templates.xml',
+        'views/event_meeting_room_views.xml',
+        'views/event_views.xml',
+        'views/event_type_views.xml',
     ],
     'application': False,
     'installable': True,

--- a/addons/website_event_meet/controllers/__init__.py
+++ b/addons/website_event_meet/controllers/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
+from . import main

--- a/addons/website_event_meet/controllers/main.py
+++ b/addons/website_event_meet/controllers/main.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+from werkzeug.exceptions import Forbidden
+from werkzeug.utils import redirect
+
+from odoo import http
+from odoo.http import request
+from odoo.addons.http_routing.models.ir_http import slug
+
+
+_logger = logging.getLogger(__name__)
+
+
+class WebsiteEventMeetController(http.Controller):
+    @http.route(["/event/<model('event.event'):event>/meeting_rooms"], type="http",
+                auth="public", website=True, sitemap=True)
+    def event_meeting_rooms(self, event, lang=None, open_room_id=None):
+        """Display the meeting rooms of the event on the frontend side.
+
+        :param event: Event for which we display the meeting rooms
+        :param lang: lang id used to perform a search
+        :param open_room_id: automatically open the meeting room given
+        """
+        if not event.can_access_from_current_website():
+            raise Forbidden()
+
+        meeting_rooms = event.sudo().meeting_room_ids.filtered(lambda m: m.room_active)
+        meeting_rooms = meeting_rooms.sorted(lambda m: (m.is_pinned, m.room_last_joined, m.id), reverse=True)
+
+        if lang is not None:
+            lang = request.env["res.lang"].browse(int(lang))
+            meeting_rooms = meeting_rooms.filtered(lambda m: m.room_lang_id == lang)
+
+        values = {
+            "event": event.sudo(),
+            "meeting_rooms": meeting_rooms,
+            "current_lang": lang,
+            "available_languages": event.sudo().meeting_room_ids.mapped("room_lang_id"),
+            "open_room_id": int(open_room_id) if open_room_id else None,
+            "is_event_manager": request.env.user.has_group("event.group_event_manager"),
+            "default_lang_code": request.env.user.lang,
+        }
+
+        return request.render("website_event_meet.template_meeting_rooms", values)
+
+    @http.route(["/event/create_meeting_room"], type="http", auth="public", methods=["POST"], website=True)
+    def create_meeting_room(self, **post):
+        name = post.get("name")
+        summary = post.get("summary")
+        target_audience = post.get("audience")
+        lang_code = post.get("lang_code")
+        max_capacity = post.get("capacity")
+        event_id = int(post.get("event"))
+
+        # get the record to be sure they really exist
+        event = request.env["event.event"].browse(event_id).exists()
+        lang = request.env["res.lang"].search([("code", "=", lang_code)], limit=1)
+
+        if not event or not event.can_access_from_current_website():
+            raise Forbidden()
+
+        if not event.website_published or not lang or max_capacity == "no_limit":
+            raise Forbidden()
+
+        _logger.info("New meeting room (%s) create by %s" % (name, request.httprequest.remote_addr))
+
+        meeting_room = request.env["event.meeting.room"].sudo().create(
+            {
+                "name": name,
+                "summary": summary,
+                "target_audience": target_audience,
+                "is_pinned": False,
+                "event_id": event.id,
+                "room_lang_id": lang.id,
+                "room_max_capacity": max_capacity,
+            },
+        )
+
+        return redirect("/event/%s/meeting_rooms?open_room_id=%i" % (slug(event), meeting_room.id))
+
+    @http.route(["/event/active_langs"], type="json", auth="public")
+    def active_langs(self):
+        return request.env["res.lang"].sudo().get_installed()

--- a/addons/website_event_meet/data/website_event_meet_demo.xml
+++ b/addons/website_event_meet/data/website_event_meet_demo.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="event_meeting_room_0" model="event.meeting.room">
+            <field name="name">Which wood to choose ?</field>
+            <field name="summary">Let's talk about the different wood types.</field>
+            <field name="target_audience">wood expert(s)</field>
+            <field name="is_pinned" eval="True"/>
+            <field name="event_id" ref="event.event_7"/>
+            <field name="room_lang_id" ref="base.lang_en"/>
+            <field name="room_max_capacity">12</field>
+            <field name="room_participant_count">9</field>
+        </record>
+        <record id="event_meeting_room_1" model="event.meeting.room">
+            <field name="name">Reducing the ecological footprint with wood ?</field>
+            <field name="summary">Share your tips to reduce your ecological footprint using wood.</field>
+            <field name="target_audience">ecologist(s)</field>
+            <field name="is_pinned" eval="True"/>
+            <field name="event_id" ref="event.event_7"/>
+            <field name="room_lang_id" ref="base.lang_en"/>
+            <field name="room_max_capacity">8</field>
+            <field name="room_participant_count">8</field>
+        </record>
+        <record id="event_meeting_room_2" model="event.meeting.room">
+            <field name="name">Vos meubles préférés ?</field>
+            <field name="summary">Venez partager vos meubles préférés et l'utilisation que vous en faites.</field>
+            <field name="target_audience">client(s)</field>
+            <field name="is_pinned" eval="True"/>
+            <field name="event_id" ref="event.event_7"/>
+            <field name="room_lang_id" ref="base.lang_fr"/>
+            <field name="room_max_capacity">8</field>
+            <field name="room_participant_count">3</field>
+        </record>
+        <record id="event.event_7" model="event.event">
+            <field name="website_meeting_room" eval="True"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/website_event_meet/models/__init__.py
+++ b/addons/website_event_meet/models/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import event
+from . import event_mail
+from . import event_type
+from . import event_meeting_room
+from . import website_event_menu

--- a/addons/website_event_meet/models/event.py
+++ b/addons/website_event_meet/models/event.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+from odoo.addons.http_routing.models.ir_http import slug
+
+
+class Event(models.Model):
+    _inherit = "event.event"
+
+    meeting_room_ids = fields.One2many("event.meeting.room", "event_id", string="Meeting rooms")
+    meeting_room_count = fields.Integer("Room count", compute="_compute_meeting_room_count")
+    website_meeting_room = fields.Boolean(
+        "Website Community",
+        help="Display community tab on website",
+        compute="_compute_website_meeting_room",
+        readonly=False,
+        store=True,
+    )
+    meeting_room_menu_ids = fields.One2many(
+        "website.event.menu",
+        "event_id",
+        string="Event Community Menus",
+        domain=[("menu_type", "=", "meeting_room")],
+    )
+
+    @api.depends("event_type_id", "website_meeting_room")
+    def _compute_website_meeting_room(self):
+        for event in self:
+            if event.event_type_id and event.event_type_id != event._origin.event_type_id:
+                event.website_meeting_room = event.event_type_id.website_meeting_room
+            elif not event.website_meeting_room:
+                event.website_meeting_room = False
+
+    @api.depends("meeting_room_ids")
+    def _compute_meeting_room_count(self):
+        meeting_room_count = self.env["event.meeting.room"].sudo().read_group(
+            domain=[("event_id", "in", self.ids)],
+            fields=["id:count"],
+            groupby=["event_id"],
+        )
+
+        meeting_room_count = {
+            result["event_id"][0]: result["event_id_count"]
+            for result in meeting_room_count
+        }
+
+        for event in self:
+            event.meeting_room_count = meeting_room_count.get(event.id, 0)
+
+    def _update_website_menus(self, split_to_update=None):
+        super(Event, self)._update_website_menus(split_to_update=split_to_update)
+
+        for event in self:
+            if event.website_meeting_room and not event.meeting_room_menu_ids:
+                # add the community menu
+                menu = super(Event, event)._create_menu(
+                    sequence=1,
+                    name=_("Community"),
+                    url="/event/%s/meeting_rooms" % slug(self),
+                    xml_id=False,
+                )
+                event.env["website.event.menu"].create(
+                    {
+                        "menu_id": menu.id,
+                        "event_id": event.id,
+                        "menu_type": "meeting_room",
+                    }
+                )
+            elif not event.website_meeting_room:
+                # remove the community menu
+                event.meeting_room_menu_ids.mapped("menu_id").unlink()
+
+    def write(self, vals):
+        community_event = self.filtered(lambda e: e.website_meeting_room)
+        no_community_event = self.filtered(lambda e: not e.website_meeting_room)
+
+        super(Event, self).write(vals)
+
+        update_events = community_event.filtered(lambda e: not e.website_meeting_room)
+        update_events |= no_community_event.filtered(lambda e: e.website_meeting_room)
+        update_events._update_website_menus()

--- a/addons/website_event_meet/models/event_mail.py
+++ b/addons/website_event_meet/models/event_mail.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import datetime
+
+from odoo import api, fields, models
+
+
+class EventMailScheduler(models.Model):
+    """Clean the non-pinned old unused meeting rooms.
+
+    Archive all non-pinned room with 0 participant if nobody has joined it for a moment.
+    Run in the event mail CRON to avoid to create a new CRON (and to clean the meeting
+    room every 2 hours).
+    """
+
+    _inherit = "event.mail"
+
+    _DELAY_CLEAN = datetime.timedelta(hours=48)
+
+    @api.model
+    def run(self, autocommit=False):
+        self.env["event.meeting.room"].sudo().search([
+            ("is_pinned", "=", False),
+            ("room_active", "=", True),
+            ("room_participant_count", "=", 0),
+            ("room_last_activity", "<", fields.Datetime.now() - self._DELAY_CLEAN),
+        ]).room_active = False
+
+        return super(EventMailScheduler, self).run(autocommit=autocommit)

--- a/addons/website_event_meet/models/event_meeting_room.py
+++ b/addons/website_event_meet/models/event_meeting_room.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from werkzeug.urls import url_join
+
+from odoo import api, fields, models
+from odoo.addons.http_routing.models.ir_http import slug
+
+
+class EventMeetingRoom(models.Model):
+    _name = "event.meeting.room"
+    _description = "Event Meeting Room"
+    _order = "is_pinned DESC, id"
+    _inherit = {"chat.room.mixin"}
+
+    name = fields.Char("Topic", required=True, size=50)
+    event_id = fields.Many2one("event.event", "Event", required=True)
+    is_pinned = fields.Boolean("Is pinned")
+    summary = fields.Char("Summary", size=200)
+    target_audience = fields.Char("Audience", required=True, size=30)
+
+    def action_join(self):
+        """Join the meeting room on the frontend side."""
+        web_base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
+        url = url_join(web_base_url, f"/event/{slug(self.event_id)}/meeting_rooms?open_room_id={self.id}")
+        return {
+            "type": "ir.actions.act_url",
+            "url": url,
+        }
+
+    @api.model
+    def create(self, vals):
+        vals["room_active"] = True
+        vals["chat_room_id"] = vals.get(
+            "chat_room_id",
+            self.env["chat.room"].create({}).id,
+        )
+        return super(EventMeetingRoom, self).create(vals)

--- a/addons/website_event_meet/models/event_type.py
+++ b/addons/website_event_meet/models/event_type.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class EventType(models.Model):
+    _inherit = "event.type"
+
+    website_meeting_room = fields.Boolean("Website Meeting Room", help="Display community tab on website")

--- a/addons/website_event_meet/models/website_event_menu.py
+++ b/addons/website_event_meet/models/website_event_menu.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class EventMenu(models.Model):
+    _inherit = "website.event.menu"
+
+    menu_type = fields.Selection(selection_add=[("meeting_room", "Event Meeting Room Menus")])

--- a/addons/website_event_meet/security/ir.model.access.csv
+++ b/addons/website_event_meet/security/ir.model.access.csv
@@ -1,0 +1,6 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+event_meeting_room_all,event_meet.event_meeting_room,model_event_meeting_room,,0,0,0,0
+event_meeting_room_user,event_meet.event_meeting_room,model_event_meeting_room,event.group_event_user,1,0,0,0
+event_meeting_room_manager,event_meet.event_meeting_room,model_event_meeting_room,event.group_event_manager,1,1,1,1
+access_chat_room_user,access_chat_room,website_jitsi.model_chat_room,event.group_event_user,1,0,0,0
+access_chat_room_system,access_chat_room,website_jitsi.model_chat_room,event.group_event_manager,1,1,1,1

--- a/addons/website_event_meet/static/src/css/website_event_meeting_room.css
+++ b/addons/website_event_meet/static/src/css/website_event_meeting_room.css
@@ -1,0 +1,21 @@
+.o_wevent_create_meeting_room_modal .modal-dialog {
+    top: 25%;
+    max-width: 500px;
+    height: auto;
+}
+
+.o_wevent_meeting_room_corner_ribbon {
+    width: 200px;
+    background: #e43;
+    top: 25px;
+    left: -50px;
+    text-align: center;
+    line-height: 50px;
+    letter-spacing: 1px;
+    color: #f0f0f0;
+    transform: rotate(-45deg);
+    -webkit-transform: rotate(-45deg);
+    z-index: 1;
+    position: absolute;
+    opacity: 0.7;
+}

--- a/addons/website_event_meet/static/src/js/customize_options.js
+++ b/addons/website_event_meet/static/src/js/customize_options.js
@@ -1,0 +1,51 @@
+odoo.define('website_event_meet.set_customize_options', function (require) {
+"use strict";
+
+let EventSpecificOptions = require('website_event.set_customize_options').EventSpecificOptions;
+
+EventSpecificOptions.include({
+    xmlDependencies: (EventSpecificOptions.prototype.xmlDependencies || [])
+        .concat([
+            '/website_event_meet/static/src/xml/customize_options.xml',
+        ]),
+
+    events: _.extend({}, EventSpecificOptions.prototype.events, {
+        'change #display-community': '_onDisplayCommunityChange',
+    }),
+
+    start: function () {
+        this.$displayCommunityInput = this.$('#display-community');
+        this._super.apply(this, arguments);
+    },
+
+    _initCheckbox: async function () {
+        let data = await this._rpc({
+            model: this.modelName,
+            method: 'read',
+            args: [[this.eventId], ['website_url', 'website_meeting_room']],
+        });
+
+        if (data[0]['website_meeting_room']) {
+            this.$displayCommunityInput.attr('checked', 'checked');
+        }
+        this.eventUrl = data[0]['website_url'];
+    },
+
+    _onDisplayCommunityChange: async function () {
+        let checkboxValue = this.$displayCommunityInput.is(':checked');
+        await this._toggleDisplayCommunity(checkboxValue);
+    },
+
+    _toggleDisplayCommunity: async function (val) {
+        await this._rpc({
+            model: this.modelName,
+            method: 'write',
+            args: [[this.eventId], {website_meeting_room: val}],
+        });
+
+        this._reloadEventPage();
+    }
+
+});
+
+});

--- a/addons/website_event_meet/static/src/js/website_event_create_meeting_room_button.js
+++ b/addons/website_event_meet/static/src/js/website_event_create_meeting_room_button.js
@@ -1,0 +1,45 @@
+odoo.define('website_event_meet.website_event_create_room_button', function (require) {
+'use strict';
+
+const publicWidget = require('web.public.widget');
+const core = require('web.core');
+const QWeb = core.qweb;
+
+publicWidget.registry.websiteEventCreateMeetingRoom = publicWidget.Widget.extend({
+    selector: '.o_wevent_create_room_button',
+    xmlDependencies: ['/website_event_meet/static/src/xml/website_event_meeting_room.xml'],
+    events: {
+        'click': '_onClick',
+    },
+
+    start: async function () {
+        const langs = await this._rpc({
+            route: "/event/active_langs",
+        });
+
+        this.$createModal = $(QWeb.render(
+            'create_meeting_room_modal',
+            {
+                csrf_token: odoo.csrf_token,
+                event: this.$el.data("event"),
+                langs: langs,
+            }
+        ));
+
+        // set the default language to the user language
+        this.$createModal.find('.o_wevent_create_meeting_room_lang').val(this.$el.data("default-lang"));
+        this.$createModal.appendTo(this.$el);
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    _onClick: async function () {
+        this.$createModal.modal('show');
+    },
+});
+
+return publicWidget.registry.websiteEventMeetingRoom;
+
+});

--- a/addons/website_event_meet/static/src/js/website_event_meeting_room.js
+++ b/addons/website_event_meet/static/src/js/website_event_meeting_room.js
@@ -1,0 +1,83 @@
+odoo.define('website_event_meet.website_event_meet_meeting_room', function (require) {
+'use strict';
+
+const publicWidget = require('web.public.widget');
+const core = require('web.core');
+const Dialog = require('web.Dialog');
+const _t = core._t;
+
+publicWidget.registry.websiteEventMeetingRoom = publicWidget.Widget.extend({
+    selector: '.o_wevent_meeting_room_card',
+    xmlDependencies: ['/website_event_meet/static/src/xml/website_event_meeting_room.xml'],
+    events: {
+        'click .o_wevent_meeting_room_delete': '_onDeleteClick',
+        'click .o_wevent_meeting_room_duplicate': '_onDuplicateClick',
+    },
+
+    start: function () {
+        this._super.apply(this, arguments);
+        this.meetingRoomId = parseInt(this.$el.data('meeting-room-id'));
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+      * Delete the meeting room.
+      *
+      * @private
+      */
+    _onDeleteClick: async function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        Dialog.confirm(
+            this,
+            _t("Are you sure you want to close this room ?"),
+            {
+                confirm_callback: async () => {
+                    await this._rpc({
+                        model: 'event.meeting.room',
+                        method: 'write',
+                        args: [this.meetingRoomId, {room_active: false}],
+                        context: this.context,
+                    });
+
+                    // remove the element so we do not need to refresh the page
+                    this.$el.remove();
+                }
+            },
+        );
+    },
+
+    /**
+      * Duplicate the room.
+      *
+      * @private
+      */
+    _onDuplicateClick: function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        Dialog.confirm(
+            this,
+            _t("Are you sure you want to duplicate this room ?"),
+            {
+                confirm_callback: async () => {
+                    await this._rpc({
+                        model: 'event.meeting.room',
+                        method: 'copy',
+                        args: [this.meetingRoomId],
+                        context: this.context,
+                    });
+
+                    window.location.reload();
+                }
+            },
+        );
+    },
+});
+
+return publicWidget.registry.websiteEventMeetingRoom;
+
+});

--- a/addons/website_event_meet/static/src/xml/customize_options.xml
+++ b/addons/website_event_meet/static/src/xml/customize_options.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-extend="website_event.customize_options">
+        <t t-jquery="a[name='display-website-menu']" t-operation="after">
+            <a class="dropdown-item" href="#" name="display-community" role="menuitem">
+                <label class="o_switch" for="display-community">
+                    <input id="display-community" type="checkbox"/>
+                    <span/>
+                    Community
+                </label>
+            </a>
+        </t>
+    </t>
+</templates>

--- a/addons/website_event_meet/static/src/xml/website_event_meeting_room.xml
+++ b/addons/website_event_meet/static/src/xml/website_event_meeting_room.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="create_meeting_room_modal">
+        <div class="modal fade o_wevent_create_meeting_room_modal" role="dialog">
+            <div class="modal-dialog">
+                <div class="modal-content border-0">
+                    <main class="modal-body p-3">
+                        <form action="/event/create_meeting_room" class="text-dark" id="o_wevent_create_meeting_room_form" method="POST">
+                            <h2>Launch a new topic</h2>
+                            <div class="row m-2">
+                                <label class="col-4 mt-2 text-left">Room Topic</label>
+                                <input class="form-control col-8" maxlength="50" name="name" placeholder="Room Topic" required="1"/>
+                            </div>
+                            <div class="row m-2">
+                                <label class="col-4 mt-2 text-left">Short Summary</label>
+                                <input class="form-control col-8" maxlength="200" name="summary" placeholder="Short Summary" required="1"/>
+                            </div>
+                            <div class="row m-2">
+                                <label class="col-4 mt-2 text-left">Target People</label>
+                                <input class="form-control col-8" maxlength="30" name="audience" placeholder="Target People" required="1"/>
+                            </div>
+                            <div class="row m-2">
+                                <label class="col-4 mt-2 text-left">Language</label>
+                                <select class="o_wevent_create_meeting_room_lang form-control col-8" name="lang_code" required="1">
+                                    <option t-foreach="langs" t-as="language" t-att-value="language[0]" t-esc="language[1]"/>
+                                </select>
+                            </div>
+                            <div class="row m-2">
+                                <label class="col-4 mt-2 text-left">Capacity</label>
+                                <select class="form-control col-8" name="capacity" required="1">
+                                    <option value="4">4</option>
+                                    <option selected="selected" value="8">8</option>
+                                    <option value="12">12</option>
+                                    <option value="16">16</option>
+                                    <option value="20">20</option>
+                                </select>
+                            </div>
+                            <input name="event" t-att-value="event" type="hidden"/>
+                            <input name="csrf_token" t-att-value="csrf_token" type="hidden"/>
+                        </form>
+                    </main>
+                    <footer class="modal-footer">
+                        <button class="btn btn-primary" form="o_wevent_create_meeting_room_form" type="submit">Create</button>
+                        <button class="btn btn-primary" data-dismiss="modal" type="button">Discard</button>
+                    </footer>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/website_event_meet/tests/__init__.py
+++ b/addons/website_event_meet/tests/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
+from . import test_website_event_meet

--- a/addons/website_event_meet/tests/test_website_event_meet.py
+++ b/addons/website_event_meet/tests/test_website_event_meet.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.event.tests.common import TestEventCommon
+from odoo.tests import Form
+
+
+class TestWebsiteEventMeet(TestEventCommon):
+    def test_meeting_room_form(self):
+        """Test that the field of the mixin are automatically filled."""
+        new_meeting_room_form = Form(self.env["event.meeting.room"])
+        new_meeting_room_form.name = "Test name"
+        new_meeting_room_form.event_id = self.event_0
+        new_meeting_room_form.target_audience = "dev"
+        new_meeting_room_form.room_max_capacity = "20"
+        meeting_room = new_meeting_room_form.save()
+
+        self.assertTrue(meeting_room.chat_room_id)
+        self.assertTrue(meeting_room.chat_room_id.active)
+        self.assertEqual(meeting_room.chat_room_id.max_capacity, "20")
+
+    def test_meeting_room_copy(self):
+        """Test the duplication of the meeting room."""
+        meeting_room_1 = self.env["event.meeting.room"].create({
+            "name": "Test meeting room",
+            "event_id": self.event_0.id,
+            "target_audience": "dev",
+            "room_max_capacity": "20",
+        })
+
+        meeting_room_2 = meeting_room_1.copy()
+
+        chat_room_1 = meeting_room_1.chat_room_id
+        chat_room_2 = meeting_room_2.chat_room_id
+
+        self.assertTrue(chat_room_1)
+        self.assertTrue(chat_room_2)
+        self.assertNotEqual(chat_room_1.id, chat_room_2.id, "Must create a new chat room")
+        self.assertNotEqual(chat_room_1.name, chat_room_2.name, "Must generate a new chat room name")
+        self.assertEqual(chat_room_1.max_capacity, "20", "Must set the max capacity on the chat room")
+        self.assertEqual(chat_room_2.max_capacity, "20", "Must copy the max capacity")
+
+    def test_meeting_room_unlink(self):
+        """Test the duplication of the meeting room."""
+        meeting_room = self.env["event.meeting.room"].create({
+            "name": "Test meeting room",
+            "event_id": self.event_0.id,
+            "target_audience": "dev",
+            "room_max_capacity": "20",
+        })
+
+        self.assertTrue(meeting_room.chat_room_id)
+        chat_room_id = meeting_room.chat_room_id.id
+
+        meeting_room.unlink()
+        self.assertFalse(self.env["chat.room"].browse(chat_room_id).exists())

--- a/addons/website_event_meet/views/assets.xml
+++ b/addons/website_event_meet/views/assets.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="assets_frontend" inherit_id="website.assets_frontend" name="Website Event Meet Assets">
+        <xpath expr="." position="inside">
+            <link href="/website_event_meet/static/src/css/website_event_meeting_room.css" rel="stylesheet" type="text/css"/>
+            <script src="/website_event_meet/static/src/js/customize_options.js" type="text/javascript"/>
+            <script src="/website_event_meet/static/src/js/website_event_meeting_room.js" type="text/javascript"/>
+            <script src="/website_event_meet/static/src/js/website_event_create_meeting_room_button.js" type="text/javascript"/>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/website_event_meet/views/event_meeting_room_views.xml
+++ b/addons/website_event_meet/views/event_meeting_room_views.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="website_event_meet.event_meeting_room_action" model="ir.actions.act_window">
+        <field name="name">Meeting Room</field>
+        <field name="res_model">event.meeting.room</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <record id="event_meeting_room_view_search" model="ir.ui.view">
+        <field name="name">event.meeting.room.search</field>
+        <field name="model">event.meeting.room</field>
+        <field name="arch" type="xml">
+            <search string="Meeting Room">
+                <field name="event_id"/>
+            </search>
+        </field>
+    </record>
+    <record id="event_meeting_room_view_form" model="ir.ui.view">
+        <field name="name">event.meeting.room.form</field>
+        <field name="model">event.meeting.room</field>
+        <field name="arch" type="xml">
+            <form string="Meeting Room">
+                <header>
+                    <button class="oe_highlight" name="action_join" string="Join the room" type="object" attrs="{'invisible': [('room_active', '=', False)]}"/>
+                    <field name="room_active" invisible="1"/>
+                </header>
+                <sheet>
+                    <label for="name"/>
+                    <h1>
+                        <field name="name"/>
+                    </h1>
+                    <group>
+                        <group>
+                            <field name="event_id"/>
+                            <field name="summary"/>
+                            <field name="target_audience"/>
+                            <field name="is_pinned"/>
+                        </group>
+                        <group>
+                            <field name="chat_room_id"/>
+                            <field name="room_participant_count"/>
+                            <field name="room_max_capacity"/>
+                            <field name="room_lang_id" options="{'no_create': True}"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page name="Reporting" string="Reporting">
+                            <group>
+                                <field name="room_last_joined"/>
+                                <field name="room_last_activity"/>
+                                <field name="room_max_participant_reached"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="event_meeting_room_view_tree" model="ir.ui.view">
+        <field name="name">event.meeting.room.tree</field>
+        <field name="model">event.meeting.room</field>
+        <field name="arch" type="xml">
+            <tree string="Meeting Room">
+                <field name="name"/>
+                <field name="summary"/>
+                <field name="target_audience"/>
+                <field name="is_pinned"/>
+                <field name="room_active"/>
+                <field name="room_participant_count"/>
+                <field name="room_max_capacity"/>
+                <field name="room_lang_id"/>
+                <field name="room_last_joined"/>
+            </tree>
+        </field>
+    </record>
+    <record id="event_meeting_room_view_search" model="ir.ui.view">
+        <field name="name">event.meeting.room.search</field>
+        <field name="model">event.meeting.room</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" string="Topic"/>
+                <field name="summary" string="Summary"/>
+                <field name="target_audience" string="Audience"/>
+                <field name="event_id" string="Event"/>
+                <filter domain="[('room_active', '=', False)]" name="archived" string="Archived"/>
+                <group expand="0" string="Group By">
+                    <filter string="Event" name="groupby_event" domain="[]" context="{'group_by': 'event_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+</odoo>

--- a/addons/website_event_meet/views/event_templates.xml
+++ b/addons/website_event_meet/views/event_templates.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template name="Meeting Rooms"  id="template_meeting_rooms">
+        <t t-call="website_event.layout">
+            <div class="oe_structure" id="oe_structure_website_event_location_1"/>
+            <section class="pt32 pb32">
+                <div class="container">
+                    <div class="row">
+                        <div class="mw-75 col-12 col-md-8">
+                            <h1 class="o_page_header mb-3 d-flex flex-row justify-content-between">
+                                <span>Join a room</span>
+                                <div class="o_dropdown_kanban dropdown">
+                                    <a aria-label="Dropdown menu" class="dropdown-toggle o-no-caret btn" data-display="static" data-toggle="dropdown" href="#" role="button" title="Dropdown menu">
+                                        <span t-esc="current_lang.name if current_lang else 'All Languages'"/> ▼</a>
+                                    <div class="dropdown-menu" role="menu">
+                                        <a class="dropdown-item" role="menuitem" t-attf-href="/event/#{slug(event)}/meeting_rooms">All Languages
+                                           </a>
+                                        <a class="dropdown-item" role="menuitem" t-as="language" t-attf-href="/event/#{slug(event)}/meeting_rooms?lang=#{language.id}" t-esc="language.name" t-foreach="available_languages"/>
+                                    </div>
+                                </div>
+                            </h1>
+                            <p>Choose a topic that interests you and start talking with the community.</p>
+                            <p>Don't forget to setup your camera and microphone.</p>
+                            <div class="d-flex flex-column justify-content-start align-items-start">
+                                <t t-as="meeting_room" t-call="website_event_meet.meeting_room_card" t-foreach="meeting_rooms">
+                                    <t t-set="meeting_room" t-value="meeting_room"/>
+                                    <t t-set="opened" t-value="int(meeting_room.id == open_room_id)"/>
+                                </t>
+                            </div>
+                        </div>
+                        <div class="w-25 d-none d-md-block col-md-4">
+                            <h1 class="o_page_header mb-3">Launch a new topic</h1>
+                            <p>Want to create your own discussion room ?</p>
+                            <p>Be sure you are ready to spend at least 10 minutes in the room if you want to initiate a new topic.</p>
+                            <button class="btn btn-primary o_wevent_create_room_button" t-att-data-event="event.id" t-att-data-default-lang="default_lang_code">Create a Room</button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </t>
+    </template>
+    <template id="meeting_room_card">
+        <div t-if="is_event_manager or not meeting_room.room_is_full" t-att-data-meeting-room-id="meeting_room.id" t-att-data-open-room="opened" t-att-data-is-event-manager="int(is_event_manager)" t-attf-class="card o_wevent_meeting_room_card w-100 m-2 bg-light">
+            <div class="text-decoration-none w-100 h-100 p-4">
+                <div class="o_wevent_meeting_room_corner_ribbon" t-if="meeting_room.room_is_full">Full</div>
+                <button t-if="is_event_manager and meeting_room.room_is_full" class="btn btn-danger float-right o_wevent_meeting_room_duplicate ml-1" type="button">Duplicate</button>
+                <button t-if="is_event_manager" class="btn btn-danger float-right o_wevent_meeting_room_delete" type="button">Close</button>
+                <h3><t t-esc="meeting_room.name"/> <t t-if="is_event_manager and meeting_room.is_pinned" t-esc="'(pinned)'"/></h3>
+                <h5 t-esc="meeting_room.summary"/>
+                <h4 class="m-0 row text-primary">
+                    <b>&amp;#9900;&amp;nbsp;</b>
+                    <span class="o_wevent_participant_count">
+                        <t t-esc="meeting_room.room_participant_count"/>&amp;nbsp;</span>
+                    <t t-esc="meeting_room.target_audience or 'participant(s)'"/>
+                </h4>
+                <div class="d-flex flex-row justify-content-between mt-3">
+                    <t t-call="website_jitsi.chat_room_join_button">
+                        <t t-set="room_name" t-value="meeting_room.room_name"/>
+                        <t t-set="chat_room_id" t-value="meeting_room.chat_room_id.id"/>
+                        <t t-set="auto_open" t-value="int(open_room_id == meeting_room.id)"/>
+                        <t t-set="check_full" t-value="int(not is_event_manager)"/>
+                    </t>
+                    <div class="d-inline border p-2 bg-secondary" t-esc="meeting_room.room_lang_id.name"/>
+                </div>
+            </div>
+        </div>
+    </template>
+</odoo>

--- a/addons/website_event_meet/views/event_type_views.xml
+++ b/addons/website_event_meet/views/event_type_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<odoo>
+<record id="event_type_view_form_inherit_track" model="ir.ui.view">
+        <field name="name">event.type.view.form.inherit.track</field>
+        <field name="model">event.type</field>
+        <field name="inherit_id" ref="website_event.event_type_view_form_inherit_website"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='event_type_visibility_website']/div[hasclass('o_setting_right_pane')]" position='inside'>
+                <div class="row mt16" attrs="{'invisible': [('website_menu', '=', False)]}">
+                    <label class="col-lg-4" for="website_meeting_room"/> <field name="website_meeting_room"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/website_event_meet/views/event_views.xml
+++ b/addons/website_event_meet/views/event_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="view_event_form" model="ir.ui.view">
+        <field name="name">Meeting rooms</field>
+        <field name="inherit_id" ref="event.view_event_form"/>
+        <field name="model">event.event</field>
+        <field eval="5" name="priority"/>
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button class="oe_stat_button" context="{'default_event_id': active_id, 'search_default_event_id': active_id}" icon="fa-comments-o" name="%(event_meeting_room_action)d" type="action">
+                    <field name="meeting_room_count" string="Rooms" widget="statinfo"/>
+                </button>
+                <field name="website_meeting_room" invisible="1"/>
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/addons/website_jitsi/__init__.py
+++ b/addons/website_jitsi/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import controllers
+from . import models

--- a/addons/website_jitsi/__manifest__.py
+++ b/addons/website_jitsi/__manifest__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "Website Jitsi",
+    "summary": "Create Jitsi room on website.",
+    "description": "Create Jitsi room on website.",
+    "version": "0.1",
+    "depends": ["website"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/chat_room_templates.xml",
+        "views/chat_room_views.xml",
+        "views/assets.xml",
+    ],
+}

--- a/addons/website_jitsi/controllers/__init__.py
+++ b/addons/website_jitsi/controllers/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import main

--- a/addons/website_jitsi/controllers/main.py
+++ b/addons/website_jitsi/controllers/main.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+from werkzeug.exceptions import Forbidden, NotFound
+
+from odoo import http
+from odoo.http import request
+
+
+_logger = logging.getLogger(__name__)
+
+
+class WebsiteJitsiController(http.Controller):
+    @http.route(["/website_jitsi/update_participant_count"], type="json", auth="public")
+    def update_participant_count(self, joined, participant_count, room_name):
+        """Update the number of participant in the room.
+
+        Use the SQL keywords "FOR UPDATE SKIP LOCKED" in order to do anything if the SQL
+        row is locked (instead of raising an exception, wait for a moment and retry).
+        As this endpoint can be called multiple times, and we do not care to have a small
+        error in the participant count (but we care about performance).
+
+        We need to provide the room name so it limit the rooms for which we can update
+        the participant count (visitors can not update the participant count for
+        unpublished rooms).
+        """
+        if participant_count < 0:
+            raise Forbidden()
+
+        self._chat_room_exists(room_name)
+
+        request.env.cr.execute(
+            """
+            WITH req AS (
+                SELECT id
+                  FROM chat_room
+                  -- Can not update the chat room if we do not have its name
+                 WHERE name = %s
+                   FOR UPDATE SKIP LOCKED
+            )
+            UPDATE chat_room AS wcr
+               SET participant_count = %s,
+                   last_joined = CASE WHEN %s THEN NOW() ELSE last_joined END,
+                   last_activity = NOW(),
+                   max_participant_reached = GREATEST(max_participant_reached, %s)
+              FROM req
+             WHERE wcr.id = req.id;
+            """,
+            [room_name, participant_count, joined, participant_count]
+        )
+
+    @http.route(["/website_jitsi/<string:room_name>/is_chat_room_full"], type="json", auth="public")
+    def is_chat_room_full(self, room_name):
+        """Return True is the given chat room is full."""
+        chat_room = self._chat_room_exists(room_name)
+        return chat_room.sudo().is_full
+
+    def _chat_room_exists(self, room_name):
+        """Return the Chat Room record or raise an exception if not found."""
+        chat_room = request.env["chat.room"].sudo().search([("name", "=", room_name)], limit=1)
+
+        if not chat_room:
+            raise NotFound()
+
+        return chat_room

--- a/addons/website_jitsi/models/__init__.py
+++ b/addons/website_jitsi/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import chat_room
+from . import chat_room_mixin

--- a/addons/website_jitsi/models/chat_room.py
+++ b/addons/website_jitsi/models/chat_room.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import uuid
+
+from odoo import api, fields, models
+
+
+class ChatRoom(models.Model):
+    """Store all useful information to manage chat room (Jitsi).
+
+    This model embed all information about the chat room. We do not store them in the
+    mixin to avoid to add too many fields on the models which want to use the chat room
+    mixin (as the behavior can be optional in those models).
+
+    The participant count is automatically updated thanks to the chat room widget.
+    """
+
+    _name = "chat.room"
+    _description = "Chat Room"
+
+    name = fields.Char(
+        "Room Name", required=True, copy=False,
+        default=lambda self: "odoo-room-%s" % str(uuid.uuid4())[:8],
+    )
+    active = fields.Boolean(default=True)
+
+    is_full = fields.Boolean("Full", compute="_compute_full")
+    lang_id = fields.Many2one(
+        "res.lang", "Language",
+        default=lambda self: self.env["res.lang"].search([("code", "=", self.env.user.lang)], limit=1),
+    )
+    max_capacity = fields.Selection(
+        [("4", "4"), ("8", "8"), ("12", "12"), ("16", "16"), ("20", "20"), ("no_limit", "No limit")],
+        "Max capacity", default="8", required=True,
+    )
+    participant_count = fields.Integer("Participant count", default=0, copy=False)
+
+    # reporting fields
+    last_activity = fields.Datetime("Last activity", readonly=True, default=lambda self: fields.Datetime.now(), copy=False)
+    last_joined = fields.Datetime("Last joined", readonly=True, default=lambda self: fields.Datetime.now(), copy=False)
+    max_participant_reached = fields.Integer(
+        "Max participant reached", readonly=True, copy=False,
+        help="Maximum number of participant reached in the room at the same time",
+    )
+
+    @api.depends("max_capacity", "participant_count")
+    def _compute_full(self):
+        for room in self:
+            if room.max_capacity == "no_limit":
+                room.is_full = False
+            else:
+                room.is_full = room.participant_count >= int(room.max_capacity)

--- a/addons/website_jitsi/models/chat_room_mixin.py
+++ b/addons/website_jitsi/models/chat_room_mixin.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ChatRoomMixin(models.AbstractModel):
+    """Add the chat room configuration (`chat.room`) on the needed models.
+
+    The chat room configuration contains all information about the room. So, we store
+    all the chat room logic at the same place, for all models.
+    Embed chat room related fields prefixed with `room_`.
+    """
+
+    _name = "chat.room.mixin"
+    _description = "Chat Room Mixin"
+
+    chat_room_id = fields.Many2one("chat.room", "Chat Room", readonly=True, copy=False, ondelete="cascade")
+
+    # Chat room related fields
+    room_name = fields.Char("Room Name", related="chat_room_id.name")
+    room_active = fields.Boolean("Active Room", related="chat_room_id.active", readonly=False)
+    room_is_full = fields.Boolean("Room Is Full", related="chat_room_id.is_full")
+    room_lang_id = fields.Many2one("res.lang", "Language", related="chat_room_id.lang_id", readonly=False)
+    room_max_capacity = fields.Selection(string="Max capacity", related="chat_room_id.max_capacity", readonly=False, required=True)
+    room_participant_count = fields.Integer("Participant count", related="chat_room_id.participant_count", readonly=False)
+    room_last_activity = fields.Datetime("Last activity", related="chat_room_id.last_activity")
+    room_last_joined = fields.Datetime("Last joined", related="chat_room_id.last_joined")
+    room_max_participant_reached = fields.Integer("Max participant reached", related="chat_room_id.max_participant_reached")
+
+    def copy(self, default=None):
+        if self.chat_room_id:
+            chat_room_id = self.chat_room_id.copy()
+            default = dict(default or {}, chat_room_id=chat_room_id.id)
+        return super().copy(default)
+
+    def unlink(self):
+        if self.chat_room_id:
+            self.chat_room_id.unlink()
+        return super(ChatRoomMixin, self).unlink()

--- a/addons/website_jitsi/security/ir.model.access.csv
+++ b/addons/website_jitsi/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_chat_room_all,access_chat_room,model_chat_room,,0,0,0,0
+access_chat_room_user,access_chat_room,model_chat_room,base.group_user,1,0,0,0
+access_chat_room_system,access_chat_room,model_chat_room,base.group_system,1,1,1,1

--- a/addons/website_jitsi/static/src/css/chat_room.css
+++ b/addons/website_jitsi/static/src/css/chat_room.css
@@ -1,0 +1,17 @@
+.o_wjitsi_room_modal .modal-dialog {
+    top: 10%;
+    max-width: 100vw;
+    max-height: 100vh;
+    width: 80%;
+    margin: auto;
+}
+
+.o_wjitsi_room_modal .modal-body {
+    height: 70vh;
+    overflow: hidden;
+    margin: 0;
+}
+
+.o_wjitsi_chat_room_loading {
+    top: 50%;
+}

--- a/addons/website_jitsi/static/src/js/chat_room.js
+++ b/addons/website_jitsi/static/src/js/chat_room.js
@@ -1,0 +1,262 @@
+odoo.define('website_jitsi.chat_room', function (require) {
+'use strict';
+
+const config = require("web.config");
+const core = require('web.core');
+const Dialog = require('web.Dialog');
+const publicWidget = require('web.public.widget');
+const QWeb = core.qweb;
+const _t = core._t;
+
+publicWidget.registry.ChatRoom = publicWidget.Widget.extend({
+    selector: '.o_wjitsi_room_widget',
+    xmlDependencies: ['/website_jitsi/static/src/xml/chat_room_modal.xml'],
+    events: {
+        'click .o_wjitsi_room_link': '_onChatRoomClick',
+    },
+
+    start: async function () {
+        await this._super.apply(this, arguments);
+        this.roomName = this.$el.data('room-name');
+        this.chatRoomId = parseInt(this.$el.data('chat-room-id'));
+        // automatically open the current room
+        this.autoOpen = parseInt(this.$el.data('auto-open') || 0);
+        // before joining, perform a RPC call to verify that the chat room is not full
+        this.checkFull = parseInt(this.$el.data('check-full') || 0);
+        // query selector of the element on which we attach the Jitsi iframe
+        // if not defined, the widget will pop in a modal instead
+        this.attachTo = this.$el.data('attach-to') || false;
+
+        if (this.autoOpen) {
+            await this._onChatRoomClick();
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+      * Click on a chat room to join it.
+      *
+      * @private
+      */
+    _onChatRoomClick: async function () {
+        if (this.checkFull) {
+            // maybe we didn't refresh the page for a while and so we might join a room
+            // which is full, so we perform a RPC call to verify that we can really join
+            let isChatRoomFull = await this._rpc({
+                route: `/website_jitsi/${this.roomName}/is_chat_room_full`,
+            });
+
+            if (isChatRoomFull) {
+                Dialog.alert(this, _t("Sorry, this room is full"), {
+                    title: _t("Warning"),
+                    // reload the page to refresh the participant count
+                    confirm_callback: () => window.location.reload(),
+                });
+                return;
+            }
+        }
+
+        if (await this._openMobileApplication(this.roomName)) {
+            // we opened the mobile application
+            return;
+        }
+
+        await this._loadJisti();
+
+        if (this.attachTo) {
+            // attach the Jitsi iframe on the given parent node
+            let $parentNode = $(this.attachTo);
+            $parentNode.find("iframe").trigger("empty");
+            $parentNode.empty();
+
+            let jitsiRoom = await this._joinJitsiRoom($parentNode);
+
+            $(jitsiRoom._frame).on("empty", async () => {
+                // we opened an other Jitsi room on the same parent node
+                await this._updatePartitipantCountIfEmpty();
+            });
+
+            jitsiRoom.addEventListener('videoConferenceLeft', async () => {
+                await this._updatePartitipantCountIfEmpty();
+            });
+        } else {
+            // create a model and append the Jitsi iframe in it
+            let $jitsiModal = $(QWeb.render('chat_room_modal', {}));
+            $("body").append($jitsiModal);
+            $jitsiModal.modal('show');
+
+            let jitsiRoom = await this._joinJitsiRoom($jitsiModal.find('.modal-body'));
+
+            // close the modal when hanging up
+            jitsiRoom.addEventListener('videoConferenceLeft', async () => {
+                $('.o_wjitsi_room_modal').modal('hide');
+            });
+
+            // when the modal is closed, delete the Jitsi room object and clear the DOM
+            $jitsiModal.on('hidden.bs.modal', async () => {
+                jitsiRoom.dispose();
+                $(".o_wjitsi_room_modal").remove();
+                await this._updatePartitipantCountIfEmpty();
+            });
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+      * Jitsi do not provide an REST API to get the number of participant in a room.
+      * The only way to get the number of participant is to be in the room and to use
+      * the Javascript API. So, to update the participant count on the server side,
+      * the participant have to send the count in RPC...
+      *
+      * When leaving a room, the event "participantLeft" is called for the current user
+      * once per participant in the room (like if all other participants were leaving the
+      * room and then the current user himself).
+      *
+      * "participantLeft" is called only one time for the other participant who are still
+      * in the room.
+      *
+      * We can not ask the user who is leaving the room to update the participant count
+      * because user might close their browser tab without hanging up (and so without
+      * triggering the event "videoConferenceLeft"). So, we wait for a moment (because the
+      * event "participantLeft" is called many time for the participant who is leaving)
+      * and the first participant send the new participant count (so we avoid spamming the
+      * server with HTTP requests).
+      *
+      * We use "setTimout" to send maximum one HTTP request per interval, even if multiple
+      * participants join/leave at the same time in the defined interval.
+      *
+      * Update on the 29 June 2020
+      *
+      * @private
+      * @param {jQuery} $jitsiModal, jQuery modal element in which we add the Jitsi room
+      * @returns {JitsiRoom} the newly created Jitsi room
+      */
+    _joinJitsiRoom: async function ($parentNode) {
+        let jitsiRoom = await this._createJitsiRoom(this.roomName, $parentNode);
+
+        let timeoutCall = null;
+        const updateParticipantCount = (joined) => {
+            // we clear the old timeout to be sure to call it only once each 2 seconds
+            // (so if 2 participants join/leave in this interval, we will perform only
+            // one HTTP request for both).
+            clearTimeout(timeoutCall);
+            timeoutCall = setTimeout(() => {
+                this.allParticipantIds = Object.keys(jitsiRoom._participants).sort();
+                if (this.participantId === this.allParticipantIds[0]) {
+                    // only the first participant of the room send the new participant
+                    // count so we avoid to send to many HTTP requests
+                    this._updateParticipantCount(this.allParticipantIds.length, joined);
+                }
+            }, 2000);
+        };
+
+        jitsiRoom.addEventListener('participantJoined', () => updateParticipantCount(true));
+        jitsiRoom.addEventListener('participantLeft', () => updateParticipantCount(false));
+
+        // update the participant count when joining the room
+        jitsiRoom.addEventListener('videoConferenceJoined', async (event) => {
+            this.participantId = event.id;
+            updateParticipantCount(true);
+            $('.o_wjitsi_chat_room_loading').addClass('d-none');
+        });
+
+        return jitsiRoom;
+    },
+
+    /**
+      * If we are the last participant in the room, we are the only one who can send the
+      * "zero participant" update to the server.
+      *
+      * @private
+      */
+    _updatePartitipantCountIfEmpty: async function () {
+        if (this.allParticipantIds && this.allParticipantIds.length === 1 && this.allParticipantIds[0] === this.participantId) {
+          // we are the last participant in the room and we left it
+          await this._updateParticipantCount(0, false);
+        }
+    },
+
+    /**
+      * Perform an HTTP request to update the participant count on the server side.
+      *
+      * @private
+      * @param {integer} count, current number of participant in the room
+      * @param {boolean} joined, true if someone joined the room
+      */
+    _updateParticipantCount: async function (count, joined) {
+        await this._rpc({
+            route: `/website_jitsi/update_participant_count`,
+            params: {
+                "participant_count": count,
+                "joined": joined,
+                "room_name": this.roomName,
+            },
+        });
+    },
+
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+      * Redirect on the Jitsi mobile application if we are on mobile.
+      *
+      * @private
+      * @param {string} roomName
+      * @returns {boolean} true is we were redirected to the mobile application
+      */
+    _openMobileApplication: async function (roomName) {
+        if (config.device.isMobile) {
+            // we are on mobile, open the room in the application
+            window.location = `intent://meet.jit.si/${roomName}#Intent;scheme=org.jitsi.meet;package=org.jitsi.meet;end`;
+            return true;
+        }
+        return false;
+    },
+
+    /**
+      * Create a Jitsi room on the given DOM element.
+      *
+      * @private
+      * @param {string} roomName
+      * @param {jQuery} $parentNode
+      * @returns {JitsiRoom} the newly created Jitsi room
+      */
+    _createJitsiRoom: async function (roomName, $parentNode) {
+      await this._loadJisti();
+        const domain = "meet.jit.si";
+        const options = {
+            roomName: roomName,
+            width: "100%",
+            height: "100%",
+            parentNode: $parentNode[0],
+            configOverwrite: {disableDeepLinking: true},
+        };
+        return new window.JitsiMeetExternalAPI(domain, options);
+    },
+
+    /**
+      * Load the Jitsi external library if necessary.
+      *
+      * @private
+      */
+    _loadJisti: async function () {
+      if (!window.JitsiMeetExternalAPI) {
+          await $.ajax({
+              url: "https://meet.jit.si/external_api.js",
+              dataType: "script",
+          });
+      }
+    },
+});
+
+return publicWidget.registry.ChatRoom;
+
+});

--- a/addons/website_jitsi/static/src/xml/chat_room_modal.xml
+++ b/addons/website_jitsi/static/src/xml/chat_room_modal.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="chat_room_modal">
+        <div class="o_wjitsi_room_modal modal fade" role="dialog">
+            <div class="modal-dialog">
+                <div class="modal-content border-0">
+                    <main class="modal-body p-0">
+                        <div class="o_wjitsi_chat_room_loading position-absolute w-100 text-center text-muted">
+                            <i class="fa fa-spin fa-spinner mr-3"/>
+                            <span>Loading your room...</span>
+                        </div>
+                    </main>
+                    <footer class="modal-footer">
+                        <button class="btn btn-primary" data-dismiss="modal" type="button">Close</button>
+                    </footer>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/website_jitsi/views/assets.xml
+++ b/addons/website_jitsi/views/assets.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="assets_frontend" inherit_id="website.assets_frontend" name="Chat Room Assets">
+        <xpath expr="." position="inside">
+            <link href="/website_jitsi/static/src/css/chat_room.css" rel="stylesheet" type="text/css"/>
+            <script src="/website_jitsi/static/src/js/chat_room.js" type="text/javascript"/>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/website_jitsi/views/chat_room_templates.xml
+++ b/addons/website_jitsi/views/chat_room_templates.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="chat_room_join_button">
+            <div class="o_wjitsi_room_widget" t-att-data-room-name="room_name" t-att-data-chat-room-id="chat_room_id" t-att-data-auto-open="auto_open" t-att-data-check-full="check_full" t-att-data-attach-to="attach_to">
+                <button class="o_wjitsi_room_link btn btn-primary">Join the room</button>
+            </div>
+        </template>
+    </data>
+</odoo>

--- a/addons/website_jitsi/views/chat_room_views.xml
+++ b/addons/website_jitsi/views/chat_room_views.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="website_jitsi.chat_room_action" model="ir.actions.act_window">
+        <field name="name">Chat Room</field>
+        <field name="res_model">chat.room</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <record id="chat_room_view_search" model="ir.ui.view">
+        <field name="name">chat.room.search</field>
+        <field name="model">chat.room</field>
+        <field name="arch" type="xml">
+            <search string="Chat Room">
+                <field name="name"/>
+            </search>
+        </field>
+    </record>
+    <record id="chat_room_view_form" model="ir.ui.view">
+        <field name="name">chat.room.form</field>
+        <field name="model">chat.room</field>
+        <field name="arch" type="xml">
+            <form string="Chat Room">
+                <sheet>
+                    <label for="name"/>
+                    <h1>
+                        <field name="name"/>
+                    </h1>
+                    <group>
+                        <group>
+                            <field name="active"/>
+                            <field name="is_full"/>
+                            <field name="lang_id" options="{'no_create': True}"/>
+                            <field name="participant_count"/>
+                            <field name="max_capacity"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page name="Reporting" string="Reporting">
+                            <group>
+                                <field name="last_joined"/>
+                                <field name="last_activity"/>
+                                <field name="max_participant_reached"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="chat_room_view_tree" model="ir.ui.view">
+        <field name="name">chat.room.tree</field>
+        <field name="model">chat.room</field>
+        <field name="arch" type="xml">
+            <tree string="Chat Room">
+                <field name="name"/>
+                <field name="active"/>
+                <field name="is_full"/>
+                <field name="lang_id"/>
+                <field name="participant_count"/>
+                <field name="max_capacity"/>
+            </tree>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Purpose
=======
Allow the website visitors to meet at online events using video
conference room.

Specifications
==============
For this purpose, we decided to use Jitsi to create the room, to not
re-create the wheel. So, we can create Jitsi room from website.

Any website visitor can create a room from the frontend.

When a room is full, it is not visible anymore for the website visitor.
This behavior encourage the visitor to create new rooms (and we also
avoid to have to many visitors in a room).

Technical
=========
Jitsi do not provide a REST API (or a similar API) to get the number of
participant in a room (without hosting our own instance of Jitsi).

The only way to get the number of participant is to be in the room and
to use the Javascript API. That's why the participant send in RPC the
number of participant in the room, to update the counter on the server
side.

We can not ask the user who is leaving to update the counter, because he
can close the tab on his browser (and so the event will not be triggered),
so, the first participant in the room send the update in RPC.

Task-2283742