### PR TITLE
[FIX/IMP] web: parseNumber with multiple thousand separators

### DIFF
--- a/addons/web/static/src/utils/numbers.js
+++ b/addons/web/static/src/utils/numbers.js
@@ -35,7 +35,9 @@ function insertThousandsSep(num, thousandsSep = ",", grouping = [3, 0]) {
  * @returns number
  */
 function parseNumber(value, options = {}) {
-  value = value.replace(options.thousandsSep || ",", "");
+  // a number can have the thousand separator multiple times. ex: 1,000,000.00
+  value = value.replaceAll(options.thousandsSep || ",", "");
+  // a number only have one decimal separator
   value = value.replace(options.decimalPoint || ".", ".");
   return Number(value);
 }


### PR DESCRIPTION
Before this commit, an error was raised when parsing a Number with
multiple thousand separators. This commit added also tests of
parseNumber.