### PR TITLE
[REF] apply eslint linting to all modified js files

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -9,6 +9,7 @@ var convertInline = require('web_editor.convertInline');
 
 var _t = core._t;
 
+
 var MassMailingFieldHtml = FieldHtml.extend({
     xmlDependencies: (FieldHtml.prototype.xmlDependencies || []).concat(["/mass_mailing/static/src/xml/mass_mailing.xml"]),
     jsLibs: [
@@ -68,10 +69,10 @@ var MassMailingFieldHtml = FieldHtml.extend({
             convertInline.classToStyle($editable);
 
             // fix outlook image rendering bug
-            _.each(['width', 'height'], function(attribute) {
-                $editable.find('img[style*="width"], img[style*="height"]').attr(attribute, function(){
+            _.each(['width', 'height'], function (attribute) {
+                $editable.find('img[style*="width"], img[style*="height"]').attr(attribute, function () {
                     return $(this)[attribute]();
-                }).css(attribute, function(){
+                }).css(attribute, function () {
                     return $(this).get(0).style[attribute] || 'auto';
                 });
             });
@@ -139,7 +140,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         if (!this.value) {
             this.value = this.recordData[this.nodeOptions['inline-field']];
         }
-        return this._super.apply(this, arguments);;
+        return this._super.apply(this, arguments);
     },
     /**
      * @override

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -3,7 +3,6 @@ odoo.define('web_editor.field.html', function (require) {
 
 var ajax = require('web.ajax');
 var basic_fields = require('web.basic_fields');
-var config = require('web.config');
 var core = require('web.core');
 var wysiwygLoader = require('web_editor.loader');
 var field_registry = require('web.field_registry');
@@ -156,7 +155,9 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      * @returns {$.Promise}
      */
     _createWysiwygIntance: async function () {
-        if (this.cssReadonly) return;
+        if (this.cssReadonly) {
+            return;
+        }
         this.wysiwyg = await wysiwygLoader.createWysiwyg(this, this._getWysiwygOptions());
         this.wysiwyg.__extraAssetsForIframe = this.__extraAssetsForIframe || [];
         return this.wysiwyg.appendTo(this.$el).then(() => {
@@ -183,7 +184,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             iframeCssAssets: this.nodeOptions.cssEdit,
             snippets: this.nodeOptions.snippets,
             value: this.value,
-            mediaModalParams: { noVideos: true },
+            mediaModalParams: {noVideos: true},
             linkForceNewWindow: true,
 
             tabsize: 0,

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3572,7 +3572,9 @@ const SnippetOptionWidget = Widget.extend({
     _select: async function (previewMode, widget) {
         let $applyTo = null;
 
-        if (previewMode === true) this.options.wysiwyg.odooEditor.automaticStepUnactive('preview_option');
+        if (previewMode === true) {
+            this.options.wysiwyg.odooEditor.automaticStepUnactive('preview_option');
+        }
 
         // Call each option method sequentially
         for (const methodName of widget.getMethodsNames()) {
@@ -3593,7 +3595,9 @@ const SnippetOptionWidget = Widget.extend({
             }
         }
 
-        if (previewMode === 'reset' || previewMode === false) this.options.wysiwyg.odooEditor.automaticStepActive('preview_option');
+        if (previewMode === 'reset' || previewMode === false) {
+            this.options.wysiwyg.odooEditor.automaticStepActive('preview_option');
+        }
 
         // We trigger the event on elements targeted by apply-to if any as
         // this.$target could not be in an editable element while the elements

--- a/addons/web_editor/static/src/js/frontend/loader.js
+++ b/addons/web_editor/static/src/js/frontend/loader.js
@@ -32,7 +32,7 @@ exports.createWysiwyg = async (parent, options, additionnalAssets = []) => {
     await wysiwygPromise;
     const Wysiwyg = odoo.__DEBUG__.services['web_editor.wysiwyg'];
     return new Wysiwyg(parent, options);
-}
+};
 
 exports.loadFromTextarea = async (parent, textarea, options) => {
     var loading = textarea.nextElementSibling;
@@ -70,7 +70,7 @@ exports.loadFromTextarea = async (parent, textarea, options) => {
     });
 
     return wysiwyg;
-}
+};
 
 return exports;
 });

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -280,7 +280,7 @@ var LinkDialog = Dialog.extend({
         if (url.indexOf('mailto:') === 0 || url.indexOf('tel:') === 0) {
             url = url.replace(/^tel:([0-9]+)$/, 'tel://$1');
         } else if (url.indexOf('@') !== -1 && url.indexOf(':') === -1) {
-            url =  'mailto:' + url;
+            url = 'mailto:' + url;
         } else if (url.indexOf('://') === -1 && url[0] !== '/'
                     && url[0] !== '#' && url.slice(0, 2) !== '${') {
             url = 'http://' + url;

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -90,7 +90,7 @@ const LinkTools = Widget.extend({
                 'we-selection-items[name="link_style_color"] > we-button',
                 'we-selection-items[name="link_style_size"] > we-button',
                 'we-selection-items[name="link_style_shape"] > we-button',
-            ]
+            ];
             for (const option of this.$(options.join(','))) {
                 const $option = $(option);
                 const value = $option.data('value');
@@ -106,8 +106,8 @@ const LinkTools = Widget.extend({
                 } else {
                     active = !this.data.iniClassName.includes('btn-');
                 }
-                this._setSelectOption($option, active)
-            };
+                this._setSelectOption($option, active);
+            }
         }
         if (this.data.url) {
             var match = /mailto:(.+)/.exec(this.data.url);
@@ -165,7 +165,9 @@ const LinkTools = Widget.extend({
             const label = (data.label && data.label.length) ? data.label : data.url;
             this.$link.html(label);
         }
-        if (createStep) this.options.wysiwyg.odooEditor.historyStep();
+        if (createStep) {
+            this.options.wysiwyg.odooEditor.historyStep();
+        }
         this.options.wysiwyg.odooEditor.automaticStepSkipStack();
         $links.addClass('oe_edited_link');
     },
@@ -219,7 +221,7 @@ const LinkTools = Widget.extend({
     _getOrCreateLink: function (linkToEdit) {
         this.options.wysiwyg.odooEditor.automaticStepSkipStack();
         const doc = this.editable.ownerDocument;
-        const range = getDeepRange(this.editable, { splitText: true, select: true, correctTripleClick: true });
+        const range = getDeepRange(this.editable, {splitText: true, select: true, correctTripleClick: true});
         this.needLabel = false;
         let link = linkToEdit || getInSelection(doc, 'a');
         const $link = $(link);
@@ -274,7 +276,7 @@ const LinkTools = Widget.extend({
         if (url.indexOf('mailto:') === 0 || url.indexOf('tel:') === 0) {
             url = url.replace(/^tel:([0-9]+)$/, 'tel://$1');
         } else if (url.indexOf('@') !== -1 && url.indexOf(':') === -1) {
-            url =  'mailto:' + url;
+            url = 'mailto:' + url;
         } else if (url.indexOf('://') === -1 && url[0] !== '/'
                     && url[0] !== '#' && url.slice(0, 2) !== '${') {
             url = 'http://' + url;

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -96,7 +96,7 @@ const Wysiwyg = Widget.extend({
         this.$editable.on(
             'mousedown touchstart',
             '[data-oe-field]',
-            function(e) {
+            function () {
                 const $field = $(this);
                 if (($field.data('oe-type') === "datetime" || $field.data('oe-type') === "date") && !$field.hasClass('o_editable_date_field_format_changed')) {
                     $field.html($field.data('oe-original-with-format'));
@@ -112,15 +112,15 @@ const Wysiwyg = Widget.extend({
             }
         );
 
-        this.$editable.on('click','.o_image, .media_iframe_video', e => e.preventDefault());
+        this.$editable.on('click', '.o_image, .media_iframe_video', e => e.preventDefault());
         this.showTooltip = true;
-        this.$editable.on('dblclick', mediaSelector, function() {
+        this.$editable.on('dblclick', mediaSelector, function () {
             self.showTooltip = false;
             const $el = $(this);
             let params = {node: $el};
             $el.selectElement();
 
-            if( $el.is('.fa')) {
+            if ($el.is('.fa')) {
                 // save layouting classes from icons to not break the page if you edit an icon
                 params.htmlClass = [...$el[0].classList].filter((className) => {
                     return !className.startsWith('fa') || faZoomClassRegex.test(className);
@@ -129,7 +129,7 @@ const Wysiwyg = Widget.extend({
 
             self.openMediaDialog(params);
         });
-        this.$editable.on('dblclick', 'a', function() {
+        this.$editable.on('dblclick', 'a', function () {
             if (!this.getAttribute('data-oe-model') && self.toolbar.$el.is(':visible')) {
                 self.showTooltip = false;
                 self.toggleLinkTools(true, this);
@@ -144,7 +144,7 @@ const Wysiwyg = Widget.extend({
             }, options));
             await this._insertSnippetMenu();
         }
-        if(this.options.getContentEditableAreas) {
+        if (this.options.getContentEditableAreas) {
             $(this.options.getContentEditableAreas()).find('*').off('mousedown mouseup click');
         }
         // The toolbar must be configured after the snippetMenu is loaded
@@ -178,7 +178,7 @@ const Wysiwyg = Widget.extend({
     /**
      * @override
      */
-    renderElement: function() {
+    renderElement: function () {
         this.$editable = this.options.editable || $('<div class="note-editable">');
 
         if (this.options.resizable) {
@@ -210,7 +210,9 @@ const Wysiwyg = Widget.extend({
             this.resizerMousemove = (e) => {
                 const offsetTop = e.pageY - startOffsetTop;
                 let height = startHeight + offsetTop;
-                if (height < minHeight) height = minHeight;
+                if (height < minHeight) {
+                    height = minHeight;
+                }
                 this.$editable.height(height);
             };
             this.resizerMouseup = () => {
@@ -240,12 +242,6 @@ const Wysiwyg = Widget.extend({
      */
     isDirty: function () {
         return this._value !== (this.$editable.html() || this.$editable.val());
-    },
-    /**
-     * Set the focus on the element.
-     */
-    focus: function () {
-        console.log('focus');
     },
     /**
      * Get the value of the editable element.
@@ -414,8 +410,8 @@ const Wysiwyg = Widget.extend({
      * Necessary to keep all copies of a given field at the same value throughout the page.
      */
     _observeOdooFieldChanges: function () {
-        const observerOptions = { characterData:true, subtree: true, childList: true };
-        if(this.odooFieldObservers) {
+        const observerOptions = {characterData: true, subtree: true, childList: true};
+        if (this.odooFieldObservers) {
             for (let observerData of this.odooFieldObservers) {
                 observerData.observer.observe(observerData.field, observerOptions);
             }
@@ -426,47 +422,62 @@ const Wysiwyg = Widget.extend({
 
             $odooFields.each((i, field) => {
                 const observer = new MutationObserver(() => {
-                    let $node = $(field)
-                    let $nodes = $odooFields.filter(function () { return this !== field;});
+                    let $node = $(field);
+                    let $nodes = $odooFields.filter(function () {
+                        return this !== field;
+                    });
                     if ($node.data('oe-model')) {
-                        $nodes = $nodes.filter('[data-oe-model="'+$node.data('oe-model')+'"]')
-                            .filter('[data-oe-id="'+$node.data('oe-id')+'"]')
-                            .filter('[data-oe-field="'+$node.data('oe-field')+'"]');
+                        $nodes = $nodes.filter('[data-oe-model="' + $node.data('oe-model') + '"]')
+                            .filter('[data-oe-id="' + $node.data('oe-id') + '"]')
+                            .filter('[data-oe-field="' + $node.data('oe-field') + '"]');
                     }
 
-                    if ($node.data('oe-translation-id')) $nodes = $nodes.filter('[data-oe-translation-id="'+$node.data('oe-translation-id')+'"]');
-                    if ($node.data('oe-type')) $nodes = $nodes.filter('[data-oe-type="'+$node.data('oe-type')+'"]');
-                    if ($node.data('oe-expression')) $nodes = $nodes.filter('[data-oe-expression="'+$node.data('oe-expression')+'"]');
-                    else if ($node.data('oe-xpath')) $nodes = $nodes.filter('[data-oe-xpath="'+$node.data('oe-xpath')+'"]');
-                    if ($node.data('oe-contact-options')) $nodes = $nodes.filter("[data-oe-contact-options='"+$node[0].dataset.oeContactOptions+"']");
+                    if ($node.data('oe-translation-id')) {
+                        $nodes = $nodes.filter('[data-oe-translation-id="' + $node.data('oe-translation-id') + '"]');
+                    }
+                    if ($node.data('oe-type')) {
+                        $nodes = $nodes.filter('[data-oe-type="' + $node.data('oe-type') + '"]');
+                    }
+                    if ($node.data('oe-expression')) {
+                        $nodes = $nodes.filter('[data-oe-expression="' + $node.data('oe-expression') + '"]');
+                    } else if ($node.data('oe-xpath')) {
+                        $nodes = $nodes.filter('[data-oe-xpath="' + $node.data('oe-xpath') + '"]');
+                    }
+                    if ($node.data('oe-contact-options')) {
+                        $nodes = $nodes.filter("[data-oe-contact-options='" + $node[0].dataset.oeContactOptions + "']");
+                    }
 
                     let nodes = $node.get();
 
                     if ($node.data('oe-type') === "many2one") {
                         $nodes = $nodes.add($('[data-oe-model]')
-                            .filter(function () { return this !== $node[0] && nodes.indexOf(this) === -1; })
-                            .filter('[data-oe-many2one-model="'+$node.data('oe-many2one-model')+'"]')
-                            .filter('[data-oe-many2one-id="'+$node.data('oe-many2one-id')+'"]')
+                            .filter(function () {
+                                return this !== $node[0] && nodes.indexOf(this) === -1;
+                            })
+                            .filter('[data-oe-many2one-model="' + $node.data('oe-many2one-model') + '"]')
+                            .filter('[data-oe-many2one-id="' + $node.data('oe-many2one-id') + '"]')
                             .filter('[data-oe-type="many2one"]'));
 
                         $nodes = $nodes.add($('[data-oe-model]')
-                            .filter(function () { return this !== $node[0] && nodes.indexOf(this) === -1; })
-                            .filter('[data-oe-model="'+$node.data('oe-many2one-model')+'"]')
-                            .filter('[data-oe-id="'+$node.data('oe-many2one-id')+'"]')
+                            .filter(function () {
+                                return this !== $node[0] && nodes.indexOf(this) === -1;
+                            })
+                            .filter('[data-oe-model="' + $node.data('oe-many2one-model') + '"]')
+                            .filter('[data-oe-id="' + $node.data('oe-many2one-id') + '"]')
                             .filter('[data-oe-field="name"]'));
                     }
 
                     this._pauseOdooFieldObservers();
                     // Tag the date fields to only replace the value
                     // with the original date value once (see mouseDown event)
-                    if($node.hasClass('o_editable_date_field_format_changed')) {
+                    if ($node.hasClass('o_editable_date_field_format_changed')) {
                         $nodes.addClass('o_editable_date_field_format_changed');
                     }
                     $nodes.html($node.html());
                     this._observeOdooFieldChanges();
                 });
                 observer.observe(field, observerOptions);
-                this.odooFieldObservers.push({ field: field, observer: observer });
+                this.odooFieldObservers.push({field: field, observer: observer});
             });
         }
     },
@@ -514,7 +525,7 @@ const Wysiwyg = Widget.extend({
             }
             if (forceOpen || !this.linkTools) {
                 const $btn = this.toolbar.$el.find('#create-link');
-                this.linkTools = new weWidgets.LinkTools(this, { wysiwyg: this }, this.odooEditor.editable, $btn, link);
+                this.linkTools = new weWidgets.LinkTools(this, {wysiwyg: this}, this.odooEditor.editable, $btn, link);
                 this.linkTools.appendTo(this.toolbar.$el);
             } else {
                 this.linkTools = undefined;
@@ -558,8 +569,8 @@ const Wysiwyg = Widget.extend({
                     }
                     range.selectNode(anchor);
                     range.collapse();
-                };
-                getDeepRange(this.odooEditor.editable, { range, select: true });
+                }
+                getDeepRange(this.odooEditor.editable, {range, select: true});
             });
         }
     },
@@ -574,7 +585,9 @@ const Wysiwyg = Widget.extend({
      */
     openMediaDialog(params = {}) {
         const sel = this.odooEditor.document.getSelection();
-        if (!sel.rangeCount) return;
+        if (!sel.rangeCount) {
+            return;
+        }
         const range = sel.getRangeAt(0);
         // We lose the current selection inside the content editable when we
         // click the media dialog button so we need to be able to restore the
@@ -596,7 +609,7 @@ const Wysiwyg = Widget.extend({
         const mediaDialog = new weWidgets.MediaDialog(this, mediaParams, $node);
         mediaDialog.open();
 
-        mediaDialog.on('save', this, function(element) {
+        mediaDialog.on('save', this, function (element) {
             // restore saved html classes
             if (params.htmlClass) {
                 element.className += " " + params.htmlClass;
@@ -610,10 +623,12 @@ const Wysiwyg = Widget.extend({
                 this.odooEditor.execCommand('insertHTML', element.outerHTML);
             }
         });
-        mediaDialog.on('closed', this,  function() {
+        mediaDialog.on('closed', this, function () {
             // if the mediaDialog content has been saved
             // the previous selection in not relevant anymore
-            if (mediaDialog.destroyAction !== 'save') {restoreSelection();}
+            if (mediaDialog.destroyAction !== 'save') {
+                restoreSelection();
+            }
         });
     },
     //--------------------------------------------------------------------------
@@ -641,27 +656,35 @@ const Wysiwyg = Widget.extend({
         };
         $toolbar.find('#create-link, #media-insert, #media-replace, #media-description').click(openTools);
         $toolbar.find('#image-shape div, #fa-spin').click(e => {
-            if (!this.lastMediaClicked) return;
+            if (!this.lastMediaClicked) {
+                return;
+            }
             this.lastMediaClicked.classList.toggle(e.target.id);
             e.target.classList.toggle('active', $(this.lastMediaClicked).hasClass(e.target.id));
         });
         const $imageWidthButtons = $toolbar.find('#image-width div');
         $imageWidthButtons.click(e => {
-            if (!this.lastMediaClicked) return;
+            if (!this.lastMediaClicked) {
+                return;
+            }
             this.lastMediaClicked.style.width = e.target.id;
             for (const button of $imageWidthButtons) {
                 button.classList.toggle('active', this.lastMediaClicked.style.width === button.id);
             }
         });
         $toolbar.find('#image-padding .dropdown-item').click(e => {
-            if (!this.lastMediaClicked) return;
+            if (!this.lastMediaClicked) {
+                return;
+            }
             $(this.lastMediaClicked).removeClass((index, className) => (
                 (className.match(/(^|\s)padding-\w+/g) || []).join(' ')
             )).addClass(e.target.dataset.class);
         });
         $toolbar.on('mousedown', e => {
             const justifyBtn = e.target.closest('#justify div.btn');
-            if (!justifyBtn || !this.lastMediaClicked) return;
+            if (!justifyBtn || !this.lastMediaClicked) {
+                return;
+            }
             e.originalEvent.stopImmediatePropagation();
             e.originalEvent.stopPropagation();
             e.originalEvent.preventDefault();
@@ -678,11 +701,15 @@ const Wysiwyg = Widget.extend({
             this._updateMediaJustifyButton(justifyBtn.id);
         });
         $toolbar.find('#image-crop').click(e => {
-            if (!this.lastMediaClicked) return;
+            if (!this.lastMediaClicked) {
+                return;
+            }
             new weWidgets.ImageCropWidget(this, this.lastMediaClicked).appendTo(this.$editable);
         });
         $toolbar.find('#image-transform').click(e => {
-            if (!this.lastMediaClicked) return;
+            if (!this.lastMediaClicked) {
+                return;
+            }
             const $image = $(this.lastMediaClicked);
             if ($image.data('transfo-destroy')) {
                 $image.removeData('transfo-destroy');
@@ -706,17 +733,21 @@ const Wysiwyg = Widget.extend({
             $(this.odooEditor.document).on('mousedown', mousedown);
         });
         $toolbar.find('#image-delete').click(e => {
-            if (!this.lastMediaClicked) return;
+            if (!this.lastMediaClicked) {
+                return;
+            }
             $(this.lastMediaClicked).remove();
             this.lastMediaClicked = undefined;
         });
         $toolbar.find('#fa-resize div').click(e => {
-            if (!this.lastMediaClicked) return;
+            if (!this.lastMediaClicked) {
+                return;
+            }
             const $target = $(this.lastMediaClicked);
             const sValue = e.target.dataset.value;
             $target.attr('class', $target.attr('class').replace(/\s*fa-[0-9]+x/g, ''));
             if (+sValue > 1) {
-                $target.addClass('fa-'+sValue+'x');
+                $target.addClass('fa-' + sValue + 'x');
             }
             this._updateFaResizeButtons();
         });
@@ -796,7 +827,7 @@ const Wysiwyg = Widget.extend({
                 });
                 return false;
             });
-        };
+        }
     },
     _processAndApplyColor: function (eventName, color) {
         if (!color) {
@@ -818,7 +849,7 @@ const Wysiwyg = Widget.extend({
             if (color.startsWith('rgb')) {
                 rgbColor = color;
             } else {
-                const $font = $(`<font class="${color}"/>`)
+                const $font = $(`<font class="${color}"/>`);
                 $(document.body).append($font);
                 const propertyName = color.startsWith('text') ? 'color' : 'backgroundColor';
                 rgbColor = $font.css(propertyName);
@@ -845,7 +876,7 @@ const Wysiwyg = Widget.extend({
         const selection = this.odooEditor.document.getSelection();
         const range = selection.rangeCount && selection.getRangeAt(0);
         const $rangeContainer = range && $(range.commonAncestorContainer);
-        const spansBlocks = range && !!$rangeContainer.contents().filter((i, node) => isBlock(node)).length
+        const spansBlocks = range && !!$rangeContainer.contents().filter((i, node) => isBlock(node)).length;
         this.toolbar.$el.find('#create-link').toggleClass('d-none', !range || spansBlocks);
         // Only show the media tools in the toolbar if the current selected
         // snippet is a media.
@@ -938,7 +969,9 @@ const Wysiwyg = Widget.extend({
         }
     },
     _updateMediaJustifyButton: function (commandState) {
-        if (!this.lastMediaClicked) return;
+        if (!this.lastMediaClicked) {
+            return;
+        }
         const $paragraphDropdownButton = this.toolbar.$el.find('#paragraphDropdownButton, #mediaParagraphDropdownButton');
         // Change the ID to prevent OdooEditor from controlling it as this is
         // custom behavior for media.
@@ -975,7 +1008,9 @@ const Wysiwyg = Widget.extend({
         }
     },
     _updateFaResizeButtons: function () {
-        if (!this.lastMediaClicked) return;
+        if (!this.lastMediaClicked) {
+            return;
+        }
         const $buttons = this.toolbar.$el.find('#fa-resize div');
         const match = this.lastMediaClicked.className.match(/\s*fa-([0-9]+)x/);
         const value = match && match[1] ? match[1] : '1';
@@ -985,7 +1020,7 @@ const Wysiwyg = Widget.extend({
     },
     _editorOptions: function () {
         var self = this;
-        var options = Object.assign({},  this.defaultOptions, this.options);
+        var options = Object.assign({}, this.defaultOptions, this.options);
         if (this.options.generateOptions) {
             options = this.options.generateOptions(options);
         }
@@ -1005,7 +1040,7 @@ const Wysiwyg = Widget.extend({
         };
         return options;
     },
-    _insertSnippetMenu: function() {
+    _insertSnippetMenu: function () {
         return this.snippetsMenu.insertBefore(this.$el);
     },
     /**
@@ -1127,7 +1162,6 @@ const Wysiwyg = Widget.extend({
         return Promise.all(defs).then(function () {
             window.onbeforeunload = null;
         }).guardedCatch((failed) => {
-            console.log(failed)
             // If there were errors, re-enable edition
             this.cancel();
             this.start();
@@ -1140,7 +1174,7 @@ const Wysiwyg = Widget.extend({
                 selector: '[data-oe-readonly]',
                 container: 'body',
                 trigger: 'hover',
-                delay: { 'show': 1000, 'hide': 100 },
+                delay: {'show': 1000, 'hide': 100},
                 placement: 'bottom',
                 title: _t("Readonly field")
             })
@@ -1210,7 +1244,7 @@ const Wysiwyg = Widget.extend({
         } else {
             window.location.reload(true);
         }
-        return new Promise(function(){});
+        return new Promise(function () {});
     },
     _onDocumentMousedown: function (e) {
         if (e.target.closest('.oe-toolbar')) {
@@ -1250,7 +1284,7 @@ Wysiwyg.getRange = function (ownerDocument) {
             so: 0,
             ec: null,
             eo: 0,
-        }
+        };
     }
     const range = selection.getRangeAt(0);
 

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
@@ -152,7 +152,7 @@ Wysiwyg.include({
         return def;
     },
 
-    _insertSnippetMenu: function() {
+    _insertSnippetMenu: function () {
         if (this.options.inIframe) {
             return this.snippetsMenu.appendTo(this.$utilsZone);
         } else {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg_utils.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg_utils.js
@@ -8,7 +8,7 @@ function getIntermediateNodes(rootNode) {
     const nodes = [];
     for (const node of rootNode.childNodes) {
         nodes.push(node);
-        nodes.push(...getIntermediateNodes(node))
+        nodes.push(...getIntermediateNodes(node));
     }
     return nodes;
 }

--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -652,7 +652,7 @@ QUnit.module('web_editor', {}, function () {
             await testUtils.form.clickEdit(form);
 
             $field = form.$('.oe_form_field[name="body"]');
-            assert.strictEqual($field.find('#iframe_target').length, 0);;
+            assert.strictEqual($field.find('#iframe_target').length, 0);
 
             form.destroy();
         });

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -118,8 +118,8 @@ var RunningTourActionHelper = core.Class.extend({
         var $to;
         var elementCenter = values.
         $element.offset();
-        elementCenter.left += values.$element.outerWidth()/2;
-        elementCenter.top += values.$element.outerHeight()/2;
+        elementCenter.left += values.$element.outerWidth() / 2;
+        elementCenter.top += values.$element.outerHeight() / 2;
         if (to) {
             $to = get_jquery_element_from_selector(to);
         } else {
@@ -134,8 +134,8 @@ var RunningTourActionHelper = core.Class.extend({
                 toCenter.left += iFrameOffset.left;
                 toCenter.top += iFrameOffset.top;
             }
-            toCenter.left += $to.outerWidth()/2;
-            toCenter.top += $to.outerHeight()/2;
+            toCenter.left += $to.outerWidth() / 2;
+            toCenter.top += $to.outerHeight() / 2;
             return toCenter;
         };
 

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2447,7 +2447,7 @@ options.registry.CookiesBar = options.registry.SnippetPopup.extend({
      */
     onTargetShow: async function () {
         // @see this.onTargetHide
-        this.$target.parent('#website_cookies_bar').show()
+        this.$target.parent('#website_cookies_bar').show();
         this._super(...arguments);
 
     },
@@ -2456,14 +2456,14 @@ options.registry.CookiesBar = options.registry.SnippetPopup.extend({
      */
     onTargetHide: async function () {
         // We hide the parent because contenteditable="true" would force the bar to stay visible in hidden mode.
-        this.$target.parent('#website_cookies_bar').hide()
+        this.$target.parent('#website_cookies_bar').hide();
         this._super(...arguments);
     },
     /**
      * @override
      */
     cleanForSave: function () {
-        this.$target.parent('#website_cookies_bar').show()
+        this.$target.parent('#website_cookies_bar').show();
     },
 });
 

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -110,7 +110,9 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             self.trigger_up('edition_was_stopped');
             self.destroy();
         };
-        if (!this.wysiwyg.isDirty()) return destroy();
+        if (!this.wysiwyg.isDirty()) {
+            return destroy();
+        }
         return this.wysiwyg.saveContent(false).then((result) => {
             var $wrapwrap = $('#wrapwrap');
             self.editableFromEditorMenu($wrapwrap).removeClass('o_editable');
@@ -259,7 +261,9 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         this.wysiwyg.odooEditor.observerUnactive();
         $('#wrapwrap').on('click.odoo-website-editor', '*', this, this._preventDefault);
         this._addEditorMessages(); // Insert editor messages in the DOM without observing.
-        if (this.options.beforeEditorActive) this.options.beforeEditorActive() ;
+        if (this.options.beforeEditorActive) {
+            this.options.beforeEditorActive();
+        }
         this.wysiwyg.odooEditor.observerActive();
 
         // Observe changes to mark dirty structures and fields.
@@ -273,8 +277,10 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             for (const record of records) {
                 const $savable = $(record.target).closest(this.savableSelector);
 
-                if (record.attributeName === 'contenteditable') continue;
-                $savable.not('.o_dirty').each(function() {
+                if (record.attributeName === 'contenteditable') {
+                    continue;
+                }
+                $savable.not('.o_dirty').each(function () {
                     const $el = $(this);
                     if (!$el.closest('[data-oe-readonly]').length) {
                         $el.addClass('o_dirty');

--- a/addons/website/static/src/js/menu/translate.js
+++ b/addons/website/static/src/js/menu/translate.js
@@ -180,7 +180,7 @@ var TranslatePageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
                 return $(savableSelector)
                     .not('[data-oe-readonly]');
             },
-            beforeEditorActive:  async() => {
+            beforeEditorActive: async () => {
                 var attrs = ['placeholder', 'title', 'alt', 'value'];
                 const $editable = self._getEditableArea();
                 const translationRegex = /<span [^>]*data-oe-translation-id="([0-9]+)"[^>]*>(.*)<\/span>/;
@@ -284,7 +284,7 @@ var TranslatePageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         var $node = $(node);
         var id = +$node.data('oe-translation-id');
         if (!id) {
-            id = $node.data('oe-model')+','+$node.data('oe-id')+','+$node.data('oe-field');
+            id = $node.data('oe-model') + ',' + $node.data('oe-id') + ',' + $node.data('oe-field');
         }
         var trans = _.find(this.translations, function (trans) {
             return trans.id === id;
@@ -302,7 +302,7 @@ var TranslatePageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         this._getEditableArea().each(function () {
             var $node = $(this);
             var trans = self._getTranlationObject(this);
-            trans.value = (trans.value ? trans.value : $node.html() ).replace(/[ \t\n\r]+/, ' ');
+            trans.value = (trans.value ? trans.value : $node.html()).replace(/[ \t\n\r]+/, ' ');
         });
         this._getEditableArea().prependEvent('click.translator', function (ev) {
             if (ev.ctrlKey || !$(ev.target).is(':o_editable')) {
@@ -319,7 +319,7 @@ var TranslatePageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             var translation = $node.data('translation');
             _.each(translation, function (node, attr) {
                 var trans = self._getTranlationObject(node);
-                trans.value = (trans.value ? trans.value : $node.html() ).replace(/[ \t\n\r]+/, ' ');
+                trans.value = (trans.value ? trans.value : $node.html()).replace(/[ \t\n\r]+/, ' ');
                 $node.attr('data-oe-translation-state', (trans.state || 'to_translate'));
             });
         });

--- a/addons/website/static/tests/tours/public_user_editor.js
+++ b/addons/website/static/tests/tours/public_user_editor.js
@@ -3,7 +3,6 @@ odoo.define('website.tour.public_user_editor_dep_widget', function (require) {
 
 const publicWidget = require('web.public.widget');
 const wysiwygLoader = require('web_editor.loader');
-const ajax = require('web.ajax');
 
 publicWidget.registry['public_user_editor_test'] = publicWidget.Widget.extend({
     selector: 'textarea.o_public_user_editor_test_textarea',

--- a/addons/website_blog/static/src/js/options.js
+++ b/addons/website_blog/static/src/js/options.js
@@ -2,7 +2,7 @@ odoo.define('website_blog.options', function (require) {
 'use strict';
 
 require('web.dom_ready');
-const {qweb, _t} = require('web.core');
+const {_t} = require('web.core');
 const options = require('web_editor.snippets.options');
 require('website.editor.snippets.options');
 
@@ -25,14 +25,16 @@ options.registry.many2one.include({
         var self = this;
         this._super.apply(this, arguments);
         if (this.$target.data('oe-field') === 'author_id') {
-            var $nodes = $('[data-oe-model="blog.post"][data-oe-id="'+this.$target.data('oe-id')+'"][data-oe-field="author_avatar"]');
+            var $nodes = $('[data-oe-model="blog.post"][data-oe-id="' + this.$target.data('oe-id') + '"][data-oe-field="author_avatar"]');
             $nodes.each(function () {
                 var $img = $(this).find('img');
                 var css = window.getComputedStyle($img[0]);
-                $img.css({ width: css.width, height: css.height });
-                $img.attr('src', '/web/image/res.partner/'+self.ID+'/image_1024');
+                $img.css({width: css.width, height: css.height});
+                $img.attr('src', '/web/image/res.partner/' + self.ID + '/image_1024');
             });
-            setTimeout(function () { $nodes.removeClass('o_dirty'); },0);
+            setTimeout(function () {
+                $nodes.removeClass('o_dirty');
+            }, 0);
         }
     }
 });


### PR DESCRIPTION
- This linting includes older code that eslint saw as problematic.
- The following rules were disabled to avoid having to make changes to
    actual code logic:
    - "eqeqeq"
    - "no-useless-escape"
    - "no-prototype-builtins"
    - "no-async-promise-executor"
- Where there was doubt, nothing was changed. Therefore, the following
    issues were not yet adressed:
    - In `addons/web_editor/static/tests/test_utils.js`:
        - `keypress.keyCode` is assigned to itself (404)
        - `dom` is not defined (455, 457)
        - `textInput` was used before it was defined (410, 676)
    - In `addons/web_editor/static/src/js/backend/field_html.js`:
        - `value` is assigned a value but never used (225)
    - In `addons/web_editor/static/src/js/editor/snippets.options.js`:
        - `userValueWidgetsRegistry` was used before it was defined (195)