### PR TITLE
[FIX] remove outline around editable areas

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -70,6 +70,10 @@ html, body {
     height: 100%;
 }
 
+*[contenteditable=true] {
+    outline: none;
+}
+
 .css_non_editable_mode_hidden {
     display: none !important;
 }


### PR DESCRIPTION
This addresses the following bug report:

> [JKE] Click on a t-field (title e.g. on blog), we have a black border. While we removed the blue border by spec in master a long time ago ...

The way it had been removed a long time ago ... was by applying the style on a class (note-air-editor) that was added by Summernote and therefore doesn't exist anymore. Now it's simply on all `contenteditable` elements.