### PR TITLE
[FIX] ensure correct state of history and its ui on start website

### DIFF
--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -3,8 +3,8 @@
 <template id="snippets" groups="base.group_user">
     <div class="o_we_website_top_actions">
         <div class="o_we_external_history_buttons">
-            <button type="button" data-action="undo" class="btn btn-secondary fa fa-undo"/>
-            <button type="button" data-action="redo" class="btn btn-secondary fa fa-repeat"/>
+            <button type="button" data-action="undo" class="btn btn-secondary fa fa-undo" disabled="true"/>
+            <button type="button" data-action="redo" class="btn btn-secondary fa fa-repeat" disabled="true"/>
         </div>
         <form class="ml-auto">
             <button type="button" class="btn btn-secondary" name="mobile" data-action="mobilePreview"><i class="fa fa-mobile"></i></button>

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -210,7 +210,6 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
 
         await this._createWysiwyg();
 
-        this._addEditorMessages();
         var res = await new Promise(function (resolve, reject) {
             self.trigger_up('widgets_start_request', {
                 editableMode: true,
@@ -265,6 +264,7 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         $('#wrapwrap *').each((key, el) => {delete el.ouid});
         $(this.savableSelector).not('[data-oe-readonly]').attr('contenteditable', 'true');
         this.wysiwyg.odooEditor.idSet($('#wrapwrap')[0]);
+        this._addEditorMessages(); // Insert editor messages in the DOM without observing.
         this.wysiwyg.odooEditor.observerActive();
 
         // Observe changes to mark dirty structures and fields.


### PR DESCRIPTION
1. The history buttons' `disabled` attributes are updated when the history is updated. That means that before any update is made to the history, they should be disabled. Their XML template was adapted to reflect that.
2. It was possible to undo adding the "editor message" ("DRAG BUILDING BLOCKS HERE"), which is not part of the edition. Add that message should not be observed by the editor as it is part of the initialization of the UI. That code was therefore moved so as not to be observed.