### PR TITLE
[FIX] web_editor: properly hide the cookie bar when needed

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2312,6 +2312,29 @@ options.registry.CookiesBar = options.registry.SnippetPopup.extend({
 
         $content.empty().append($template);
     },
+    /**
+     * @override
+     */
+    onTargetShow: async function () {
+        // @see this.onTargetHide
+        this.$target.parent('#website_cookies_bar').show()
+        this._super(...arguments);
+
+    },
+    /**
+     * @override
+     */
+    onTargetHide: async function () {
+        // We hide the parent because contenteditable="true" would force the bar to stay visible in hidden mode.
+        this.$target.parent('#website_cookies_bar').hide()
+        this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    cleanForSave: function () {
+        this.$target.parent('#website_cookies_bar').show()
+    },
 });
 
 /**


### PR DESCRIPTION
Bug report :
[RDE--01] Clicking on "Cookies Bar" in the Invisible Elements Panel is wrongly toggling the element visibility, a blank square remains
                 Build 6809783 | Version 88.0.4324.182 (Official Build) (64-bit) | Linux Mint 19.3

    👁‍ See:
    - master https://drive.google.com/file/d/1NfiMRyGiNHI8yd2UOvj_Ymu0hF2iGJuo/view
    - now https://drive.google.com/file/d/1fAT7o_cSLMfQf_fhKi0WBxuCOk7_lEQ0/view

    ❗️ Steps to Reproduce :
    1. Enable Cookies in website settings
    2. Enter Edit mode
    3. Click (multiple times if you want) on Cookies Bar in bottom right of right panel, there is a leftover when hidden -> NOK ❌

    ✅ Expected behavior :
    > Fully hidden