### PR TITLE
[REF] web: use <t t-name> everywhere

### DIFF
--- a/addons/web/static/src/actions/action_container.js
+++ b/addons/web/static/src/actions/action_container.js
@@ -51,7 +51,9 @@ export class ActionContainer extends Component {
 }
 ActionContainer.components = { ActionDialog };
 ActionContainer.template = tags.xml`
-    <div t-name="web.ActionContainer" class="o_action_manager">
-      <t t-if="main.Component" t-component="main.Component" t-props="main.componentProps" t-key="main.id"/>
-      <ActionDialog t-if="dialog.id" t-props="dialog.props" t-key="dialog.id" t-on-dialog-closed="onDialogClosed"/>
-    </div>`;
+    <t t-name="web.ActionContainer">
+      <div class="o_action_manager">
+        <t t-if="main.Component" t-component="main.Component" t-props="main.componentProps" t-key="main.id"/>
+        <ActionDialog t-if="dialog.id" t-props="dialog.props" t-key="dialog.id" t-on-dialog-closed="onDialogClosed"/>
+      </div>
+    </t>`;

--- a/addons/web/static/src/commands/command_palette.xml
+++ b/addons/web/static/src/commands/command_palette.xml
@@ -1,41 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-  <div t-name="web.CommandPalette" owl="1">
-    <div class="o_command_palette_search">
-      <input type="text" class="o_command_palette_search" t-on-input="onSearchInput" autofocus="" placeholder="Search for an action..." />
-      <i title="Search for an action..." role="img" aria-label="Search for an action..." class="fa fa-search"></i>
-    </div>
+  <t t-name="web.CommandPalette" owl="1">
+    <div>
+      <div class="o_command_palette_search">
+        <input type="text" class="o_command_palette_search" t-on-input="onSearchInput" autofocus="" placeholder="Search for an action..." />
+        <i title="Search for an action..." role="img" aria-label="Search for an action..." class="fa fa-search"></i>
+      </div>
 
-    <div class="o_command_palette_listbox">
+      <div class="o_command_palette_listbox">
 
-      <div t-if="!categories.length" class="o_command_palette_listbox_empty">No action found</div>
+        <div t-if="!categories.length" class="o_command_palette_listbox_empty">No action found</div>
 
-      <t t-foreach="categories" t-as="category">
+        <t t-foreach="categories" t-as="category">
 
-        <div class="o_command_category">
+          <div class="o_command_category">
 
-          <t t-foreach="category.commands" t-as="command">
-            <t t-set="commandIndex" t-value="state.commands.indexOf(command)" />
-            <span t-attf-id="o_command_{{commandIndex}}" class="o_command" t-att-class="{ focused: state.selectedCommand === command }" t-on-click="onCommandClicked(commandIndex)" t-on-mouseenter="onCommandMouseEnter(commandIndex)">
-              <span t-esc="command.name" />
-              <span t-if="command.hotkey">
-                <t t-foreach="command.hotkey.toUpperCase().split('+')" t-as="key">
-                  <kbd t-esc="key" />
-                  <span t-if="!key_last"> + </span>
-                </t>
+            <t t-foreach="category.commands" t-as="command">
+              <t t-set="commandIndex" t-value="state.commands.indexOf(command)" />
+              <span t-attf-id="o_command_{{commandIndex}}" class="o_command" t-att-class="{ focused: state.selectedCommand === command }" t-on-click="onCommandClicked(commandIndex)" t-on-mouseenter="onCommandMouseEnter(commandIndex)">
+                <span t-esc="command.name" />
+                <span t-if="command.hotkey">
+                  <t t-foreach="command.hotkey.toUpperCase().split('+')" t-as="key">
+                    <kbd t-esc="key" />
+                    <span t-if="!key_last"> + </span>
+                  </t>
+                </span>
               </span>
-            </span>
-          </t>
+            </t>
 
-        </div>
+          </div>
 
-        <hr t-if="!category_last" />
+          <hr t-if="!category_last" />
 
-      </t>
+        </t>
+
+      </div>
 
     </div>
-
-  </div>
-
+  </t>
 </templates>

--- a/addons/web/static/src/components/dropdown/dropdown.xml
+++ b/addons/web/static/src/components/dropdown/dropdown.xml
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <div class="o_dropdown" t-name="web.Dropdown" t-on-dropdown-item-selected="onItemSelected" owl="1">
-    <button
-      t-attf-class="o_dropdown_toggler {{ props.togglerClass || '' }}"
-      t-att-class="{ 'o_dropdown_active': state.open }"
-      t-on-click="onTogglerClick"
-      t-on-mouseenter="onTogglerMouseEnter"
-      t-att-title="props.title"
-      t-att-data-hotkey="props.hotkey">
-      <span>
-        <t t-slot="default" />
-      </span>
-    </button>
-    <ul t-if="state.open" class="o_dropdown_menu" t-att-class="props.menuClass">
-      <t t-slot="menu" />
-    </ul>
-  </div>
+
+  <t t-name="web.Dropdown" owl="1">
+    <div class="o_dropdown" t-on-dropdown-item-selected="onItemSelected">
+      <button
+        t-attf-class="o_dropdown_toggler {{ props.togglerClass || '' }}"
+        t-att-class="{ 'o_dropdown_active': state.open }"
+        t-on-click="onTogglerClick"
+        t-on-mouseenter="onTogglerMouseEnter"
+        t-att-title="props.title"
+        t-att-data-hotkey="props.hotkey">
+        <span>
+          <t t-slot="default" />
+        </span>
+      </button>
+      <ul t-if="state.open" class="o_dropdown_menu" t-att-class="props.menuClass">
+        <t t-slot="menu" />
+      </ul>
+    </div>
+  </t>
+
 </templates>

--- a/addons/web/static/src/components/dropdown/dropdown_item.xml
+++ b/addons/web/static/src/components/dropdown/dropdown_item.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <li t-name="web.DropdownItem" class="o_dropdown_item" t-on-click="onClick" t-att-title="props.title" t-att-data-hotkey="props.hotkey" owl="1">
-    <span>
-      <t t-slot="default" />
-    </span>
-  </li>
+  <t t-name="web.DropdownItem" owl="1">
+    <li class="o_dropdown_item" t-on-click="onClick" t-att-title="props.title" t-att-data-hotkey="props.hotkey">
+      <span>
+        <t t-slot="default" />
+      </span>
+    </li>
+  </t>
 
 </templates>

--- a/addons/web/static/src/effects/rainbow_man.xml
+++ b/addons/web/static/src/effects/rainbow_man.xml
@@ -1,49 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <div t-name="web.RainbowMan"
-         class="o_reward"
-         t-on-animationend="_onAnimationEnd"
-         owl="1">
-        <svg class="o_reward_rainbow" viewBox="0 0 340 180">
-            <path d="M270,170a100,100,0,0,0-200,0" style="stroke:#FF9E80;"/>
-            <path d="M290,170a120,120,0,0,0-240,0" style="stroke:#FFE57F;"/>
-            <path d="M310,170a140,140,0,0,0-280,0" style="stroke:#80D8FF;"/>
-            <path d="M330,170a160,160,0,0,0-320,0" style="stroke:#c794ba;"/>
-        </svg>
-        <div class="o_reward_stars" t-foreach="[1, 2, 3, 4]" t-as="star">
-            <t t-call="web.RainbowMan.Star">
-                <t t-set="class" t-value="star"/>
-            </t>
-        </div>
-        <div class="o_reward_face_group">
-            <svg style="display:none">
-                <symbol id="thumb">
-                    <path d="M10,52 C6,51 3,48 3,44 C2,42 3,39 5,38 C3,36 2,34 2,32 C2,29 3,27 5,26 C3,24 2,21 2,19 C2,15 7,12 10,12 L23,12 C23,11 23,11 23,11 L23,10 C23,8 24,6 25,4 C27,2 29,2 31,2 C33,2 35,2 36,4 C38,5 39,7 39,10 L39,38 C39,41 37,45 35,47 C32,50 28,51 25,52 L10,52 L10,52 Z" fill="#FBFBFC"/>
-                    <polygon fill="#ECF1FF" points="25 11 25 51 5 52 5 12"/>
-                    <path d="M31,0 C28,0 26,1 24,3 C22,5 21,7 21,10 L10,10 C8,10 6,11 4,12 C2,14 1,16 1,19 C1,21 1,24 2,26 C1,27 1,29 1,32 C1,34 1,36 2,38 C1,40 0,42 1,45 C1,50 5,53 10,54 L25,54 C29,54 33,52 36,49 C39,46 41,42 41,38 L41,10 C41,4 36,3.38176876e-16 31,0 M31,4 C34,4 37,6 37,10 L37,38 C37,41 35,44 33,46 C31,48 28,49 25,50 L10,50 C7,49 5,47 5,44 C4,41 6,38 9,37 L9,37 C6,37 5,35 5,32 C5,28 6,26 9,26 L9,26 C6,26 5,22 5,19 C5,16 8,14 11,14 L23,14 C24,14 25,12 25,11 L25,10 C25,7 28,4 31,4" id="Shape" fill="#A1ACBA"/>
-                </symbol>
-            </svg>
-            <span class="o_reward_face" t-attf-style="background-image:url({{props.imgUrl}});"/>
 
-            <svg class="o_reward_thumbup" viewBox="0 0 42 60">
-                <use href="#thumb"/>
+    <t t-name="web.RainbowMan" owl="1">
+        <div class="o_reward" t-on-animationend="_onAnimationEnd">
+            <svg class="o_reward_rainbow" viewBox="0 0 340 180">
+                <path d="M270,170a100,100,0,0,0-200,0" style="stroke:#FF9E80;"/>
+                <path d="M290,170a120,120,0,0,0-240,0" style="stroke:#FFE57F;"/>
+                <path d="M310,170a140,140,0,0,0-280,0" style="stroke:#80D8FF;"/>
+                <path d="M330,170a160,160,0,0,0-320,0" style="stroke:#c794ba;"/>
             </svg>
-
-            <div class="o_reward_msg_container">
-                <svg class="o_reward_thumb_right" viewBox="0 0 100 55">
-                    <use href="#thumb" transform="scale(-1, 1.2) rotate(-90) translate(-42,-60)"/>
+            <div class="o_reward_stars" t-foreach="[1, 2, 3, 4]" t-as="star">
+                <t t-call="web.RainbowMan.Star">
+                    <t t-set="class" t-value="star"/>
+                </t>
+            </div>
+            <div class="o_reward_face_group">
+                <svg style="display:none">
+                    <symbol id="thumb">
+                        <path d="M10,52 C6,51 3,48 3,44 C2,42 3,39 5,38 C3,36 2,34 2,32 C2,29 3,27 5,26 C3,24 2,21 2,19 C2,15 7,12 10,12 L23,12 C23,11 23,11 23,11 L23,10 C23,8 24,6 25,4 C27,2 29,2 31,2 C33,2 35,2 36,4 C38,5 39,7 39,10 L39,38 C39,41 37,45 35,47 C32,50 28,51 25,52 L10,52 L10,52 Z" fill="#FBFBFC"/>
+                        <polygon fill="#ECF1FF" points="25 11 25 51 5 52 5 12"/>
+                        <path d="M31,0 C28,0 26,1 24,3 C22,5 21,7 21,10 L10,10 C8,10 6,11 4,12 C2,14 1,16 1,19 C1,21 1,24 2,26 C1,27 1,29 1,32 C1,34 1,36 2,38 C1,40 0,42 1,45 C1,50 5,53 10,54 L25,54 C29,54 33,52 36,49 C39,46 41,42 41,38 L41,10 C41,4 36,3.38176876e-16 31,0 M31,4 C34,4 37,6 37,10 L37,38 C37,41 35,44 33,46 C31,48 28,49 25,50 L10,50 C7,49 5,47 5,44 C4,41 6,38 9,37 L9,37 C6,37 5,35 5,32 C5,28 6,26 9,26 L9,26 C6,26 5,22 5,19 C5,16 8,14 11,14 L23,14 C24,14 25,12 25,11 L25,10 C25,7 28,4 31,4" id="Shape" fill="#A1ACBA"/>
+                    </symbol>
                 </svg>
-                <div class="o_reward_msg">
-                    <div class="o_reward_msg_card">
-                        <div class="o_reward_msg_content"><t t-raw="props.message" /></div>
-                        <div class="o_reward_shadow_container">
-                            <div class="o_reward_shadow"/>
+                <span class="o_reward_face" t-attf-style="background-image:url({{props.imgUrl}});"/>
+
+                <svg class="o_reward_thumbup" viewBox="0 0 42 60">
+                    <use href="#thumb"/>
+                </svg>
+
+                <div class="o_reward_msg_container">
+                    <svg class="o_reward_thumb_right" viewBox="0 0 100 55">
+                        <use href="#thumb" transform="scale(-1, 1.2) rotate(-90) translate(-42,-60)"/>
+                    </svg>
+                    <div class="o_reward_msg">
+                        <div class="o_reward_msg_card">
+                            <div class="o_reward_msg_content"><t t-raw="props.message" /></div>
+                            <div class="o_reward_shadow_container">
+                                <div class="o_reward_shadow"/>
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
+    </t>
+
     <t t-name="web.RainbowMan.Star" owl="1">
         <svg t-attf-class="star{{ star }}" width="35px" height="34px" viewBox="0 0 35 34">
             <path fill="#fff" d="M33,15.9 C26.3557814,13.6951256 21.1575294,8.45974313 19,1.8 C19,1.24771525 18.5522847,0.8 18,0.8 C17.4477153,0.8 17,1.24771525 17,1.8 C14.6431206,8.69377078 9.02624222,13.9736364 2,15.9 C1.36487254,15.9 0.85,16.4148725 0.85,17.05 C0.85,17.6851275 1.36487254,18.2 2,18.2 C8.6215326,20.3844521 13.8155479,25.5784674 16,32.2 C16,32.7522847 16.4477153,33.2 17,33.2 C17.5522847,33.2 18,32.7522847 18,32.2 C20.3568794,25.3062292 25.9737578,20.0263636 33,18.1 C33.6351275,18.1 34.15,17.5851275 34.15,16.95 C34.15,16.3148725 33.6351275,15.8 33,15.8"></path>

--- a/addons/web/static/src/notifications/notification.xml
+++ b/addons/web/static/src/notifications/notification.xml
@@ -1,29 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <div t-name="web.NotificationWowl" t-attf-class="o_notification {{className}}"
-         role="alert" aria-live="assertive" aria-atomic="true" owl="1">
-        <div class="o_notification_body">
-            <button type="button" class="close o_notification_close"
+    <t t-name="web.NotificationWowl" owl="1">
+        <div t-attf-class="o_notification {{className}}"
+        role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="o_notification_body">
+                <button type="button" class="close o_notification_close"
                 aria-label="Close"
-                t-on-click="notificationService.close(props.id)">
-                <span class="d-inline" aria-hidden="true">×</span>
-            </button>
-            <div t-if="props.title" class="font-weight-bold o_notification_title mb-1" t-raw="props.title"/>
-            <div t-if="props.message" t-raw="props.message" class="mr-auto o_notification_content"/>
-            <div t-if="props.buttons.length" class="mt-2 o_notification_buttons">
-                <button t-foreach="props.buttons" t-as="button" type="button"
-                        t-attf-class="btn {{button.primary ? 'btn-primary' : 'btn-link'}}" t-on-click="button.onClick()">
+                    t-on-click="notificationService.close(props.id)">
+                    <span class="d-inline" aria-hidden="true">×</span>
+                </button>
+                <div t-if="props.title" class="font-weight-bold o_notification_title mb-1" t-raw="props.title"/>
+                <div t-if="props.message" t-raw="props.message" class="mr-auto o_notification_content"/>
+                <div t-if="props.buttons.length" class="mt-2 o_notification_buttons">
+                    <button t-foreach="props.buttons" t-as="button" type="button"
+                    t-attf-class="btn {{button.primary ? 'btn-primary' : 'btn-link'}}" t-on-click="button.onClick()">
                     <t t-if="button.icon">
                         <i t-if="button.icon.indexOf('fa-') === 0" role="img"
-                            t-att-aria-label="button.name" t-att-title="button.name"
-                            t-attf-class="fa fa-fw o_button_icon {{button.icon}}"/>
+                        t-att-aria-label="button.name" t-att-title="button.name"
+                        t-attf-class="fa fa-fw o_button_icon {{button.icon}}"/>
                         <img t-else="" t-att-src="button.icon" t-att-alt="button.name"/>
                     </t>
                     <span t-esc="button.name"/>
                 </button>
+                </div>
             </div>
         </div>
-    </div>
+    </t>
 
 </templates>

--- a/addons/web/static/src/webclient/loading_indicator/loading_indicator.xml
+++ b/addons/web/static/src/webclient/loading_indicator/loading_indicator.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <div t-name="web.LoadingIndicator" class="o_loading_indicator" owl="1">
-        <span t-if="state.show" class="o_loading" t-transition="fade">
-            <t>Loading<t t-if="env.debug" t-esc="' (' + state.count + ')'" /></t>
-        </span>
-    </div>
+    <t t-name="web.LoadingIndicator" owl="1">
+        <div class="o_loading_indicator">
+            <span t-if="state.show" class="o_loading" t-transition="fade">
+                <t>Loading<t t-if="env.debug" t-esc="' (' + state.count + ')'" /></t>
+            </span>
+        </div>
+    </t>
 
 </templates>

--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -1,96 +1,97 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <header t-name="web.NavBar" owl="1">
-    <nav class="o_main_navbar" t-on-dropdown-item-selected="onNavBarDropdownItemSelection" data-command-category="navbar">
-      <!-- Apps Menu -->
-      <t t-call="web.NavBar.AppsMenu">
-        <t t-set="apps" t-value="menuService.getApps()" />
-      </t>
-
-      <!-- App Brand -->
-      <DropdownItem
-        t-if="currentApp"
-        class="o_menu_brand"
-        payload="currentApp"
-        t-esc="currentApp.name"
-        t-ref="menuBrand"/>
-
-      <!-- Current App Sections -->
-      <t t-call="web.NavBar.SectionsMenu">
-        <t t-set="sections" t-value="currentAppSections" />
-      </t>
-
-      <!-- Systray -->
-      <ul class="o_menu_systray" role="menu">
-        <t t-foreach="systrayItems" t-as="Item" t-key="Item_index">
-          <t t-component="Item" />
+  <t t-name="web.NavBar" owl="1">
+    <header>
+      <nav class="o_main_navbar" t-on-dropdown-item-selected="onNavBarDropdownItemSelection" data-command-category="navbar">
+        <!-- Apps Menu -->
+        <t t-call="web.NavBar.AppsMenu">
+          <t t-set="apps" t-value="menuService.getApps()" />
         </t>
-      </ul>
-    </nav>
-  </header>
 
-  <Dropdown t-name="web.NavBar.AppsMenu" owl="1"
-    hotkey="'h'"
-    title="'Home Menu'"
-    class="o_navbar_apps_menu"
-  >
-    <i class="fa fa-th-large" />
-    <t t-set-slot="menu">
-      <MenuItem
-        t-foreach="apps" t-as="app" t-key="app.id"
-        class="o_app"
-        t-att-class="{ o_dropdown_active: menuService.getCurrentApp() === app }"
-        payload="app"
-        t-esc="app.name" />
-    </t>
-  </Dropdown>
+        <!-- App Brand -->
+        <DropdownItem
+          t-if="currentApp"
+          class="o_menu_brand"
+          payload="currentApp"
+          t-esc="currentApp.name"
+          t-ref="menuBrand"/>
 
-  <ul t-name="web.NavBar.SectionsMenu" class="o_menu_sections" t-ref="appSubMenus" role="menu" owl="1">
-    <t
-      t-foreach="sections"
-      t-as="section"
-      t-key="section.id">
+        <!-- Current App Sections -->
+        <t t-call="web.NavBar.SectionsMenu">
+          <t t-set="sections" t-value="currentAppSections" />
+        </t>
 
-      <t t-set="sectionsVisibleCount" t-value="(sections.length - currentAppSectionsExtra.length)" />
+        <!-- Systray -->
+        <ul class="o_menu_systray" role="menu">
+          <t t-foreach="systrayItems" t-as="Item" t-key="Item_index">
+            <t t-component="Item" />
+          </t>
+        </ul>
+      </nav>
+    </header>
+  </t>
 
-      <t t-if="section_index lt Math.min(10, sectionsVisibleCount)">
-        <t t-set="hotkey" t-value="((section_index + 1) % 10).toString()"/>
+  <t t-name="web.NavBar.AppsMenu" owl="1">
+    <Dropdown hotkey="'h'" title="'Home Menu'" class="o_navbar_apps_menu">
+      <i class="fa fa-th-large" />
+      <t t-set-slot="menu">
+        <MenuItem
+          t-foreach="apps" t-as="app" t-key="app.id"
+          class="o_app"
+          t-att-class="{ o_dropdown_active: menuService.getCurrentApp() === app }"
+          payload="app"
+          t-esc="app.name" />
       </t>
-      <t t-else="">
-        <t t-set="hotkey" t-value="undefined"/>
+    </Dropdown>
+  </t>
+
+  <t t-name="web.NavBar.SectionsMenu" owl="1">
+    <ul class="o_menu_sections" t-ref="appSubMenus" role="menu">
+
+      <t t-foreach="sections" t-as="section" t-key="section.id">
+        <t t-set="sectionsVisibleCount" t-value="(sections.length - currentAppSectionsExtra.length)" />
+
+        <t t-if="section_index lt Math.min(10, sectionsVisibleCount)">
+          <t t-set="hotkey" t-value="((section_index + 1) % 10).toString()"/>
+        </t>
+        <t t-else="">
+          <t t-set="hotkey" t-value="undefined"/>
+        </t>
+
+        <t t-if="!section.childrenTree.length">
+          <MenuItem title="section.name" payload="section" hotkey="hotkey">
+            <span t-esc="section.name" t-att-data-section="section.id" />
+          </MenuItem>
+        </t>
+        <t t-else="" t-call="web.NavBar.SectionsMenu.Dropdown">
+          <t t-set="sectionId" t-value="section.id" />
+          <t t-set="name" t-value="section.name" />
+          <t t-set="items" t-value="section.childrenTree" />
+          <t t-set="hotkey" t-value="hotkey"/>
+        </t>
       </t>
 
-      <MenuItem t-if="!section.childrenTree.length" title="section.name" payload="section" hotkey="hotkey">
-        <span t-esc="section.name" t-att-data-section="section.id" />
-      </MenuItem>
-
-      <t t-else="" t-call="web.NavBar.SectionsMenu.Dropdown">
-        <t t-set="sectionId" t-value="section.id" />
-        <t t-set="name" t-value="section.name" />
-        <t t-set="items" t-value="section.childrenTree" />
-        <t t-set="hotkey" t-value="hotkey"/>
+      <t t-call="web.NavBar.SectionsMenu.MoreDropdown">
+        <t t-set="sections" t-value="currentAppSectionsExtra" />
+        <t t-if="sectionsVisibleCount lt 10">
+          <t t-set="hotkey" t-value="(sectionsVisibleCount + 1 % 10).toString()"/>
+        </t>
       </t>
 
-    </t>
+    </ul>
+  </t>
 
-    <t t-call="web.NavBar.SectionsMenu.MoreDropdown">
-      <t t-set="sections" t-value="currentAppSectionsExtra" />
-      <t t-if="sectionsVisibleCount lt 10">
-        <t t-set="hotkey" t-value="(sectionsVisibleCount + 1 % 10).toString()"/>
+  <t t-name="web.NavBar.SectionsMenu.Dropdown" owl="1">
+    <Dropdown hotkey="hotkey" title="name">
+      <span t-esc="name" t-att-data-section="sectionId" />
+      <t t-set-slot="menu">
+        <t t-call="web.NavBar.SectionsMenu.Dropdown.MenuSlot">
+          <t t-set="items" t-value="items" />
+        </t>
       </t>
-    </t>
-
-  </ul>
-
-  <Dropdown t-name="web.NavBar.SectionsMenu.Dropdown" hotkey="hotkey" title="name" owl="1" >
-    <span t-esc="name" t-att-data-section="sectionId" />
-    <t t-set-slot="menu">
-      <t t-call="web.NavBar.SectionsMenu.Dropdown.MenuSlot">
-        <t t-set="items" t-value="items" />
-      </t>
-    </t>
-  </Dropdown>
+    </Dropdown>
+  </t>
 
   <t t-name="web.NavBar.SectionsMenu.Dropdown.MenuSlot" owl="1">
     <t t-foreach="items" t-as="item" t-key="item.id">
@@ -109,35 +110,30 @@
     </t>
   </t>
 
-  <Dropdown t-name="web.NavBar.SectionsMenu.MoreDropdown"
-            class="o_menu_sections_more d-none"
-            title="'More Menu'"
-            hotkey="hotkey"
-            owl="1">
-    <i class="fa fa-plus"/>
-    <t t-set-slot="menu">
-      <t
-        t-foreach="sections"
-        t-as="section"
-        t-key="section.id">
+  <t t-name="web.NavBar.SectionsMenu.MoreDropdown" owl="1">
+    <Dropdown class="o_menu_sections_more d-none" title="'More Menu'" hotkey="hotkey">
+      <i class="fa fa-plus"/>
+      <t t-set-slot="menu">
+        <t t-foreach="sections" t-as="section" t-key="section.id">
 
-        <MenuItem
-          t-if="!section.childrenTree.length"
-          class="o_more_dropdown_section"
-          payload="section"
-          t-esc="section.name" />
-
-        <t t-else="">
-          <div
-            class="o_more_dropdown_section o_more_dropdown_section_group"
-            t-esc="section.name" />
-          <t t-call="web.NavBar.SectionsMenu.Dropdown.MenuSlot">
-            <t t-set="items" t-value="section.childrenTree" />
+          <t t-if="!section.childrenTree.length">
+            <MenuItem
+              class="o_more_dropdown_section"
+              payload="section"
+              t-esc="section.name" />
           </t>
+          <t t-else="">
+            <div
+              class="o_more_dropdown_section o_more_dropdown_section_group"
+              t-esc="section.name" />
+            <t t-call="web.NavBar.SectionsMenu.Dropdown.MenuSlot">
+              <t t-set="items" t-value="section.childrenTree" />
+            </t>
+          </t>
+ 
         </t>
-
       </t>
-    </t>
-  </Dropdown>
+    </Dropdown>
+  </t>
 
 </templates>

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
@@ -1,41 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<li t-name="web.SwitchCompanyMenu" class="o_switch_company_menu" owl="1">
-    <Dropdown>
-        <span t-attf-class="{{env.isSmall ? 'fa fa-building-o' : 'oe_topbar_name'}}">
-            <t t-if="!env.isSmall"><t t-esc="user.current_company.name"/></t>
-        </span>
-        <t t-set-slot="menu">
-            <t t-foreach="user.allowed_companies" t-as="company_id">
-                <t t-call="web.SwitchCompanyItem">
-                    <t t-set="company" t-value="user.allowed_companies[company_id]" />
+<t t-name="web.SwitchCompanyMenu" owl="1">
+    <li class="o_switch_company_menu">
+        <Dropdown>
+            <span t-attf-class="{{env.isSmall ? 'fa fa-building-o' : 'oe_topbar_name'}}">
+                <t t-if="!env.isSmall"><t t-esc="user.current_company.name"/></t>
+            </span>
+            <t t-set-slot="menu">
+                <t t-foreach="user.allowed_companies" t-as="company_id">
+                    <t t-call="web.SwitchCompanyItem">
+                        <t t-set="company" t-value="user.allowed_companies[company_id]" />
+                    </t>
                 </t>
             </t>
-        </t>
-    </Dropdown>
-</li>
+        </Dropdown>
+    </li>
+</t>
 
-<div t-name="web.SwitchCompanyItem" owl="1">
-    <t t-set="isCompanySelected" t-value="user.context.allowed_company_ids.includes(company.id)"/>
-    <t t-set="isCurrent" t-value="company.id === user.current_company.id"/>
-    <DropdownItem>
-        <div class="dropdown-item d-flex py-0 px-0" data-menu="company" t-att-data-company-id="company.id">
-            <div role="menuitemcheckbox"
-                t-att-aria-checked="isCompanySelected" t-att-aria-label="company.name" tabindex="0" class="ml-auto pl-3 pr-3 border border-top-0 border-left-0   border-bottom-0 toggle_company o_py"
-                t-on-click="toggleCompany(company.id)">
-                <span style="height: 2rem;">
-                    <i class="fa fa-fw pt-2" t-attf-class="{{isCompanySelected ? 'fa-check-square' : 'fa-square-o'}}"/>
-                </span>
+
+<t t-name="web.SwitchCompanyItem" owl="1">
+    <div>
+        <t t-set="isCompanySelected" t-value="user.context.allowed_company_ids.includes(company.id)"/>
+        <t t-set="isCurrent" t-value="company.id === user.current_company.id"/>
+        <DropdownItem>
+            <div class="dropdown-item d-flex py-0 px-0" data-menu="company" t-att-data-company-id="company.id">
+                <div
+                    role="menuitemcheckbox"
+                    t-att-aria-checked="isCompanySelected"
+                    t-att-aria-label="company.name"
+                    tabindex="0"
+                    class="ml-auto pl-3 pr-3 border border-top-0 border-left-0 border-bottom-0 toggle_company o_py"
+                    t-on-click="toggleCompany(company.id)">
+
+                    <span style="height: 2rem;">
+                        <i class="fa fa-fw pt-2" t-attf-class="{{isCompanySelected ? 'fa-check-square' : 'fa-square-o'}}"/>
+                    </span>
+
+                </div>
+
+                <div
+                    role="button"
+                    t-att-aria-pressed="isCurrent"
+                    aria-label="Switch to this company"
+                    tabindex="0"
+                    class="d-flex flex-grow-1 align-items-center py-0 log_into pl-3 o_py"
+                    t-attf-style="{{isCurrent ? 'background-color: lightgrey;' : ''}}"
+                    t-on-click="logIntoCompany(company.id)">
+
+                    <span class='mr-3 company_label' t-attf-class="{{isCompanySelected ? '' : 'text-muted'}}">
+                        <t t-esc="company.name"/>
+                    </span>
+
+                </div>
             </div>
-            <div role="button" t-att-aria-pressed="isCurrent" aria-label="Switch to this company" tabindex="0" class="d-flex flex-grow-1 align-items-center py-0 log_into pl-3 o_py" t-attf-style="{{isCurrent ? 'background-color: lightgrey;' : ''}}"
-                t-on-click="logIntoCompany(company.id)">
-                <span class='mr-3 company_label' t-attf-class="{{isCompanySelected ? '' : 'text-muted'}}">
-                    <t t-esc="company.name"/>
-                </span>
-            </div>
-        </div>
-    </DropdownItem>
-</div>
+        </DropdownItem>
+    </div>
+</t>
 
 </templates>

--- a/addons/web/static/src/webclient/webclient.xml
+++ b/addons/web/static/src/webclient/webclient.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <body t-name="web.WebClient" class="o_web_client" owl="1">
-        <NavBar/>
-        <ActionContainer/>
-        <div class="o_dialog_container"/>
-        <div>
-            <t t-foreach="Components" t-as="Component" t-key="Component[0]">
-                <t t-component="Component[1]"/>
-            </t>
-        </div>
-    </body>
+    <t t-name="web.WebClient" owl="1">
+        <body class="o_web_client">
+            <NavBar/>
+            <ActionContainer/>
+            <div class="o_dialog_container"/>
+            <div>
+                <t t-foreach="Components" t-as="Component" t-key="Component[0]">
+                    <t t-component="Component[1]"/>
+                </t>
+            </div>
+        </body>
+    </t>
 
 </templates>


### PR DESCRIPTION
This commit makes sure that every defined template
(new webclient version) uses an empty tag instead of any other tag.

We chose by convention to always put [t-name] attributes on `t` tags.

While using any other tag in conjunction with a [t-name] attribute
works, it forces templates that inherits to be aware of this root tag.

https://github.com/odoo-dev/enterprise/pull/81