### PR TITLE
[IMP] website_event_{meet, online, track_exhibitor}: add a toast message during the registration

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -207,15 +207,19 @@ class WebsiteEventController(http.Controller):
         if not event.can_access_from_current_website():
             raise werkzeug.exceptions.NotFound()
 
+        values = self._prepare_event_register_values(event, **post)
+        return request.render("website_event.event_description_full", values)
+
+    def _prepare_event_register_values(self, event, **post):
+        """Return the require values to render the template."""
         urls = event._get_event_resource_urls()
-        values = {
+        return {
             'event': event,
             'main_object': event,
             'range': range,
             'google_url': urls.get('google_url'),
             'iCal_url': urls.get('iCal_url'),
         }
-        return request.render("website_event.event_description_full", values)
 
     @http.route('/event/add_event', type='json', auth="user", methods=['POST'], website=True)
     def add_event(self, event_name="New Event", **kwargs):

--- a/addons/website_event_meet/controllers/__init__.py
+++ b/addons/website_event_meet/controllers/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import community
+from . import website_event_main

--- a/addons/website_event_meet/controllers/website_event_main.py
+++ b/addons/website_event_meet/controllers/website_event_main.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from babel.dates import format_datetime
+
+from odoo import _
+from odoo.http import request
+from odoo.addons.website_event.controllers.main import WebsiteEventController
+
+
+class WebsiteEventController(WebsiteEventController):
+    def _prepare_event_register_values(self, event, **post):
+        values = super(WebsiteEventController, self)._prepare_event_register_values(event, **post)
+
+        if "from_room_id" in post and not event.is_ongoing:
+            meeting_room = request.env["event.meeting.room"].browse(int(post["from_room_id"])).sudo().exists()
+            if meeting_room and meeting_room.is_published:
+                date_begin = format_datetime(event.with_context(tz=event.date_tz).date_begin, format="medium")
+
+                values["toast_message"] = (
+                    _('The event %s starts at %s (%s). \nJoin us there to chat about "%s" !')
+                    % (event.name, date_begin, event.date_tz, meeting_room.name)
+                )
+
+        return values

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -101,7 +101,7 @@
     </t>
     <t t-elif="not event.is_ongoing and not event.is_participating">
         <!--Pre-event, if not registered yet-->
-        <t t-set="meeting_room_href" t-value="'/event/' + slug(event) + '/register'"/>
+        <t t-set="meeting_room_href" t-value="'/event/' + slug(event) + '/register?from_room_id=%i' % meeting_room.id"/>
     </t>
     <t t-else="">
         <!--Pre-event, if registered but event not stared yet-->

--- a/addons/website_event_meet/views/event_meet_templates_page.xml
+++ b/addons/website_event_meet/views/event_meet_templates_page.xml
@@ -31,17 +31,19 @@
     <div t-att-class="'col-12 o_wevent_online_page_main o_wemeet_room_main bg-white p-0 %s' % ('col-md-9 col-lg-10' if option_widescreen else 'col-md-8 col-lg-9')">
         <!-- EVENT NOT STARTED ALERTS -->
         <div t-if="not meeting_room.event_id.is_ongoing" class="alert alert-warning text-center">
-            Event <span t-esc="meeting_room.event_id.name" class="font-weight-bold"/>
+            The event <span t-esc="meeting_room.event_id.name" class="font-weight-bold"/>
             <span t-if="meeting_room.event_id.start_today">
                 starts in
                 <span t-esc="meeting_room.event_id.start_remaining"
-                    t-options="{'widget': 'duration', 'digital': True, 'unit': 'minute', 'round': 'minute'}"/>
+                    t-options="{'widget': 'duration', 'digital': True, 'unit': 'minute', 'round': 'minute'}"/>.
             </span>
             <span class="my-0" t-else="meeting_room.event_id.start_today">
                 starts at
                 <span t-field="meeting_room.event_id.with_context(tz=meeting_room.event_id.date_tz).date_begin"
-                    t-options="{'format': 'medium'}"/>
+                    t-options="{'format': 'medium'}"/> (<t t-esc="meeting_room.event_id.date_tz"/>).
             </span>
+            <br/>
+            <span>Join us there to chat about "<b t-esc="meeting_room.name"/> !</span>
         </div>
         <!-- ROOM CONTENT -->
         <div class="d-flex flex-column">

--- a/addons/website_event_online/static/src/js/register_toaster_widget.js
+++ b/addons/website_event_online/static/src/js/register_toaster_widget.js
@@ -1,0 +1,31 @@
+odoo.define('website_event_online.register_toaster_widget', function (require) {
+'use strict';
+
+let core = require('web.core');
+let _t = core._t;
+let publicWidget = require('web.public.widget');
+
+publicWidget.registry.RegisterToasterWidget = publicWidget.Widget.extend({
+    selector: '.o_wevent_register_toaster',
+
+    /**
+     * This widget allows to display a toast message on the page.
+     *
+     * @override
+     */
+    start: function () {
+        const message = this.$el.data('message');
+        if (message && message.length) {
+            this.displayNotification({
+                title: _t("Register"),
+                message: message,
+                type: 'info'
+            });
+        }
+        return this._super.apply(this, arguments);
+    },
+});
+
+return publicWidget.registry.RegisterToasterWidget;
+
+});

--- a/addons/website_event_online/views/assets.xml
+++ b/addons/website_event_online/views/assets.xml
@@ -7,6 +7,7 @@
         </xpath>
         <xpath expr="//script[last()]" position="after">
             <script type="text/javascript" src="/website_event_online/static/src/js/display_timer_widget.js"></script>
+            <script type="text/javascript" src="/website_event_online/static/src/js/register_toaster_widget.js"></script>
         </xpath>
     </template>
 

--- a/addons/website_event_online/views/event_templates_event.xml
+++ b/addons/website_event_online/views/event_templates_event.xml
@@ -46,4 +46,10 @@
     </div>
 </template>
 
+<template id="registration_template" inherit_id="website_event.registration_template">
+    <xpath expr="//div" position="after">
+        <div t-if="toast_message" class="o_wevent_register_toaster d-none" t-att-data-message="toast_message"/>
+    </xpath>
+</template>
+
 </odoo>

--- a/addons/website_event_track_exhibitor/controllers/__init__.py
+++ b/addons/website_event_track_exhibitor/controllers/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import exhibitor
+from . import website_event_main

--- a/addons/website_event_track_exhibitor/controllers/website_event_main.py
+++ b/addons/website_event_track_exhibitor/controllers/website_event_main.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from babel.dates import format_datetime
+
+from odoo import _
+from odoo.http import request
+from odoo.addons.website_event.controllers.main import WebsiteEventController
+
+
+class WebsiteEventController(WebsiteEventController):
+    def _prepare_event_register_values(self, event, **post):
+        values = super(WebsiteEventController, self)._prepare_event_register_values(event, **post)
+
+        if "from_sponsor_id" in post and not event.is_ongoing:
+            sponsor = request.env["event.sponsor"].browse(int(post["from_sponsor_id"])).exists()
+            if sponsor:
+                date_begin = format_datetime(event.with_context(tz=event.date_tz).date_begin, format="medium")
+
+                values["toast_message"] = (
+                    _('The event %s starts at %s (%s). \nJoin us there to meet %s !')
+                    % (event.name, date_begin, event.date_tz, sponsor.partner_name)
+                )
+
+        return values

--- a/addons/website_event_track_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_track_exhibitor/views/event_exhibitor_templates_list.xml
@@ -167,7 +167,7 @@
                 </small>
 
                 <div t-att-data-sponsor-url="sponsor.website_url" class="o_wesponsor_js_connect"
-                     t-att-data-register-url="'/event/%s/register' % (slug(event))"
+                     t-attf-data-register-url="/event/#{slug(event)}/register?from_sponsor_id=#{sponsor.id}"
                      t-att-data-is-participating="event.is_participating"
                      t-att-data-sponsor-id="sponsor.id"
                      t-att-data-event-is-ongoing="sponsor.event_id.is_ongoing"

--- a/addons/website_event_track_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_track_exhibitor/views/event_exhibitor_templates_page.xml
@@ -35,13 +35,15 @@
             <span t-if="sponsor.event_id.start_today">
                 starts in
                 <span t-esc="sponsor.event_id.start_remaining"
-                    t-options="{'widget': 'duration', 'digital': True, 'unit': 'minute', 'round': 'minute'}"/>
+                    t-options="{'widget': 'duration', 'digital': True, 'unit': 'minute', 'round': 'minute'}"/>.
             </span>
             <span class="my-0" t-else="">
                 starts at
                 <span t-field="sponsor.event_id.with_context(tz=sponsor.event_id.date_tz).date_begin"
-                    t-options="{'format': 'medium'}"/>
+                    t-options="{'format': 'medium'}"/> (<t t-esc="sponsor.event_id.date_tz"/>).
             </span>
+            <br/>
+            <span>Join us there to meet <b t-esc="sponsor.partner_name"/> !</span>
         </div>
         <!-- SPONSOR JITSI + CLOSED/FULL ALERTS -->
         <div t-if="sponsor.event_id.is_ongoing and sponsor.chat_room_id" class="d-flex flex-column">


### PR DESCRIPTION
Purpose
=======
On `website_event_meet` and `website_event_track_exhibitor`, you can
join chat room if the event is ongoing. If you try to join a room of an
event (which is not ongoing) and if you are not registered to this event,
you will be redirected to the registration page of the event.

We want to add a toast message to explain why the user was redirected to
this page.

Improve the other message to be coherent with the new ones.

Task-2283796