### PR TITLE
[FIX] web: remove else when removing sibling target of the popover

### DIFF
--- a/addons/web/static/src/components/popover/popover.js
+++ b/addons/web/static/src/components/popover/popover.js
@@ -247,20 +247,9 @@ export class Popover extends Component {
    * Closes the popover when the target is removed from dom.
    */
   onTargetMutate() {
-    const target = this.target;
-    if (!target) {
+    if (!this.target) {
       this.disconnectTargetObserver();
       this.trigger("popover-closed");
-    } else {
-      for (const mutation of mutations) {
-        for (const node of mutation.removedNodes) {
-          if (node === target) {
-            this.disconnectTargetObserver();
-            this.trigger("popover-closed");
-            break;
-          }
-        }
-      }
     }
   }
 }

--- a/addons/web/static/tests/components/popover_tests.js
+++ b/addons/web/static/tests/components/popover_tests.js
@@ -304,12 +304,13 @@ QUnit.test("Target click", async function (assert) {
 });
 
 QUnit.test("close popover when target is removed", async function (assert) {
-  assert.expect(3);
+  assert.expect(4);
 
   class Parent extends Component {}
   Parent.components = { Popover };
   Parent.template = xml`
     <div class="d-flex h-25 justify-content-around align-items-start">
+      <button id="siblingTarget">SiblingTarget</button>
       <button id="target">target</button>
       <Popover target="'#target'">
         <t t-set-slot="content">
@@ -324,6 +325,10 @@ QUnit.test("close popover when target is removed", async function (assert) {
 
   await click(target, "#target");
   assert.containsOnce(target, ".o_popover", "Should contain one popover");
+
+  target.querySelector("#siblingTarget").remove();
+  await nextTick();
+  assert.containsOnce(target, ".o_popover", "When a target sibling is removed the popover should be shown");
 
   target.querySelector("#target").remove();
   await nextTick();


### PR DESCRIPTION
When a sibling of the target of a popover is removed from the DOM, the
code shouldn't remove the popover.