### PR TITLE
[IMP] wowl: implement sequence ordering in systray items

### DIFF
--- a/addons/wowl/doc/systray.md
+++ b/addons/wowl/doc/systray.md
@@ -15,8 +15,9 @@ A systray item is an object with the following properties:
   usually prefixed by the current module name)
 - `Component`: the Component class that will be used to display the item. Its root
   node has to be a `<li>` tag!
-- `sequence (number, optional)`: if given, this number will be used to order the
-  items.
+- sequence (number, optional): defaults to 50. If given, this number will be used
+  to order the items. The lowest sequence is on the right and the highest sequence
+  is on the left in the systray menu.
 
 Warning: the root node need to be a `<li>` tag. Otherwise, the systray item will
 not be styled properly.

--- a/addons/wowl/static/src/components/navbar/navbar.ts
+++ b/addons/wowl/static/src/components/navbar/navbar.ts
@@ -8,10 +8,18 @@ export class NavBar extends Component<{}, OdooEnv> {
   menuRepo = useService("menus");
   state = useState({ showDropdownMenu: false });
 
-  systrayItems = this.env.registries.systray.getAll();
+  systrayItems = this._getSystrayItems();
 
   toggleDropdownMenu() {
     this.state.showDropdownMenu = !this.state.showDropdownMenu;
+  }
+
+  _getSystrayItems() {
+    return this.env.registries.systray.getAll().sort((x, y) => {
+      const xSeq = x.sequence ?? 50;
+      const ySeq = y.sequence ?? 50;
+      return ySeq - xSeq;
+    });
   }
 
   _onMenuClicked(menu: any) {

--- a/addons/wowl/static/src/components/user_menu/user_menu.ts
+++ b/addons/wowl/static/src/components/user_menu/user_menu.ts
@@ -10,4 +10,5 @@ export class UserMenu extends Component<{}, OdooEnv> {
 export const userMenuItem: SystrayItem = {
   name: "wowl.user_menu",
   Component: UserMenu,
+  sequence: 0,
 };

--- a/addons/wowl/static/tests/components/navbar_tests.ts
+++ b/addons/wowl/static/tests/components/navbar_tests.ts
@@ -76,3 +76,39 @@ QUnit.test("navbar can display systray items", async (assert) => {
 
   assert.containsOnce(target, "li.my-item");
 });
+
+QUnit.test("navbar can display systray items ordered based on their sequence", async (assert) => {
+  class MyItem1 extends Component {
+    static template = xml`<li class="my-item-1">my item 1</li>`;
+  }
+  class MyItem2 extends Component {
+    static template = xml`<li class="my-item-2">my item 2</li>`;
+  }
+  class MyItem3 extends Component {
+    static template = xml`<li class="my-item-3">my item 3</li>`;
+  }
+
+  const item1 = {
+    name: "addon.myitem1",
+    Component: MyItem1,
+    sequence: 0,
+  };
+  const item2 = {
+    name: "addon.myitem2",
+    Component: MyItem2,
+  };
+  const item3 = {
+    name: "addon.myitem3",
+    Component: MyItem3,
+    sequence: 100,
+  };
+  env.registries.systray.add(item2.name, item2);
+  env.registries.systray.add(item1.name, item1);
+  env.registries.systray.add(item3.name, item3);
+
+  await mount(NavBar, { env, target });
+  const menuSystray = target.getElementsByClassName("o_menu_systray")[0] as HTMLElement;
+
+  assert.containsN(menuSystray, "li", 3, "tree systray items should be displayed");
+  assert.strictEqual(menuSystray.innerText, "my item 3\nmy item 2\nmy item 1");
+});


### PR DESCRIPTION
Orders the systray based on their sequence in the navbar.
Adds one test to check the order.

Task-2357801