### PR TITLE
[IMP] wowl: add loading indicator + loading overlay

### DIFF
--- a/addons/wowl/__manifest__.py
+++ b/addons/wowl/__manifest__.py
@@ -27,5 +27,6 @@ Odoo Web core module written in Owl.
         'static/src/utils',
         'static/src/components',
         'static/src/views',
+        'static/src/services',
     ]
 }

--- a/addons/wowl/static/src/components/loading_indicator/loading_indicator.scss
+++ b/addons/wowl/static/src/components/loading_indicator/loading_indicator.scss
@@ -1,0 +1,13 @@
+.o_loading {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  z-index: $zindex-modal + 1;
+  background-color: $o-brand-odoo;
+  color: white;
+  padding: 4px;
+
+  &.hide {
+    visibility: hidden;
+  }
+}

--- a/addons/wowl/static/src/components/loading_indicator/loading_indicator.ts
+++ b/addons/wowl/static/src/components/loading_indicator/loading_indicator.ts
@@ -1,0 +1,37 @@
+import { Component, useState } from "@odoo/owl";
+import type { OdooEnv } from "../../types";
+
+export class LoadingIndicator extends Component<{}, OdooEnv> {
+  static template = "wowl.LoadingIndicator";
+  state = useState({
+    count: 0,
+    isShown: false,
+  });
+  rpcIds = new Set();
+  blockUITimer?: number;
+
+  constructor() {
+    super(...arguments);
+    this.env.bus.on("RPC:REQUEST", this, this.requestCall);
+    this.env.bus.on("RPC:RESPONSE", this, this.responseCall);
+  }
+
+  requestCall(rpcId: number) {
+    if (this.state.count === 0) {
+      this.state.isShown = true;
+      this.blockUITimer = this.env.browser.setTimeout(this.env.services.ui.block, 3000);
+    }
+    this.rpcIds.add(rpcId);
+    this.state.count++;
+  }
+
+  responseCall(rpcId: number) {
+    this.rpcIds.delete(rpcId);
+    this.state.count = this.rpcIds.size;
+    if (this.state.count === 0) {
+      clearTimeout(this.blockUITimer);
+      this.env.services.ui.unblock();
+      this.state.isShown = false;
+    }
+  }
+}

--- a/addons/wowl/static/src/components/loading_indicator/loading_indicator.xml
+++ b/addons/wowl/static/src/components/loading_indicator/loading_indicator.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <div t-name="wowl.LoadingIndicator" t-att-class="state.isShown ? 'o_loading' : ''" owl="1">
+        <t t-if="state.isShown">
+            Loading (<t t-esc="state.count"/>)
+        </t>
+    </div>
+
+</templates>

--- a/addons/wowl/static/src/registries.ts
+++ b/addons/wowl/static/src/registries.ts
@@ -1,4 +1,5 @@
 import { Component } from "@odoo/owl";
+import { LoadingIndicator } from "./components/loading_indicator/loading_indicator";
 import { userMenuItem } from "./components/user_menu/user_menu";
 import { Registry } from "./core/registry";
 import { actionManagerService } from "./services/action_manager/action_manager";
@@ -8,6 +9,7 @@ import { modelService } from "./services/model";
 import { notificationService } from "./services/notifications";
 import { routerService } from "./services/router";
 import { rpcService } from "./services/rpc";
+import { uiService } from "./services/ui/ui";
 import { userService } from "./services/user";
 import { viewManagerService } from "./services/view_manager";
 import { ComponentAction, FunctionAction, Service, SystrayItem, Type, View } from "./types";
@@ -34,6 +36,7 @@ const services = [
   notificationService,
   routerService,
   rpcService,
+  uiService,
   userService,
   viewManagerService,
 ];
@@ -49,6 +52,8 @@ for (let service of services) {
 // Components registered in this registry will be rendered inside the root node
 // of the webclient.
 export const mainComponentRegistry: Registry<Type<Component>> = new Registry();
+
+mainComponentRegistry.add("LoadingIndicator", LoadingIndicator);
 
 // -----------------------------------------------------------------------------
 // Client Actions

--- a/addons/wowl/static/src/services/ui/ui.scss
+++ b/addons/wowl/static/src/services/ui/ui.scss
@@ -1,0 +1,31 @@
+.o_blockUI {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1100;
+
+  cursor: wait;
+  background: #000000;
+  opacity: 0.6;
+  height: 100vh;
+  width: 100vw;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  .o_spinner {
+    height: 4.2rem;
+    margin-bottom: 1rem;
+
+    img {
+      animation: fa-spin 1s infinite steps(12);
+    }
+  }
+
+  .o_message {
+    color: #ffffff;
+    text-align: center;
+  }
+}

--- a/addons/wowl/static/src/services/ui/ui.ts
+++ b/addons/wowl/static/src/services/ui/ui.ts
@@ -1,0 +1,108 @@
+import { Component, core, tags, useState } from "@odoo/owl";
+import type { OdooEnv, Service } from "../../types";
+
+const { EventBus } = core;
+
+export interface UIService {
+  block: () => void;
+  unblock: () => void;
+}
+
+class BlockUI extends Component<{}, OdooEnv> {
+  static template = tags.xml`
+    <div t-att-class="state.blockUI ? 'o_blockUI' : ''">
+      <t t-if="state.blockUI">
+        <div class="o_spinner">
+            <img src="/wowl/static/img/spin.png" alt="Loading..."/>
+        </div>
+        <div class="o_message">
+            <t t-raw="state.line1"/> <br/>
+            <t t-raw="state.line2"/>
+        </div>
+      </t>
+    </div>`;
+  messagesByDuration = [
+    { time: 20, l1: this.env._t("Loading...") },
+    { time: 40, l1: this.env._t("Still loading...") },
+    { time: 60, l1: this.env._t("Still loading..."), l2: this.env._t("Please be patient.") },
+    { time: 180, l1: this.env._t("Don't leave yet,"), l2: this.env._t("it's still loading...") },
+    {
+      time: 120,
+      l1: this.env._t("You may not believe it,"),
+      l2: this.env._t("but the application is actually loading..."),
+    },
+    {
+      time: 3180,
+      l1: this.env._t("Take a minute to get a coffee,"),
+      l2: this.env._t("because it's loading..."),
+    },
+    {
+      time: null,
+      l1: this.env._t("Maybe you should consider reloading the application by pressing F5..."),
+    },
+  ];
+  state = useState({
+    blockUI: false,
+    line1: "",
+    line2: "",
+    count: 0,
+  });
+  msgTimer?: number;
+
+  replaceMessage(index: number) {
+    const message = this.messagesByDuration[index];
+    this.state.line1 = message.l1;
+    this.state.line2 = message.l2 || "";
+    if (message.time !== null) {
+      this.msgTimer = this.env.browser.setTimeout(() => {
+        this.replaceMessage(index + 1);
+      }, message.time * 1000);
+    }
+  }
+
+  block() {
+    if (this.state.count === 0) {
+      this.state.blockUI = true;
+      this.replaceMessage(0);
+    }
+    this.state.count++;
+  }
+
+  unblock() {
+    if (this.state.count > 0) {
+      this.state.count--;
+    }
+    if (this.state.count === 0) {
+      this.state.blockUI = false;
+      clearTimeout(this.msgTimer);
+      this.state.line1 = "";
+      this.state.line2 = "";
+    }
+  }
+}
+
+export const uiService: Service<UIService> = {
+  name: "ui",
+  deploy(env: OdooEnv): UIService {
+    const bus = new EventBus();
+
+    class ReactiveBlockUI extends BlockUI {
+      constructor() {
+        super(...arguments);
+        bus.on("BLOCK", this, this.block);
+        bus.on("UNBLOCK", this, this.unblock);
+      }
+    }
+    env.registries.Components.add("BlockUI", ReactiveBlockUI);
+
+    function block(): void {
+      bus.trigger("BLOCK");
+    }
+
+    function unblock(): void {
+      bus.trigger("UNBLOCK");
+    }
+
+    return { block, unblock };
+  },
+};

--- a/addons/wowl/static/tests/components/loading_indicator_tests.ts
+++ b/addons/wowl/static/tests/components/loading_indicator_tests.ts
@@ -1,0 +1,109 @@
+import * as QUnit from "qunit";
+import { LoadingIndicator } from "../../src/components/loading_indicator/loading_indicator";
+import { uiService } from "../../src/services/ui/ui";
+import { OdooEnv, Service } from "../../src/types";
+import { Registry } from "../../src/core/registry";
+import { getFixture, makeTestEnv, mount, nextTick } from "../helpers/index";
+import { TestConfig } from "../helpers/utility";
+
+let target: HTMLElement;
+let services: Registry<Service>;
+let browser: Partial<OdooEnv["browser"]>;
+
+let baseConfig: TestConfig;
+
+QUnit.module("LoadingIndicator", {
+  async beforeEach() {
+    target = getFixture();
+    services = new Registry<Service>();
+    services.add(uiService.name, uiService);
+    browser = { setTimeout: () => 1 };
+
+    baseConfig = { services, browser };
+  },
+});
+
+QUnit.test("displays the loading indicator for one rpc", async (assert) => {
+  const env = await makeTestEnv({ ...baseConfig });
+  await mount(LoadingIndicator, { env, target });
+
+  let loadingIndicator = target.querySelector(".o_loading");
+  assert.strictEqual(loadingIndicator, null, "the loading indicator should not be displayed");
+
+  env.bus.trigger("RPC:REQUEST", 1);
+  await nextTick();
+  loadingIndicator = target.querySelector(".o_loading");
+  assert.notStrictEqual(loadingIndicator, null, "the loading indicator should be displayed");
+  assert.strictEqual(
+    loadingIndicator!.textContent,
+    " Loading (1) ",
+    "the loading indicator should indicate 1 request in progress"
+  );
+
+  env.bus.trigger("RPC:RESPONSE", 1);
+  await nextTick();
+  loadingIndicator = target.querySelector(".o_loading");
+  assert.strictEqual(loadingIndicator, null, "the loading indicator should not be displayed");
+});
+
+QUnit.test("displays the loading indicator for multi rpc", async (assert) => {
+  const env = await makeTestEnv({ ...baseConfig });
+  await mount(LoadingIndicator, { env, target });
+
+  let loadingIndicator = target.querySelector(".o_loading");
+  assert.strictEqual(loadingIndicator, null, "the loading indicator should not be displayed");
+
+  env.bus.trigger("RPC:REQUEST", 1);
+  env.bus.trigger("RPC:REQUEST", 2);
+  await nextTick();
+
+  loadingIndicator = target.querySelector(".o_loading");
+  assert.notStrictEqual(loadingIndicator, null, "the loading indicator should be displayed");
+  assert.strictEqual(
+    loadingIndicator!.textContent,
+    " Loading (2) ",
+    "the loading indicator should indicate 2 requests in progress."
+  );
+
+  env.bus.trigger("RPC:REQUEST", 3);
+  await nextTick();
+  loadingIndicator = target.querySelector(".o_loading");
+  assert.strictEqual(
+    loadingIndicator!.textContent,
+    " Loading (3) ",
+    "the loading indicator should indicate 3 requests in progress."
+  );
+
+  env.bus.trigger("RPC:RESPONSE", 1);
+  await nextTick();
+  loadingIndicator = target.querySelector(".o_loading");
+  assert.strictEqual(
+    loadingIndicator!.textContent,
+    " Loading (2) ",
+    "the loading indicator should indicate 2 requests in progress."
+  );
+
+  env.bus.trigger("RPC:REQUEST", 4);
+  await nextTick();
+  loadingIndicator = target.querySelector(".o_loading");
+  assert.strictEqual(
+    loadingIndicator!.textContent,
+    " Loading (3) ",
+    "the loading indicator should indicate 3 requests in progress."
+  );
+
+  env.bus.trigger("RPC:RESPONSE", 2);
+  env.bus.trigger("RPC:RESPONSE", 3);
+  await nextTick();
+  loadingIndicator = target.querySelector(".o_loading");
+  assert.strictEqual(
+    loadingIndicator!.textContent,
+    " Loading (1) ",
+    "the loading indicator should indicate 1 request in progress."
+  );
+
+  env.bus.trigger("RPC:RESPONSE", 4);
+  await nextTick();
+  loadingIndicator = target.querySelector(".o_loading");
+  assert.strictEqual(loadingIndicator, null, "the loading indicator should not be displayed");
+});

--- a/addons/wowl/static/tests/main.ts
+++ b/addons/wowl/static/tests/main.ts
@@ -12,6 +12,8 @@ import "./services/notifications_tests";
 import "./services/router_tests";
 import "./services/rpc_tests";
 import "./services/services_tests";
+import "./services/ui_tests";
+import "./components/loading_indicator_tests";
 import "./components/webclient_tests";
 import "./components/web_client_integrated_tests";
 import "./components/user_menu_tests";

--- a/addons/wowl/static/tests/services/ui_tests.ts
+++ b/addons/wowl/static/tests/services/ui_tests.ts
@@ -1,0 +1,65 @@
+import * as QUnit from "qunit";
+import { uiService } from "../../src/services/ui/ui";
+import { OdooEnv, Service } from "../../src/types";
+import { Registry } from "../../src/core/registry";
+import { getFixture, makeTestEnv, mount, nextTick } from "../helpers/index";
+import { TestConfig } from "../helpers/utility";
+
+let target: HTMLElement;
+let services: Registry<Service>;
+let browser: Partial<OdooEnv["browser"]>;
+let baseConfig: TestConfig;
+
+QUnit.module("UI", {
+  async beforeEach() {
+    target = getFixture();
+    services = new Registry<Service>();
+    services.add(uiService.name, uiService);
+    browser = { setTimeout: () => 1 };
+    baseConfig = { services, browser };
+  },
+});
+
+QUnit.test("block and unblock once ui with ui service", async (assert) => {
+  const env = await makeTestEnv({ ...baseConfig });
+  const ui = env.services.ui;
+  await mount(env.registries.Components.get("BlockUI"), { env, target });
+  let blockUI = target.querySelector(".o_blockUI");
+  assert.strictEqual(blockUI, null, "ui should not be blocked");
+
+  ui.block();
+  await nextTick();
+  blockUI = target.querySelector(".o_blockUI");
+  assert.notStrictEqual(blockUI, null, "ui should be blocked");
+
+  ui.unblock();
+  await nextTick();
+  blockUI = target.querySelector(".o_blockUI");
+  assert.strictEqual(blockUI, null, "ui should not be blocked");
+});
+
+QUnit.test("use block and unblock several times to block ui with ui service", async (assert) => {
+  const env = await makeTestEnv({ ...baseConfig });
+  const ui = env.services.ui;
+  await mount(env.registries.Components.get("BlockUI"), { env, target });
+  let blockUI = target.querySelector(".o_blockUI");
+  assert.strictEqual(blockUI, null, "ui should not be blocked");
+
+  ui.block();
+  ui.block();
+  ui.block();
+  await nextTick();
+  blockUI = target.querySelector(".o_blockUI");
+  assert.notStrictEqual(blockUI, null, "ui should be blocked");
+
+  ui.unblock();
+  ui.unblock();
+  await nextTick();
+  blockUI = target.querySelector(".o_blockUI");
+  assert.notStrictEqual(blockUI, null, "ui should be blocked");
+
+  ui.unblock();
+  await nextTick();
+  blockUI = target.querySelector(".o_blockUI");
+  assert.strictEqual(blockUI, null, "ui should not be blocked");
+});


### PR DESCRIPTION
Added component LoadingIndicator. LoadingIndicator displays a small rectangle at the bottom right with the number of current RPC requests. The rectangle is displayed if there is at least one current RPC request.
Adds the LoadingOverrlay component, which displays a loading screen that will block the UI.

Task-2358626