### PR TITLE
[FIX] Web_editor: Ensure the Toolbar always have the correct layout

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -155,6 +155,8 @@ const Wysiwyg = Widget.extend({
 
         $(this.odooEditor.editable).on('click', this._updateEditorUI.bind(this));
         $(this.odooEditor.editable).on('keydown', this._updateEditorUI.bind(this));
+        // Ensure the Toolbar always have the correct layout in note.
+        this._updateEditorUI();
 
         return _super.apply(this, arguments).then(() => {
             if (this.options.autohideToolbar) {
@@ -829,7 +831,7 @@ const Wysiwyg = Widget.extend({
      */
     _updateEditorUI: function (e) {
         this.odooEditor.automaticStepSkipStack();
-        const $target = $(e.target);
+        const $target = e ? $(e.target) : $();
         // Restore paragraph dropdown button's default ID.
         this.toolbar.$el.find('#mediaParagraphDropdownButton').attr('id', 'paragraphDropdownButton');
         // Remove the alt tools.
@@ -885,7 +887,7 @@ const Wysiwyg = Widget.extend({
         // Toggle the toolbar arrow.
         this.toolbar.$el.toggleClass('noarrow', isInMedia);
         // open the link modal / tool when CTRL+K is pressed
-        if (e.key === 'k' && (e.ctrlKey || e.metaKey)) {
+        if (e && e.key === 'k' && (e.ctrlKey || e.metaKey)) {
             e.preventDefault();
             this.toggleLinkTools();
         }


### PR DESCRIPTION
in note.

Bug report:
[NBY] In Note, when selecting text after clicking on edit, the toolbar is full of button that should not be present https://drive.google.com/file/d/1Jfut284Tsuwe-b3wWi0ZtAw0EKjAkIKa/view
    [AGE] Only the first time you select text, weirdly