### PR TITLE
[FIX] web_editor : Don't close the link toolbar in some special case

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2965,8 +2965,12 @@ var SnippetsMenu = Widget.extend({
      */
     _checkEditorToolbarVisibility: function (e) {
         const $toolbarContainer = $('#o_we_editor_toolbar_container');
+        const docSelection = document.getSelection();
+        const $currentSelectionTarget = docSelection.rangeCount > 0 ? $(docSelection.getRangeAt(0).commonAncestorContainer) : $();
         // Do not  toggle visibility if the target is inside the toolbar ( eg. during link edition).
-        if (e && $(e.target).parents('#toolbar').length) {
+        if ($currentSelectionTarget.parents('#toolbar').length ||
+            (e && $(e.target).parents('#toolbar').length)
+        ) {
             return;
         }
 


### PR DESCRIPTION
1. Prevent toolbar to close when using the autocomplete when entering an URL.
2. Prevent toolbar to close when creating a range inside the URL input whith mouseUp event ouside of the link toolbar

Bug reports :
[NBY] When selecting an url from the suggestion in the link tool, the toolbar disappears https://drive.google.com/file/d/1o4N7H4zgmaGemw1WPLD9BI92vHNka1eS/view

[NBY] when selecting the text of the url in the link tool and trigger mouseup outside the toolbar, the toolbar disappears https://drive.google.com/file/d/1h3vmlCNMJqQ47qK_v_gf0AZ3fSWaaT0L/view