### PR TITLE
[IMP] website_event_online: allow to search website.visitor based on …

### DIFF
--- a/addons/website_event_online/tests/__init__.py
+++ b/addons/website_event_online/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_visitor_events

--- a/addons/website_event_online/tests/test_visitor_events.py
+++ b/addons/website_event_online/tests/test_visitor_events.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+
+from odoo import fields
+from odoo.addons.event.tests.common import TestEventCommon
+
+
+class TestVisitorEvents(TestEventCommon):
+    def test_visitor_events(self):
+        event_1 = self.env['event.event'].create({
+            'name': 'OtherEvent',
+            'auto_confirm': True,
+            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
+        })
+
+        [main_visitor, child_visitor] = self.env['website.visitor'].create([{
+            'name': 'Main Visitor',
+            'event_registration_ids': [(0, 0, {
+                'event_id': self.event_0.id
+            })]
+        }, {
+            'name': 'Child Visitor',
+            'event_registration_ids': [(0, 0, {
+                'event_id': event_1.id
+            })]
+        }])
+
+        self.assertEqual(self.event_0, main_visitor.event_wchildren_ids)
+        self.assertEqual(event_1, child_visitor.event_wchildren_ids)
+        self.assertEqual(
+            main_visitor,
+            self.env['website.visitor'].search([('event_wchildren_ids', 'in', self.event_0.ids)])
+        )
+        self.assertEqual(
+            child_visitor,
+            self.env['website.visitor'].search([('event_wchildren_ids', 'in', event_1.ids)])
+        )
+        child_visitor._link_to_visitor(main_visitor)
+        self.assertEqual(self.event_0 | event_1, main_visitor.event_wchildren_ids)
+        self.assertEqual(
+            main_visitor | child_visitor,
+            self.env['website.visitor'].with_context(active_test=False).search([('event_wchildren_ids', 'in', self.event_0.ids)])
+        )
+        self.assertEqual(
+            main_visitor | child_visitor,
+            self.env['website.visitor'].with_context(active_test=False).search([('event_wchildren_ids', 'in', event_1.ids)])
+        )


### PR DESCRIPTION
…their events

This commit adds a 'event_wchildren_ids' field that is computed/searchable
field allowing to filter website.visitors based on the event.event they are
registered for.
This includes their potential children records.

It is done as a preparation for push notifications that will need to send
social.posts targeting all attendees of a specific event.

Task 2283869