### PR TITLE
[IMP] notes: open links in new window checked by default

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -74,6 +74,7 @@ var LinkDialog = Dialog.extend({
             const endLink = $(this.data.range.endContainer).closest('a')[0];
             const isLink = startLink && (startLink === endLink);
             this.data.url = $link.attr('href') || '';
+            this.data.isNewWindow = isLink ? $link.attr('target') === '_blank' : this.data.isNewWindow;
             this.data.text = (isLink ? startLink.textContent : this.data.range.toString())
                 .replace(/[ \t\r\n]+/g, ' ');
         } else {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -515,7 +515,7 @@ const Wysiwyg = Widget.extend({
                 this.linkTools.appendTo(this.toolbar.$el);
             }
         } else {
-            const linkDialog = new weWidgets.LinkDialog(this, {}, this.$editable[0]);
+            const linkDialog = new weWidgets.LinkDialog(this, {}, this.$editable[0], { isNewWindow: true });
             linkDialog.open();
             linkDialog.on('save', this, (linkInfo) => {
                 const linkUrl = linkInfo.url;


### PR DESCRIPTION
Change request from new editor test session : 

[SBU] Create a link, open in a new tab should be activate by default: https://tinyurl.com/yagda77l (are you sure that's the case now? or is that a new feature request?) => yes, new feature