### PR TITLE
[FIX] website_event_meet: fix frontend related bugs

### DIFF
--- a/addons/website_event_meet/controllers/community.py
+++ b/addons/website_event_meet/controllers/community.py
@@ -148,7 +148,7 @@ class WebsiteEventMeetController(WebsiteEventCommunityController):
         return {
             # event information
             'event': event,
-            'main_object': event,
+            'main_object': meeting_room,
             'meeting_room': meeting_room,
             # sidebar
             'meeting_rooms_other': meeting_rooms_other,

--- a/addons/website_event_meet/models/event_event.py
+++ b/addons/website_event_meet/models/event_event.py
@@ -10,7 +10,6 @@ class Event(models.Model):
 
     meeting_room_ids = fields.One2many("event.meeting.room", "event_id", string="Meeting rooms")
     meeting_room_count = fields.Integer("Room count", compute="_compute_meeting_room_count")
-
     meeting_room_allow_creation = fields.Boolean(
         "Allow Room Creation", compute="_compute_meeting_room_allow_creation",
         readonly=False, store=True,
@@ -37,5 +36,7 @@ class Event(models.Model):
         for event in self:
             if event.event_type_id and event.event_type_id != event._origin.event_type_id:
                 event.meeting_room_allow_creation = event.event_type_id.meeting_room_allow_creation
+            elif event.community_menu and event.community_menu != event._origin.community_menu:
+                event.meeting_room_allow_creation = True
             elif not event.community_menu or not event.meeting_room_allow_creation:
                 event.meeting_room_allow_creation = False

--- a/addons/website_event_meet/static/src/js/website_event_create_meeting_room_button.js
+++ b/addons/website_event_meet/static/src/js/website_event_create_meeting_room_button.js
@@ -12,29 +12,45 @@ publicWidget.registry.websiteEventCreateMeetingRoom = publicWidget.Widget.extend
         'click': '_onClickCreate',
     },
 
-    start: async function () {
-        const langs = await this._rpc({
-            route: "/event/active_langs",
-        });
-
-        this.$createModal = $(QWeb.render(
-            'event_meet_create_room_modal',
-            {
-                csrf_token: odoo.csrf_token,
-                eventId: this.$el.data("eventId"),
-                defaultLangCode: this.$el.data("defaultLangCode"),
-                langs: langs,
-            }
-        ));
-        this.$createModal.appendTo(this.$el);
-    },
-
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
 
     _onClickCreate: async function () {
+        if (!this.$createModal) {
+            const langs = await this._rpc({
+                route: "/event/active_langs",
+            });
+
+            this.$createModal = $(QWeb.render(
+                'event_meet_create_room_modal',
+                {
+                    csrf_token: odoo.csrf_token,
+                    eventId: this.$el.data("eventId"),
+                    defaultLangCode: this.$el.data("defaultLangCode"),
+                    langs: langs,
+                }
+            ));
+
+            this.$createModal.appendTo(this.$el.parentNode);
+        }
+
         this.$createModal.modal('show');
+    },
+
+    //--------------------------------------------------------------------------
+    // Override
+    //--------------------------------------------------------------------------
+
+    /**
+     * Remove the create modal from the DOM, to avoid issue when editing the template
+     * with the website editor.
+     *
+     * @override
+     */
+    destroy: function () {
+        $('.o_wevent_create_meeting_room_modal').remove();
+        this._super.apply(this, arguments);
     },
 });
 

--- a/addons/website_event_meet/views/event_event_views.xml
+++ b/addons/website_event_meet/views/event_event_views.xml
@@ -11,6 +11,9 @@
                     <field name="meeting_room_count" string="Rooms" widget="statinfo"/>
                 </button>
             </xpath>
+            <xpath expr="//field[@name='community_menu']" position="after">
+                <field name="meeting_room_allow_creation" invisible="1"/>
+            </xpath>
         </field>
     </record>
 

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -53,15 +53,16 @@
         <h1 class="o_page_header mb-3">Launch a new topic</h1>
         <p>Want to create your own discussion room ?</p>
         <p>Be sure you are ready to spend at least 10 minutes in the room if you want to initiate a new topic.</p>
-        <button class="btn btn-primary o_wevent_create_room_button"
+        <a href="#" role="button"  class="btn btn-primary o_wevent_create_room_button"
             t-att-data-event-id="event.id"
-            t-att-data-default-lang-code="default_lang_code">Create a Room
-        </button>
+            t-att-data-default-lang-code="default_lang_code">
+            <span>Create a Room</span>
+        </a>
     </div>
 </template>
 
 <template id="meeting_room_card" name="Meeting Room Card">
-    <div class="modal o_join_later_modal" tabindex="-1" role="dialog" style="height: 400px; top:calc(50% - 200px);">
+    <div class="modal o_join_later_modal" t-attf-id="o_join_later_modal_#{meeting_room.id}" tabindex="-1" role="dialog" style="height: 400px; top:calc(50% - 200px);">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="mt-4 col-12 alert alert-warning text-center" role="alert">
@@ -106,7 +107,7 @@
         <!--Pre-event, if registered but event not stared yet-->
         <t t-set="meeting_room_href" t-value="'#'"/>
         <t t-set="meeting_room_data_toggle" t-value="'modal'"/>
-        <t t-set="meeting_room_data_target" t-value="'.o_join_later_modal'"/>
+        <t t-set="meeting_room_data_target" t-value="'#o_join_later_modal_%i' % meeting_room.id"/>
     </t>
 
     <a t-if="is_event_manager or not meeting_room.room_is_full"
@@ -119,28 +120,31 @@
         t-att-data-target="meeting_room_data_target">
         <div class="text-decoration-none w-100 h-100 p-3">
             <div class="o_wevent_meeting_room_corner_ribbon" t-if="meeting_room.room_is_full">Full</div>
-            <div t-if="is_event_manager" class="dropdown float-right dropleft">
-                <button class="btn py-0" data-toggle="dropdown"><h2>&#8942;</h2></button>
-                <div class="dropdown-menu">
-                    <div class="dropdown-item font-weight-bold disabled">Event Manager</div>
-                    <button class="dropdown-item btn btn-danger o_wevent_meeting_room_duplicate" type="button">Duplicate</button>
-                    <button class="dropdown-item btn btn-danger o_wevent_meeting_room_delete" type="button">Close</button>
-                </div>
-            </div>
-            <button t-if="is_event_manager" t-attf-class="o_wevent_meeting_room_is_pinned float-right btn #{'o_wevent_meeting_room_pinned' if meeting_room.is_pinned else ''}">
-                <i class="fa fa-thumb-tack"/>
-            </button>
             <div class="d-flex flex-column">
-                <h3 class="ml-0 mb-0" t-esc="meeting_room.name"/>
-                <span t-esc="meeting_room.summary" class="h5 text-muted mt-2"/>
-                <div class="d-flex flex-row justify-content-between align-items-center mt-2">
-                    <span class="h4 m-0 row">
-                        <b>&amp;#9900;&amp;nbsp;</b>
+                <div class="d-flex flex-row justify-content-between">
+                    <h4 class="text-break mw-75" t-esc="meeting_room.name"/>
+                    <div t-if="is_event_manager" class="w-25">
+                        <div class="dropdown float-right dropleft">
+                            <button class="btn py-0" data-toggle="dropdown"><h3 class="m-0">&#8942;</h3></button>
+                            <div class="dropdown-menu">
+                                <div class="dropdown-item font-weight-bold disabled">Room Manager</div>
+                                <button class="dropdown-item btn btn-danger o_wevent_meeting_room_duplicate" type="button">Duplicate</button>
+                                <button class="dropdown-item btn btn-danger o_wevent_meeting_room_delete" type="button">Close</button>
+                            </div>
+                        </div>
+                        <button t-attf-class="o_wevent_meeting_room_is_pinned float-right btn #{'o_wevent_meeting_room_pinned' if meeting_room.is_pinned else ''}">
+                            <i class="fa fa-thumb-tack"/>
+                        </button>
+                    </div>
+                </div>
+                <span t-esc="meeting_room.summary" class="h5 text-muted"/>
+                <div class="d-flex flex-row justify-content-between align-items-center">
+                    <span class="h6 m-0 row">
                         <span class="o_wevent_participant_count">
                             <t t-esc="meeting_room.room_participant_count"/>&amp;nbsp;</span>
                         <t t-esc="meeting_room.target_audience or 'participant(s)'"/>
                     </span>
-                    <div class="d-inline border p-2 bg-secondary" t-esc="meeting_room.room_lang_id.name"/>
+                    <div class="d-inline border py-1 px-2 bg-secondary" t-esc="meeting_room.room_lang_id.name"/>
                 </div>
             </div>
         </div>

--- a/addons/website_event_meet/views/event_meeting_room_views.xml
+++ b/addons/website_event_meet/views/event_meeting_room_views.xml
@@ -19,11 +19,11 @@
         <field name="model">event.meeting.room</field>
         <field name="arch" type="xml">
             <form string="Meeting Room">
-                <header>
-                    <button class="oe_highlight" name="action_join" string="Join the room" type="object"
-                        attrs="{'invisible': [('is_published', '=', False)]}"/>
-                </header>
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <field name="website_url" invisible="1"/>
+                        <field name="is_published" widget="website_redirect_button"/>
+                    </div>
                     <label for="name"/>
                     <h1>
                         <field name="name" placeholder="e.g. Finance"/>
@@ -33,7 +33,6 @@
                             <field name="event_id"/>
                             <field name="summary" placeholder="e.g. Let's talk about Corporate Finance"/>
                             <field name="target_audience" placeholder="e.g. CFOs &amp; Accountants"/>
-                            <field name="is_published"/>
                             <field name="is_pinned"/>
                         </group>
                         <group>


### PR DESCRIPTION
Purpose
=======
Set the "Allow Room Creation" to True by default, when the
community tab is visible.

Improve the meeting room card view and fixes some bugs.

Bug 1
=====
When we are on the meeting room page view, we can unpublish the record.
But, on this page it will unpublish the event instead of the meeting room.

Bug 2
=====
When editing the meeting rooms list view with the website editor (the
text of the create button), the editor will add 2 buttons...

Bug 3
=====
When the event is not ongoing, and if we are already registered to the event,
when we try to open a meeting room, a model will pop with the information of
the room. The popup will always display the information of the first room of
the list...

That's because we use the CSS class as selector instead of an unique id.

Task-2283742