### PR TITLE
[FIX] website: properly display the dropzone and its preview of snippets

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -210,18 +210,12 @@ var Wysiwyg = Widget.extend({
         const emptyClass = "oe_blank_wrap";
         const targetNode = this.editorEditable.querySelector("#wrap");
         if (this.options.enableWebsite && targetNode) {
-            let mutationCallback = function () {
-                if (targetNode.textContent.trim() === '' && !targetNode.querySelector('section, div')) {
-                    targetNode.setAttribute('data-editor-message', _t('DRAG BUILDING BLOCKS HERE'));
-                    targetNode.classList.add(emptyClass);
-                } else {
-                    targetNode.classList.remove(emptyClass);
-                }
-            };
-            const observer = new MutationObserver(mutationCallback);
-            observer.observe(targetNode, {childList: true});
-            // force check at editor startup
-            mutationCallback();
+            if (targetNode.textContent.trim() === '' && !targetNode.querySelector('section, div')) {
+                targetNode.setAttribute('data-editor-message', _t('DRAG BUILDING BLOCKS HERE'));
+                targetNode.classList.add(emptyClass);
+            } else {
+                targetNode.classList.remove(emptyClass);
+            }
         }
 
         if (this.options.enableTranslation) {

--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -40,7 +40,7 @@ $-editor-messages-margin-x: 2%;
     }
 
     &.oe_structure.oe_empty, &[data-oe-type=html], .oe_structure.oe_empty {
-        &:empty, &.oe_blank_wrap {
+        &#wrap:empty, &#wrap > .oe_drop_zone.oe_insert:not(.oe_vertical):only-child {
             @extend %o-editor-messages;
             padding: 112px 0px;
         }


### PR DESCRIPTION
This is essentially a revert of some changes that don't seem necessary anymore, but prevented the proper rendering of the preview of snippets on drag over the dropzone.