### PR TITLE
[FIX] Jabberwock: On focus, remove the outline on the editor

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -481,4 +481,5 @@ img.o_we_custom_image.mx-auto {
 }
 .o_editor_center {
     flex: 1 1 auto;
+    outline: none;
 }


### PR DESCRIPTION
Visual bug on Chrome browser