### PR TITLE
[FIX] Web_editor : don't show toolbar when editing non html odoo field

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1038,13 +1038,15 @@ function checkEditorToolbarVisibility (doc, e) {
     if ($currentSelectionTarget.parents('#toolbar').length ||
         (e && $(e.target).parents('#toolbar').length)
     ) {
-        $toolbarContainer.hide();
         return false;
     }
 
     const selection = doc.getSelection();
     const range = selection.rangeCount && selection.getRangeAt(0);
-    if (!range || !$(range.commonAncestorContainer).parents('#wrap').length) {
+    if (!range ||
+        !$(range.commonAncestorContainer).parents('#wrapwrap').length ||
+        $(range.commonAncestorContainer).parent('[data-oe-model]:not([data-oe-type="html"]):not([data-oe-field="arch"])').length
+    ) {
         $toolbarContainer.hide();
         return false;
     } else {
@@ -2985,6 +2987,7 @@ var SnippetsMenu = Widget.extend({
         $customizeBlock.append($title);
         $customizeBlock.append(this.options.wysiwyg.toolbar.$el);
         $(this.customizePanel).append($customizeBlock);
+        checkEditorToolbarVisibility(this.options.wysiwyg.odooEditor.document);
     },
     /**
      * On click on discard button.


### PR DESCRIPTION
eg. Blog Post title/ Subtitle

Bug report :
➡[SRA] link does not work in blog post
    👁‍ See:https://youtu.be/GXvTwSbBptE
    1. Create Blog post and add hyper link below blog post
    2. add url for link
    3. save and try to click on hyper link.
    4. it does not open url page.

    [NBY] We should not be able to create a link/bold/... with thoses at it is a text Odoo field that does not support html tags.