### PR TITLE
[IMP] web: configure fake localization service

### DIFF
--- a/addons/web/static/tests/helpers/mock_services.js
+++ b/addons/web/static/tests/helpers/mock_services.js
@@ -30,8 +30,11 @@ export const defaultLocalization = {
     weekStart: 7,
 };
 
-export function makeFakeLocalizationService() {
-    patchWithCleanup(localization, defaultLocalization);
+/**
+ * @param {Partial<typeof defaultLocalization>} [config]
+ */
+export function makeFakeLocalizationService(config = {}) {
+    patchWithCleanup(localization, Object.assign({}, defaultLocalization, config));
 
     return {
         name: "localization",


### PR DESCRIPTION
The `makeFakeLocalizationService` test helper could not be configurated.