### PR TITLE
[IMP] website_event_meet: improve backend & frontend views

### DIFF
--- a/addons/website_event_meet/models/event_event.py
+++ b/addons/website_event_meet/models/event_event.py
@@ -18,7 +18,7 @@ class Event(models.Model):
         "website.event.menu", "event_id", string="Event Community Menus",
         domain=[("menu_type", "=", "meeting_room")])
     meeting_room_allow_creation = fields.Boolean(
-        "Allow meeting room creation", compute="_compute_meeting_room_allow_creation",
+        "Allow Room Creation", compute="_compute_meeting_room_allow_creation",
         readonly=False, store=True,
         help="Let Visitors Create Rooms")
 

--- a/addons/website_event_meet/models/event_meeting_room.py
+++ b/addons/website_event_meet/models/event_meeting_room.py
@@ -20,7 +20,7 @@ class EventMeetingRoom(models.Model):
     active = fields.Boolean('Active', default=True)
     is_published = fields.Boolean(copy=True)  # make the inherited field copyable
     event_id = fields.Many2one("event.event", string="Event", required=True, ondelete="cascade")
-    is_pinned = fields.Boolean("Is pinned")
+    is_pinned = fields.Boolean("Is Pinned")
     summary = fields.Char("Summary")
     target_audience = fields.Char("Audience", translate=True)
 
@@ -47,7 +47,7 @@ class EventMeetingRoom(models.Model):
                 values["chat_room_id"] = chat_room.id
 
             values["name"] = values["name"].capitalize()
-            values["target_audience"] = (values.get("target_audience") or _("People")).capitalize()
+            values["target_audience"] = (values.get("target_audience") or _("Attendee(s)")).capitalize()
 
         return super(EventMeetingRoom, self).create(values_list)
 

--- a/addons/website_event_meet/models/event_type.py
+++ b/addons/website_event_meet/models/event_type.py
@@ -12,7 +12,7 @@ class EventType(models.Model):
         readonly=False, store=True,
         help="Display community tab on website")
     meeting_room_allow_creation = fields.Boolean(
-        "Allow meeting room creation", compute='_compute_meeting_room_allow_creation',
+        "Allow Room Creation", compute='_compute_meeting_room_allow_creation',
         readonly=False, store=True,
         help="Let Visitors Create Rooms")
 

--- a/addons/website_event_meet/static/src/scss/event_meet_templates.scss
+++ b/addons/website_event_meet/static/src/scss/event_meet_templates.scss
@@ -30,17 +30,16 @@
 /* TDE FIXME: reorganize css cleanly */
 .o_wevent_meeting_room_is_pinned {
     transition: 0.2s;
+
+    // the icon must be filled with white when the meeting room is not pinned
     color: white;
     -webkit-text-stroke: 1px $o-main-text-color;
     -webkit-text-fill-color: transparent;
 
-    &:hover {
-        border: 1px solid $o-main-text-color;
+    &.o_wevent_meeting_room_pinned {
+        // the icon must be filled with black when the meeting room is pinned
+        -webkit-text-fill-color: $o-main-text-color;
     }
-}
-
-.o_wevent_meeting_room_pinned {
-    -webkit-text-fill-color: $o-main-text-color;
 }
 
 .o_wevent_meeting_room_corner_ribbon {
@@ -56,5 +55,5 @@
     -webkit-transform: rotate(-45deg);
     z-index: 1;
     position: absolute;
-    opacity: 0.7;
+    opacity: 0.6;
 }

--- a/addons/website_event_meet/static/src/xml/customize_options.xml
+++ b/addons/website_event_meet/static/src/xml/customize_options.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
     <t t-extend="website_event.customize_options">
         <t t-jquery="a[name='display-website-menu']" t-operation="after">
-            <a class="dropdown-item" href="#" name="allow-room-creation" role="menuitem">
+            <a t-if="window.document.location.pathname.endsWith('/meeting_rooms')" class="dropdown-item" href="#" name="allow-room-creation" role="menuitem">
                 <label class="o_switch" for="allow-room-creation">
                     <input id="allow-room-creation" type="checkbox"/>
                     <span/>
-                    Allow meeting room creation
+                    Allow Room Creation
                 </label>
             </a>
         </t>

--- a/addons/website_event_meet/static/src/xml/website_event_meeting_room.xml
+++ b/addons/website_event_meet/static/src/xml/website_event_meeting_room.xml
@@ -20,7 +20,7 @@
                             </div>
                             <div class="row m-2">
                                 <label class="col-4 mt-2 text-left">Target People</label>
-                                <input class="form-control col-8" maxlength="30" name="audience" placeholder="e.g. CFOs &amp; Accountants" required="1"/>
+                                <input class="form-control col-8" maxlength="30" name="audience" placeholder="e.g. CFOs &amp; Accountants"/>
                             </div>
                             <div class="row m-2">
                                 <label class="col-4 mt-2 text-left">Language</label>

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -113,11 +113,11 @@
         t-att-data-meeting-room-id="meeting_room.id"
         t-att-data-open-room="opened"
         t-att-data-is-event-manager="int(is_event_manager)"
-        t-attf-class="card o_wevent_meeting_room_card w-100 m-2 bg-light d-block text-decoration-none"
+        t-attf-class="card o_wevent_meeting_room_card w-100 my-2 bg-light d-block text-decoration-none"
         t-att-href="meeting_room_href"
         t-att-data-toggle="meeting_room_data_toggle"
         t-att-data-target="meeting_room_data_target">
-        <div class="text-decoration-none w-100 h-100 p-4">
+        <div class="text-decoration-none w-100 h-100 p-3">
             <div class="o_wevent_meeting_room_corner_ribbon" t-if="meeting_room.room_is_full">Full</div>
             <div t-if="is_event_manager" class="dropdown float-right dropleft">
                 <button class="btn py-0" data-toggle="dropdown"><h2>&#8942;</h2></button>
@@ -127,14 +127,14 @@
                     <button class="dropdown-item btn btn-danger o_wevent_meeting_room_delete" type="button">Close</button>
                 </div>
             </div>
-            <div class="row">
-                <button t-if="is_event_manager" t-attf-class="o_wevent_meeting_room_is_pinned btn #{'o_wevent_meeting_room_pinned' if meeting_room.is_pinned else ''}">
-                    <i class="fa fa-thumb-tack"/>
-                </button>
-                <h3 class="ml-3" t-esc="meeting_room.name"/>
+            <button t-if="is_event_manager" t-attf-class="o_wevent_meeting_room_is_pinned float-right btn #{'o_wevent_meeting_room_pinned' if meeting_room.is_pinned else ''}">
+                <i class="fa fa-thumb-tack"/>
+            </button>
+            <div class="d-flex flex-row justify-content-start align-items-center">
+                <h3 class="ml-1 mb-0" t-esc="meeting_room.name"/>
             </div>
             <h5 t-esc="meeting_room.summary" class="text-muted"/>
-            <div class="d-flex flex-row justify-content-between mt-3">
+            <div class="d-flex flex-row justify-content-between align-items-center mt-3">
                 <h4 class="m-0 row">
                     <b>&amp;#9900;&amp;nbsp;</b>
                     <span class="o_wevent_participant_count">

--- a/addons/website_event_meet/views/event_meet_templates_page.xml
+++ b/addons/website_event_meet/views/event_meet_templates_page.xml
@@ -73,7 +73,7 @@
             <br/>
             <span>A chat among <t t-esc="meeting_room.target_audience"/></span>
             <hr class="mt-2 pb-1 mb-1"/>
-            <div class="row mt32">
+            <div class="row">
                 <div t-field="meeting_room.summary" class="col-12 oe_no_empty mb-3"/>
             </div>
         </div>
@@ -97,9 +97,9 @@
             <ul id="collapse_meet_room_aside" class="list-unstyled mx-2 collapse d-lg-block">
                 <li t-foreach="meeting_rooms_other" t-as="meeting_room_other">
                     <div class="d-flex mb-3">
-                        <div class="flex-grow-1">
-                            <span class="d-flex align-items-top">
-                                <a t-att-href="'/event/%s/meeting_room/%s' % (slug(event), slug(meeting_room_other))"><t t-esc="meeting_room_other.name"/></a>
+                        <div class="flex-grow-1 mw-100">
+                            <span class="d-flex align-items-top mw-100">
+                                <a t-att-href="'/event/%s/meeting_room/%s' % (slug(event), slug(meeting_room_other))" class="text-truncate"><t t-esc="meeting_room_other.name"/></a>
                             </span>
                             <span class="text-muted" t-esc="meeting_room_other.summary"></span>
                             <div class="d-flex justify-content-between align-items-center">


### PR DESCRIPTION
Purpose
=======
Improve the meeting rooms card views on mobile.

Display the "Allow Room Creation" frontend option only if we are on
the community tab (this can not be done with `customize_show` as the
options is event specific...).

If no target audience is set, use "Attendees" instead of "People".

Task-2283742