### PR TITLE
[FIX wowl: ]Handle Error in dialogManager to avoid error loops

### DIFF
--- a/addons/wowl/static/src/services/dialog_manager.js
+++ b/addons/wowl/static/src/services/dialog_manager.js
@@ -4,6 +4,14 @@ const { Component, core, tags, hooks } = owl;
 const { EventBus } = core;
 const { useState } = hooks;
 
+class ErrorHandler extends Component {
+    catchError(error) {
+      this.props.callback();
+      throw error;
+  }
+}
+ErrorHandler.template = tags.xml`<t t-component="props.dialog.class" t-props="props.dialog.props" />`;
+
 class DialogManager extends Component {
   constructor() {
     super(...arguments);
@@ -21,13 +29,22 @@ class DialogManager extends Component {
   }
 
   onDialogClosed(id) {
+    this._doCloseDialog(id);
+  }
+
+  _doCloseDialog(id) {
     delete this.dialogs[id];
   }
+
+  _errorCallBack(id) {
+    return () => this._doCloseDialog(id);
+  }
 }
+DialogManager.components = { ErrorHandler };
 DialogManager.template = tags.xml`
     <div class="o_dialog_manager">
       <t t-foreach="Object.values(dialogs)" t-as="dialog" t-key="dialog.id">
-        <t t-component="dialog.class" t-props="dialog.props" t-on-dialog-closed="onDialogClosed(dialog.id)"/>
+        <ErrorHandler dialog="dialog" t-on-dialog-closed="onDialogClosed(dialog.id)" callback="_errorCallBack(dialog.id)" />
       </t>
     </div>
     `;

--- a/addons/wowl/static/tests/helpers/legacy.js
+++ b/addons/wowl/static/tests/helpers/legacy.js
@@ -17,6 +17,8 @@ odoo.define("wowl.test_legacy", async (require) => {
       legacyViewRegistry: require("web.view_registry"),
       FormView: require("web.FormView"),
     });
+    const CrashManager = require('web.CrashManager');
+    CrashManager.disable();
     resolve(legacyExports);
   });
   function getLegacy() {


### PR DESCRIPTION
Try to open a dialog that fails for a programming error
The crash manager catches the error on top of every component
and opens a dialog
The dialog manager re-renders, but the original dialog that failed is still registered
==>> error loop!

This commit fixes that by closing the faulty dialog if it catches an error