### PR TITLE
fix order syncing considering order selection from different actions

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -38,6 +38,9 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
                 this.env.actionHandler({ name: 'actionDeleteOrder', args: [order] });
             }
         }
+        async onClickDiscard() {
+            await this.env.actionHandler({ name: 'actionToggleScreen', args: ['TicketScreen'] });
+        }
         /**
          * Override to conditionally show the new ticket button.
          */

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -16,6 +16,9 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
                 this.env.actionHandler({ name: 'actionSetTicketScreenSearchDetails', args: [searchDetails] })
             );
         }
+        async onClickOrder(order) {
+            await this.env.actionHandler({ name: 'actionSelectOrder', args: [order] })
+        }
         async onDeleteOrder(order) {
             const orderlines = this.env.model.getOrderlines(order);
             if (['ProductScreen', 'PaymentScreen'].includes(order._extras.activeScreen) && orderlines.length > 0) {

--- a/addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml
@@ -8,7 +8,7 @@
                     <div class="buttons">
                         <button t-if="showNewTicketButton" class="highlight"
                             t-on-click="env.actionHandler({ name: 'actionCreateNewOrder' })">New Order</button>
-                        <button class="discard" t-on-click="env.actionHandler({ name: 'actionToggleScreen', args: ['TicketScreen'] })">Discard</button>
+                        <button class="discard" t-on-click="onClickDiscard">Discard</button>
                     </div>
                     <t t-set="placeholder">Search Tickets...</t>
                     <SearchBar config="searchBarConfig" placeholder="placeholder" />

--- a/addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml
@@ -26,7 +26,7 @@
                     </div>
                     <t t-foreach="filteredOrderList" t-as="order" t-key="order.id">
                         <div class="order-row pointer"
-                            t-on-click="env.actionHandler({ name: 'actionSelectOrder', args: [order] })">
+                            t-on-click="onClickOrder(order)">
                             <div class="col start wide">
                                 <t t-esc="getDate(order)"></t>
                             </div>

--- a/addons/pos_hr/static/src/js/models.js
+++ b/addons/pos_hr/static/src/js/models.js
@@ -57,6 +57,13 @@ odoo.define('pos_hr.employees', function (require) {
             newOrder.employee_id = this.data.uiState.activeEmployeeId;
             return newOrder;
         },
+        _getStartScreens(activeOrder) {
+            const result = this._super(...arguments);
+            if (this.config.module_pos_hr) {
+                result.push(['LoginScreen', 0]);
+            }
+            return result;
+        },
         /**
          * This override augments the method to identify if the active cashier is a manager.
          */
@@ -66,16 +73,6 @@ odoo.define('pos_hr.employees', function (require) {
                 return this._super(...arguments);
             }
             return cashier.user_id === this.user.id && this._super(...arguments);
-        },
-        /**
-         * Start screen should be the LoginScreen.
-         */
-        getStartScreen() {
-            if (this.config.module_pos_hr) {
-                return 'LoginScreen';
-            } else {
-                return this._super(...arguments);
-            }
         },
         /**
          * When this module is installed, a cashier is represented by an employee.

--- a/addons/pos_hr/static/src/js/models.js
+++ b/addons/pos_hr/static/src/js/models.js
@@ -163,6 +163,13 @@ odoo.define('pos_hr.employees', function (require) {
         getActiveCashier() {
             return this.getRecord('hr.employee', this.data.uiState.activeEmployeeId);
         },
+        _shouldTriggerAfterIdleCallback() {
+            if (this.getActiveScreen() === 'LoginScreen') {
+                return false;
+            } else {
+                return this._super(...arguments);
+            }
+        }
     });
 
     unpatch.PointOfSaleUIPrototype = patch(PointOfSaleUI.prototype, 'pos_hr', {

--- a/addons/pos_restaurant/static/src/js/PointOfSaleModel.js
+++ b/addons/pos_restaurant/static/src/js/PointOfSaleModel.js
@@ -52,16 +52,29 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
                 return firstTableId;
             }
         },
-        getStartScreen() {
-            if (this.ifaceFloorplan) return 'FloorScreen';
-            return this._super();
+        _getStartScreens(activeOrder) {
+            const result = this._super(...arguments);
+            if (this.ifaceFloorplan) {
+                result.push(['FloorScreen', 50]);
+            }
+            return result;
+        },
+        _getDefaultScreen() {
+            if (this.ifaceFloorplan) {
+                return 'FloorScreen';
+            } else {
+                return this._super(...arguments);
+            }
         },
         async actionDoneLoading() {
-            await this._super();
             if (this.ifaceFloorplan) {
-                this.actionSetFloor(this.data.derived.sortedFloors[0]);
+                const floor = this.data.derived.sortedFloors[0];
+                this.data.uiState.activeTableId = false;
+                this.data.uiState.activeFloorId = floor.id;
+                this.data.uiState.FloorScreen.isEditMode = false;
                 this._setActivityListeners();
             }
+            await this._super();
         },
         async actionOrderDone(order, nextScreen) {
             await this._super(...arguments);

--- a/addons/pos_restaurant/static/src/js/PointOfSaleModel.js
+++ b/addons/pos_restaurant/static/src/js/PointOfSaleModel.js
@@ -70,7 +70,7 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
             }
         },
         _createDefaultOrder() {
-            const result = this._super();
+            const result = this._super(...arguments);
             if (this.ifaceFloorplan) {
                 result.table_id = this.data.uiState.activeTableId || this._getDefaultTableId();
             }
@@ -94,18 +94,12 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
         async actionSelectOrder(order) {
             await this._super(...arguments);
             if (this.ifaceFloorplan) {
-                const activeTable = this.getActiveTable();
-                const orderTable = this.getRecord('restaurant.table', order.table_id);
-                if (activeTable && orderTable !== activeTable) {
-                    await this._syncToServer(activeTable);
-                    await this._syncFromServer(orderTable);
-                }
                 if (!this.data.uiState.OrderManagementScreen.managementOrderIds.has(order.id) && order.table_id) {
                     const table = this.getRecord('restaurant.table', order.table_id);
                     this.data.uiState.activeTableId = order.table_id;
                     this.data.uiState.activeFloorId = table.floor_id;
                 }
-                if (order.lines.length) {
+                if (order.lines.length && !this.getActiveOrderline(order)) {
                     this.actionSelectOrderline(order, order.lines[order.lines.length - 1]);
                 }
             }
@@ -407,24 +401,52 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
             this.data.uiState.FloorScreen.isEditMode = false;
             await this.actionShowScreen('FloorScreen');
         },
-        async actionSetTable(table) {
+        /**
+         * Set the given `table` as active, and optionally select the given `orderToSelectId`.
+         * @param {'restaurant.table'} table
+         * @param {'string' | undefined} orderToSelectId
+         */
+        async actionSetTable(table, orderToSelectId) {
             if (this.data.uiState.FloorScreen.isEditMode) {
                 this.data.uiState.FloorScreen.selectedTableId = table.id;
+            } else if (this.exists('pos.order', orderToSelectId)) {
+                // This is reached when selecting an order from the TicketScreen and
+                // OrderManagementScreen.
+                await this._setTableWithOrder(table, orderToSelectId);
             } else {
-                this.data.uiState.activeTableId = table.id;
-                await this._syncFromServer(table);
-                if (this.data.uiState.orderIdToTransfer) {
-                    const orderToTransfer = this.getRecord('pos.order', this.data.uiState.orderIdToTransfer);
-                    this.updateRecord('pos.order', orderToTransfer.id, { table_id: table.id });
-                    this.data.uiState.orderIdToTransfer = false;
-                    await this.actionSelectOrder(orderToTransfer);
+                // This is reached when clicking a table from the floorscreen.
+                await this._setTableOnly(table);
+            }
+        },
+        async _setTableWithOrder(table, orderToSelectId) {
+            const orderToSelect = this.getRecord('pos.order', orderToSelectId);
+            if (orderToSelect.table_id !== table.id) {
+                throw new Error("Can't select order that doesn't belong to the table.");
+            }
+            const currentlyActiveTable = this.getActiveTable();
+            if (!currentlyActiveTable) {
+                await this._fetchTableOrdersFromServer(table);
+            } else if (table !== currentlyActiveTable) {
+                await this._saveTableOrdersToServer(currentlyActiveTable);
+                await this._fetchTableOrdersFromServer(table);
+            }
+            this.data.uiState.activeTableId = table.id;
+            await this.actionSelectOrder(this.getRecord('pos.order', orderToSelectId));
+        },
+        async _setTableOnly(table) {
+            this.data.uiState.activeTableId = table.id;
+            await this._fetchTableOrdersFromServer(table);
+            if (this.data.uiState.orderIdToTransfer) {
+                const orderToTransfer = this.getRecord('pos.order', this.data.uiState.orderIdToTransfer);
+                this.updateRecord('pos.order', orderToTransfer.id, { table_id: table.id });
+                this.data.uiState.orderIdToTransfer = false;
+                await this.actionSelectOrder(orderToTransfer);
+            } else {
+                const tableOrders = this.getTableOrders(table);
+                if (tableOrders.length) {
+                    await this.actionSelectOrder(tableOrders[0]);
                 } else {
-                    const tableOrders = this.getTableOrders(table);
-                    if (tableOrders.length) {
-                        await this.actionSelectOrder(tableOrders[0]);
-                    } else {
-                        await this.actionCreateNewOrder();
-                    }
+                    await this.actionCreateNewOrder();
                 }
             }
         },
@@ -671,7 +693,7 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
         async actionExitTable(table) {
             if (table) {
                 const floor = this.getRecord('restaurant.table', table.floor_id);
-                await this._syncToServer(table);
+                await this._saveTableOrdersToServer(table);
                 await this.actionSetFloor(floor);
             } else {
                 await this.actionShowScreen('FloorScreen');
@@ -716,7 +738,12 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
             });
             this._deleteOrderIdsToRemove(deletedOrderIds);
         },
-        async _syncToServer(table) {
+        /**
+         * Saves the orders of the given table to the backend.
+         * @related _fetchTableOrdersFromServer
+         * @param {'restaurant.table'} table
+         */
+        async _saveTableOrdersToServer(table) {
             const ordersToSave = this.getDraftOrders().filter(
                 (order) => order.table_id === table.id && order.lines.length
             );
@@ -724,11 +751,12 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
             await this._removeDeletedOrders(this._getOrderIdsToRemove());
         },
         /**
-         * Get from server the updated orders of the given table.
-         * @param {number} tableId
+         * Get from the backend the updated orders of the given table.
+         * @related _saveTableOrdersToServer
+         * @param {'restaurant.table'} table
          */
-        async _syncFromServer(table) {
-            const { data } = await this._rpc({
+        async _fetchTableOrdersFromServer(table) {
+            const data = await this._rpc({
                 model: 'pos.order',
                 method: 'get_table_draft_orders',
                 args: [table.id],
@@ -747,9 +775,8 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
             for (const model in data) {
                 for (const record of data[model]) {
                     if (model === 'pos.order') {
-                        const uid = record.pos_reference.match(/\d{5,}-\d{3,}-\d{4,}/);
-                        extras = this._defaultOrderExtras(uid ? uid[0] : record.id);
-                        extras.server_id = record.id;
+                        extras = this._defaultOrderExtras(record.id);
+                        extras.server_id = record.server_id;
                     }
                     this.setRecord(model, record.id, record, extras);
                     extras = {};

--- a/addons/pos_restaurant/static/src/js/PointOfSaleModel.js
+++ b/addons/pos_restaurant/static/src/js/PointOfSaleModel.js
@@ -105,9 +105,9 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
                     this.data.uiState.activeTableId = order.table_id;
                     this.data.uiState.activeFloorId = table.floor_id;
                 }
-
-                if(order.lines)
+                if (order.lines.length) {
                     this.actionSelectOrderline(order, order.lines[order.lines.length - 1]);
+                }
             }
         },
         actionUpdateOrderline(orderline, vals) {

--- a/addons/pos_restaurant/static/src/js/PointOfSaleModel.js
+++ b/addons/pos_restaurant/static/src/js/PointOfSaleModel.js
@@ -741,7 +741,11 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
                 }
             }
         },
-        async _removeDeletedOrders(orderIds) {
+        /**
+         * Removes from server the deleted orders.
+         */
+        async removeDeletedOrders() {
+            const orderIds = this._getOrderIdsToRemove();
             if (!orderIds.length) return;
             const deletedOrderIds = await this._rpc({
                 model: 'pos.order',
@@ -760,7 +764,7 @@ odoo.define('pos_restaurant.PointOfSaleModel', function (require) {
                 (order) => order.table_id === table.id && order.lines.length
             );
             await this._saveDraftOrders(ordersToSave);
-            await this._removeDeletedOrders(this._getOrderIdsToRemove());
+            await this.removeDeletedOrders();
         },
         /**
          * Get from the backend the updated orders of the given table.

--- a/addons/pos_restaurant/static/src/js/Screens/AbstractOrderManagementScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/AbstractOrderManagementScreen.js
@@ -1,0 +1,18 @@
+odoo.define('pos_restaurant.AbstractOrderManagementScreen', function (require) {
+    'use strict';
+
+    const AbstractOrderManagementScreen = require('point_of_sale.AbstractOrderManagementScreen');
+    const { patch } = require('web.utils');
+
+    return patch(AbstractOrderManagementScreen.prototype, 'pos_restaurant', {
+        async _onClickOrder(event) {
+            const order = event.detail;
+            if (this.env.model.ifaceFloorplan && order.table_id) {
+                const table = this.env.model.getRecord('restaurant.table', order.table_id);
+                await this.env.actionHandler({ name: 'actionSetTable', args: [table, order.id] });
+            } else {
+                await this._super(...arguments);
+            }
+        },
+    });
+});

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -19,6 +19,12 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                 await this._super(...arguments);
             }
         },
+        async onClickDiscard() {
+            await this._super(...arguments);
+            if (!this.env.model.getActiveTable()) {
+                await this.env.model.removeDeletedOrders();
+            }
+        },
         get filteredOrderList() {
             const orders = this._super();
             const activeTable = this.env.model.getActiveTable();

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -11,6 +11,14 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
     const unpatch = {};
 
     unpatch.TicketScreenProto = patch(TicketScreen.prototype, 'pos_restaurant', {
+        async onClickOrder(order) {
+            if (this.env.model.ifaceFloorplan && order.table_id) {
+                const table = this.env.model.getRecord('restaurant.table', order.table_id);
+                await this.env.actionHandler({ name: 'actionSetTable', args: [table, order.id] });
+            } else {
+                await this._super(...arguments);
+            }
+        },
         get filteredOrderList() {
             const orders = this._super();
             const activeTable = this.env.model.getActiveTable();

--- a/addons/pos_restaurant/views/pos_restaurant_templates.xml
+++ b/addons/pos_restaurant/views/pos_restaurant_templates.xml
@@ -25,6 +25,7 @@
             <script type="text/javascript" src="/pos_restaurant/static/src/js/Screens/FloorScreen/TableWidget.js"></script>
             <script type="text/javascript" src="/pos_restaurant/static/src/js/Screens/FloorScreen/EditableTable.js"></script>
             <script type="text/javascript" src="/pos_restaurant/static/src/js/Screens/TicketScreen.js"></script>
+            <script type="text/javascript" src="/pos_restaurant/static/src/js/Screens/AbstractOrderManagementScreen.js"></script>
             <script type="text/javascript" src="/pos_restaurant/static/src/js/ChromeWidgets/BackToFloorButton.js"></script>
             <script type="text/javascript" src="/pos_restaurant/static/src/js/ChromeWidgets/TicketButton.js"></script>
             <script type="text/javascript" src="/pos_restaurant/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js"></script>


### PR DESCRIPTION
This considers setting of table and selection of orders

1. clicking table from the floor screen
2. select order from the ticket screen
3. select order from the order management screen
4. select order from the ticket screen when a table is already selected
5. select order from the order management screen when a table is already selected