### PR TITLE
[FIX] pos_restaurant: select default orderline

### DIFF
--- a/addons/point_of_sale/static/src/js/PointOfSaleModel.js
+++ b/addons/point_of_sale/static/src/js/PointOfSaleModel.js
@@ -1777,7 +1777,7 @@ odoo.define('point_of_sale.PointOfSaleModel', function (require) {
                 } else {
                     mergeWith.qty += line.qty;
                 }
-                order._extras.activeOrderlineId = mergeWith.id;
+                this.actionSelectOrderline(order, mergeWith.id)
                 return mergeWith;
             } else {
                 if (product.tracking === 'serial' || product.tracking === 'lot') {
@@ -1788,12 +1788,12 @@ odoo.define('point_of_sale.PointOfSaleModel', function (require) {
                     }
                 }
                 order.lines.push(line.id);
-                order._extras.activeOrderlineId = line.id;
+                this.actionSelectOrderline(order, line.id);
                 return line;
             }
         }
-        actionSelectOrderline(order, orderline) {
-            order._extras.activeOrderlineId = orderline.id;
+        actionSelectOrderline(order, lineID) {
+            order._extras.activeOrderlineId = lineID;
         }
         actionUpdateOrderline(orderline, vals) {
             if ('price_unit' in vals) {
@@ -1812,9 +1812,9 @@ odoo.define('point_of_sale.PointOfSaleModel', function (require) {
             if (order.lines.length) {
                 // set as active the orderline with the same index as the deleted
                 if (indexOfDeleted === order.lines.length) {
-                    order._extras.activeOrderlineId = order.lines[order.lines.length - 1];
+                    this.actionSelectOrderline(order, order.lines[order.lines.length - 1]);
                 } else {
-                    order._extras.activeOrderlineId = order.lines[indexOfDeleted];
+                    this.actionSelectOrderline(order, order.lines[indexOfDeleted]);
                 }
             }
         }
@@ -1840,7 +1840,7 @@ odoo.define('point_of_sale.PointOfSaleModel', function (require) {
                     id: this._getNextId(),
                 });
                 order.lines.push(newLine.id);
-                this.actionSelectOrderline(order, newLine);
+                this.actionSelectOrderline(order, newLine.id);
             }
         }
         /**

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -186,7 +186,7 @@ odoo.define('point_of_sale.ProductScreen', function (require) {
         }
         onSelectOrderline({ detail: orderline }) {
             this.state.numpadMode = 'quantity';
-            this.env.actionHandler({ name: 'actionSelectOrderline', args: [this.props.activeOrder, orderline] });
+            this.env.actionHandler({ name: 'actionSelectOrderline', args: [this.props.activeOrder, orderline.id] });
             NumberBuffer.reset();
         }
         async _onSearchTermChange([searchTerm, key]) {

--- a/addons/pos_restaurant/static/src/js/PointOfSaleModel.js
+++ b/addons/pos_restaurant/static/src/js/PointOfSaleModel.js
@@ -100,14 +100,14 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
                     await this._syncToServer(activeTable);
                     await this._syncFromServer(orderTable);
                 }
-                if (!activeTable) {
-                    await this._syncFromServer(orderTable);
-                }
                 if (!this.data.uiState.OrderManagementScreen.managementOrderIds.has(order.id) && order.table_id) {
                     const table = this.getRecord('restaurant.table', order.table_id);
                     this.data.uiState.activeTableId = order.table_id;
                     this.data.uiState.activeFloorId = table.floor_id;
                 }
+
+                if(order.lines)
+                    this.actionSelectOrderline(order, order.lines[order.lines.length - 1]);
             }
         },
         actionUpdateOrderline(orderline, vals) {


### PR DESCRIPTION
When in pos_restaurant, the extra attributes for selected line was not loaded because of the server sync.
When loading a table, we set the last line of the order as the selected line.

We also do a better management of order lines selections.