### PR TITLE
[FIX] web_editor: constrain link edition to avoid edition bug

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -196,12 +196,12 @@ const LinkTools = Widget.extend({
         if (link && (!$link.has(range.startContainer).length || !$link.has(range.endContainer).length)) {
             // Expand the current link to include the whole selection.
             let before = link.previousSibling;
-            while (range.intersectsNode(before)) {
+            while (before !== null && range.intersectsNode(before)) {
                 link.insertBefore(before, link.firstChild);
                 before = link.previousSibling;
             }
             let after = link.nextSibling;
-            while (range.intersectsNode(after)) {
+            while (after !== null && range.intersectsNode(after)) {
                 link.appendChild(after);
                 after = link.nextSibling;
             }


### PR DESCRIPTION
bug report : ux: editing a link fully selected has a strange behavior https://drive.google.com/file/d/1KjwRNg2gc3VlBbD4JCiZumUFeyGjtALg/view

Solution inspired from summernote : when clicking on a `<a>` we make it content `editable=true` and temporary remove the `contenteditable` from the main editor container.