### PR TITLE
[FIX] web: DebugManager: items like Set defaults, View Metadata are broken

### DIFF
--- a/addons/web/static/src/debug/debug_menu_items.xml
+++ b/addons/web/static/src/debug/debug_menu_items.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <Dialog t-name="web.DebugManager.SetDefault" title="title">
-        <t t-call="web.DebugManager.setDefault"/>
-        <t t-set-slot="buttons">
-            <button class="btn btn-secondary" t-on-click="trigger('dialog-closed')">Close</button>
-            <button class="btn btn-secondary" t-on-click="saveDefault">Save default</button>
-        </t>
-    </Dialog>
+    <t t-name="web.DebugManager.SetDefault" owl="1">
+        <Dialog title="title">
+            <t t-call="web.DebugManager.setDefault"/>
+            <t t-set-slot="buttons">
+                <button class="btn btn-secondary" t-on-click="trigger('dialog-closed')">Close</button>
+                <button class="btn btn-secondary" t-on-click="saveDefault">Save default</button>
+            </t>
+        </Dialog>
+    </t>
 
-    <t t-name="web.DebugManager.setDefault">
+    <t t-name="web.DebugManager.setDefault" owl="1">
         <table style="width: 100%">
             <tr>
                 <td>
@@ -65,11 +67,13 @@
         </table>
     </t>
 
-    <Dialog t-name="web.DebugManager.GetMetadata" title="title">
-        <t t-call="web.DebugManager.getMetadata"/>
-    </Dialog>
+    <t t-name="web.DebugManager.GetMetadata" owl="1">
+        <Dialog title="title">
+            <t t-call="web.DebugManager.getMetadata"/>
+        </Dialog>
+    </t>
 
-    <t t-name="web.DebugManager.getMetadata">
+    <t t-name="web.DebugManager.getMetadata" owl="1">
         <table class="table table-sm table-striped">
             <tr>
                 <th>ID:</th>

--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -3,6 +3,7 @@
 import { editModelDebug } from "../debug/debug_service";
 import { json_node_to_xml } from "../utils/misc";
 import { formatMany2one } from "../utils/fields";
+import { parseDateTime, formatDateTime } from "../utils/dates";
 
 const { Component, hooks, tags } = owl;
 const { useState } = hooks;
@@ -198,12 +199,11 @@ class GetMetadataDialog extends Component {
     this.state.creator = formatMany2one(metadata.create_uid);
     this.state.lastModifiedBy = formatMany2one(metadata.write_uid);
     this.state.noupdate = metadata.noupdate;
-    const localization = this.env.services.localization;
-    this.state.create_date = localization.formatDateTime(
-      localization.parseDateTime(metadata.create_date)
+    this.state.create_date = formatDateTime(
+      parseDateTime(metadata.create_date)
     );
-    this.state.write_date = localization.formatDateTime(
-      localization.parseDateTime(metadata.write_date)
+    this.state.write_date = formatDateTime(
+      parseDateTime(metadata.write_date)
     );
   }
 }

--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -29,9 +29,8 @@ export function setupDebugAction(accessRights, env, action) {
     description: description,
     callback: async () => {
       const modelId = (
-        await env.services
-          .model("ir.model")
-          .search([["model", "=", action.res_model]], { limit: 1 })
+        await env.services.orm
+          .search("ir.model", [["model", "=", action.res_model]], { limit: 1 })
       )[0];
       env.services.action.doAction({
         res_model: "ir.model.fields",
@@ -77,9 +76,8 @@ export function setupDebugAction(accessRights, env, action) {
     type: "item",
     description: env._t("Technical Translation"),
     callback: async () => {
-      const result = await env.services
-        .model("ir.translation")
-        .call("get_technical_translations", [action.res_model]);
+      const result = await env.services.orm
+        .call("ir.translation", "get_technical_translations", [action.res_model]);
       env.services.action.doAction(result);
     },
     sequence: 140,
@@ -96,9 +94,8 @@ export function setupDebugAction(accessRights, env, action) {
     description: description,
     callback: async () => {
       const modelId = (
-        await env.services
-          .model("ir.model")
-          .search([["model", "=", action.res_model]], { limit: 1 })
+        await env.services.orm
+          .search("ir.model", [["model", "=", action.res_model]], { limit: 1 })
       )[0];
       env.services.action.doAction({
         res_model: "ir.model.access",
@@ -123,9 +120,8 @@ export function setupDebugAction(accessRights, env, action) {
     description: env._t("View Record Rules"),
     callback: async () => {
       const modelId = (
-        await env.services
-          .model("ir.model")
-          .search([["model", "=", action.res_model]], { limit: 1 })
+        await env.services.orm
+          .search("ir.model", [["model", "=", action.res_model]], { limit: 1 })
       )[0];
       env.services.action.doAction({
         res_model: "ir.rule",
@@ -187,17 +183,15 @@ class GetMetadataDialog extends Component {
   }
 
   async toggleNoupdate() {
-    await this.env.services
-      .model("ir.model.data")
-      .call("toggle_noupdate", [this.props.res_model, this.state.id]);
+    await this.env.services.orm
+      .call("ir.model.data", "toggle_noupdate", [this.props.res_model, this.state.id]);
     await this.getMetadata();
   }
 
   async getMetadata() {
     const metadata = (
-      await this.env.services
-        .model(this.props.res_model)
-        .call("get_metadata", [this.props.selectedIds])
+      await this.env.services.orm
+        .call(this.props.res_model,"get_metadata", [this.props.selectedIds])
     )[0];
     this.state.id = metadata.id;
     this.state.xmlid = metadata.xmlid;
@@ -345,9 +339,8 @@ class SetDefaultDialog extends Component {
     const fieldToSet = this.defaultFields.find((field) => {
       return field.name === this.state.fieldToSet;
     }).value;
-    await this.env.services
-      .model("ir.default")
-      .call("set", [
+    await this.env.services.orm
+      .call("ir.default", "set", [
         this.props.res_model,
         this.state.fieldToSet,
         fieldToSet,

--- a/addons/web/static/src/utils/dates.js
+++ b/addons/web/static/src/utils/dates.js
@@ -101,6 +101,7 @@ export function parseDateTime(value, options = {}) {
       (woSeps &&
         (check(DateTime.fromFormat(woSeps.val, woSeps.fmt)) ||
           check(DateTime.fromFormat(woSeps.val, woSeps.fmt.slice(0, woSeps.val.length))))) ||
+      check(DateTime.fromSQL(value)) ||
       DateTime.fromISO(value) || // last try: ISO8601
       DateTime.invalid("mandatory but unused string");
   }

--- a/addons/web/static/tests/utils/dates_tests.js
+++ b/addons/web/static/tests/utils/dates_tests.js
@@ -199,4 +199,19 @@ QUnit.module("utils", () => {
       DateTime.local().minus({ days: 1 }).toFormat(format)
     );
   });
+
+  QUnit.test("parseDateTime SQL Format", async (assert) => {
+    patch(localization, "default loc", defaultLocalization);
+
+    let dateStr = "2017-05-15 09:12:34";
+    let date1 = parseDateTime(dateStr);
+    let date2 = DateTime.fromFormat(dateStr, "yyyy-MM-dd HH:mm:ss");
+    assert.equal(date1.toISO(), date2.toISO(), "Date with SQL format");
+    dateStr = "2017-05-08 09:12:34";
+    date1 = parseDateTime(dateStr);
+    date2 = DateTime.fromFormat(dateStr, "yyyy-MM-dd HH:mm:ss");
+    assert.equal(date1.toISO(), date2.toISO(), "Date SQL format, check date is not confused with month");
+
+    unpatch(localization, "default loc");
+  });
 });


### PR DESCRIPTION
[FIX] web: access SetDefault and GetMetadata Dialog

Before this commit, the SetDefault and the GetMetadata Dialog weren't
accessible.

---------------

[FIX] web: support for SQL dates

Before this commit, when trying to parse a date time that came directly
from the SQL ("yyyy-MM-dd HH:mm:ss"), the parseDateTime function
answered with an Error.

Now, the SQL format is accepted and parsed. Note that this format is
almost identical than the ISO one, the only difference is the lack of
'T' on the format ("yyyy-MM-ddTHH:mm:ss")

-----------------

[FIX] web: change model service to orm service

Before this commit, an old service was used to access the orm functions
(call, search, etc.).

------------------

[FIX] web: using utils/dates to format and parse date

Before this commit, the service localization was used to format and
parse Datetime.

Now, the utils/dates is used to format and parse date.