### PR TITLE
[FIX] Website: fix editor side bar top button height in FF

### DIFF
--- a/addons/website/static/src/scss/website.wysiwyg.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.scss
@@ -25,6 +25,8 @@
     justify-content: flex-end;
     width: $o-we-sidebar-width;
     height: $o-we-sidebar-top-height;
+    // Firefox css fix
+    min-height: $o-we-sidebar-top-height;
     background-color: $o-we-sidebar-tabs-bg;
 
     .btn-group, .btn {


### PR DESCRIPTION
Bug report : 

[22. QSM] Website editor: Save/discard UI is too small on Firefox.
    👁‍ See: https://drive.google.com/file/d/1aFXe2UOe0W9sUJ7f53LaG9445WWNTUXj/view?usp=sharing
