### PR TITLE
[FIX] website_event_meet: fix "No Open Room" message

### DIFF
--- a/addons/website_event_meet/controllers/community.py
+++ b/addons/website_event_meet/controllers/community.py
@@ -54,6 +54,10 @@ class WebsiteEventMeetController(WebsiteEventCommunityController):
         meeting_rooms = request.env['event.meeting.room'].sudo().search(search_domain)
         meeting_rooms = meeting_rooms.sorted(self._sort_event_rooms, reverse=True)
 
+        is_event_manager = request.env.user.has_group("event.group_event_manager")
+        if not is_event_manager:
+            meeting_rooms = meeting_rooms.filtered(lambda m: not m.room_is_full)
+
         visitor = request.env['website.visitor']._get_visitor_from_request()
 
         return {
@@ -67,7 +71,7 @@ class WebsiteEventMeetController(WebsiteEventCommunityController):
             "default_lang_code": request.context.get('lang', request.env.user.lang),
             "default_username": visitor.display_name if visitor else None,
             # environment
-            "is_event_manager": request.env.user.has_group("event.group_event_manager"),
+            "is_event_manager": is_event_manager,
         }
 
     @http.route("/event/<model('event.event'):event>/meeting_room_create",

--- a/addons/website_event_track_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_track_exhibitor/views/event_exhibitor_templates_page.xml
@@ -140,7 +140,8 @@
                 <li t-foreach="sponsors_other" t-as="sponsor_other">
                     <a class="d-flex w-100 h-100 px-2 pt-2 pb-1 text-decoration-none"
                         t-att-href="sponsor_other.website_url">
-                        <img class="mr-2 o_wesponsor_aside_logo"
+                        <img t-if="sponsor_other.partner_id.country_id"
+                            class="mr-2 o_wesponsor_aside_logo"
                             t-att-src="website.image_url(sponsor_other.partner_id.country_id, 'image')"
                             t-att-alt="sponsor_other.partner_id.country_id.name"/>
                         <div class="flex-grow-1 overflow-auto">

--- a/addons/website_event_track_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_track_exhibitor/views/event_exhibitor_templates_page.xml
@@ -86,7 +86,7 @@
                 <span t-else="" t-field="sponsor.partner_id.image_512" class="o_wevent_online_page_avatar"
                     t-options="{'widget': 'image', 'class': 'rounded-circle', 'max-width': '96'}"/>
             </div>
-            <div class="px-3 pt-3 d-flex flex-row position-relative">
+            <div class="px-3 pt-3 d-flex flex-row justify-content-between position-relative">
                 <div class="d-flex flex-column">
                     <div class="d-flex align-items-center">
                         <span t-field="sponsor.name" class="h4 mb-0"/>
@@ -110,7 +110,7 @@
                 </div>
                 <a t-if="sponsor.partner_id.country_id"
                     t-att-href="'/event/%s/exhibitors?countries=%s' % (slug(sponsor.event_id), [sponsor.partner_id.country_id.id])"
-                    t-attf-class="flex-grow-1 text-right d-none d-md-block #{'mr-5' if sponsor.sponsor_type_id.display_ribbon_style and sponsor.sponsor_type_id.display_ribbon_style != 'no_ribbon' else ''}">
+                    t-attf-class="text-right d-none d-md-block #{'mr-5' if sponsor.sponsor_type_id.display_ribbon_style and sponsor.sponsor_type_id.display_ribbon_style != 'no_ribbon' else ''}">
                     <img class="img"
                         style="max-height: 36px;"
                         t-att-src="website.image_url(sponsor.partner_id.country_id, 'image')"

--- a/addons/website_event_track_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_track_exhibitor/views/event_exhibitor_templates_page.xml
@@ -83,7 +83,7 @@
             <div class="float-left pt-3">
                 <span t-if="sponsor.image_512" t-field="sponsor.image_512" class="o_wevent_online_page_avatar"
                     t-options="{'widget': 'image', 'class': 'rounded-circle', 'max-width': '96'}"/>
-                <span t-else="" t-field="sponsor.partner_id.image_512" class="o_wevent_online_page_avatar"
+                <span t-elif="sponsor.partner_id.image_512" t-field="sponsor.partner_id.image_512" class="o_wevent_online_page_avatar"
                     t-options="{'widget': 'image', 'class': 'rounded-circle', 'max-width': '96'}"/>
             </div>
             <div class="px-3 pt-3 d-flex flex-row justify-content-between position-relative">

--- a/addons/website_event_track_quiz/controllers/community.py
+++ b/addons/website_event_track_quiz/controllers/community.py
@@ -49,9 +49,10 @@ class WebsiteEventTrackQuizCommunityController(WebsiteEventCommunityController):
         position = 1
         for visitor_id, points in data_map.items():
             visitor = request.env['website.visitor'].sudo().browse(visitor_id)
-            if (searched_name and searched_name.lower() in visitor.name.lower()) or not searched_name:
+            if (searched_name and searched_name.lower() in visitor.display_name.lower()) or not searched_name:
                 leaderboard.append({'visitor': visitor, 'points': points, 'position': position})
             position = position + 1
+
         return {
             'top3_visitors': leaderboard[:3] if len(leaderboard) >= 3 else False,
             'visitors': leaderboard

--- a/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
+++ b/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
@@ -12,7 +12,7 @@
                     </div>
                 </div>
                 <table class="table table-sm">
-                    <tr t-foreach="visitors" t-as="visitor" class="o_wprofile_pointer bg-white">
+                    <tr t-foreach="visitors" t-as="visitor" class="bg-white">
                         <t t-call="website_event_track_quiz.all_visitor_card"/>
                     </tr>
                 </table>
@@ -52,7 +52,7 @@
 </template>
 
 <template id="top3_visitor_card" name="Top 3 Visitor Card">
-    <div class="card w-100 text-center mb-2 border-bottom-0 o_wprofile_pointer">
+    <div class="card w-100 text-center mb-2 border-bottom-0">
         <div class="card-body">
             <div class="d-inline-block position-relative">
                 <img class="rounded-circle img-fluid"


### PR DESCRIPTION
Bug
===
If no rooms are opened, a message "No Open Room" will be displayed.

In the case where we are a standard visitor (not event manager) and if
some room are opened, but they are all full, no room will be displayed
but the message "No Open Room" will not be visible.

In that case, we also want to display the message "No Open Room".

(Those room are filtered in QWeb, but if we clean the variable `meeting_rooms`
passed to the template, it will display the message when needed).

Task-2283742