### PR TITLE
FIX/IMP: protect keys in router state

### DIFF
--- a/addons/wowl/static/src/demo_data.ts
+++ b/addons/wowl/static/src/demo_data.ts
@@ -1,10 +1,18 @@
 import { Component, tags } from "@odoo/owl";
 import { actionRegistry } from "./registries";
 import { OdooEnv } from "./types";
+import { useService } from "./core/hooks";
 
 // Demo code
 class HelloAction extends Component<{}, OdooEnv> {
-  static template = tags.xml`<div>Discuss ClientAction</div>`;
+  static template = tags.xml`<div>
+      Discuss ClientAction
+      <button t-on-click="_pushState">Push Stuff in URL</button>
+    </div>`;
+  router = useService("router");
+  _pushState() {
+    this.router.pushState({ stuff: "inurl" });
+  }
 }
 actionRegistry.add("mail.widgets.discuss", HelloAction);
 // actionRegistry.add("mail.widgets.discuss", () => console.log("I'm a function client action"));

--- a/addons/wowl/static/src/services/menus.ts
+++ b/addons/wowl/static/src/services/menus.ts
@@ -75,9 +75,6 @@ function makeMenus(env: OdooEnv, menusData: MenuData): MenuService {
       if (menu && menu.appID !== currentAppId) {
         currentAppId = menu.appID;
         env.bus.trigger("MENUS:APP-CHANGED");
-        env.services.router.pushState({
-          menu_id: `${menu.appID}`,
-        });
       }
     },
   };
@@ -85,7 +82,7 @@ function makeMenus(env: OdooEnv, menusData: MenuData): MenuService {
 
 export const menusService: Service<MenuService> = {
   name: "menus",
-  dependencies: ["action_manager", "router"],
+  dependencies: ["action_manager"],
   async deploy(env: OdooEnv, config): Promise<MenuService> {
     const { odoo } = config;
     const cacheHashes = odoo.session_info.cache_hashes;

--- a/addons/wowl/static/src/services/user.ts
+++ b/addons/wowl/static/src/services/user.ts
@@ -60,6 +60,7 @@ export const userService: Service<UserService> = {
       userName: username,
       isAdmin: is_admin,
       partnerId: partner_id,
+      // LPE FIXME: allowed_companies should be retrievec from url if present, otherwise should be current company
       allowed_companies: user_companies.allowed_companies,
       current_company: user_companies.current_company,
       get lang() {

--- a/addons/wowl/static/tests/helpers/mocks.ts
+++ b/addons/wowl/static/tests/helpers/mocks.ts
@@ -192,7 +192,7 @@ export function makeMockFetch(mockRPC: MockRPC): typeof fetch {
 }
 
 interface FakeRouterParams {
-  onPushState?: (...args: any[]) => any;
+  onPushState?: (mode: "push" | "replace", newState: Route["hash"]) => any;
   initialRoute?: Partial<Route>;
 }
 
@@ -234,9 +234,9 @@ export function makeFakeRouterService(params?: FakeRouterParams): Service<Router
         return current;
       }
 
-      function doPush(route: Route) {
+      function doPush(mode: "push" | "replace" = "push", route: Route) {
         if (params && params.onPushState) {
-          params.onPushState(route.hash);
+          params.onPushState(mode, route.hash);
         }
         current = getRoute(route);
       }
@@ -244,7 +244,8 @@ export function makeFakeRouterService(params?: FakeRouterParams): Service<Router
         get current(): Route {
           return getCurrent();
         },
-        pushState: makePushState(env, getCurrent, doPush),
+        pushState: makePushState(env, getCurrent, doPush.bind(null, "push")),
+        replaceState: makePushState(env, getCurrent, doPush.bind(null, "replace")),
       };
     },
   };


### PR DESCRIPTION
Hash keys that are pushed by actions should be replaced every time.
Hash keys that are pushed by other objects may want to stay there even if we order the hash to be replaced
In particular: menu_id and cids