### PR TITLE
[FIX] web: correct display of action menus

### DIFF
--- a/addons/web/static/src/components/dropdown/dropdown.scss
+++ b/addons/web/static/src/components/dropdown/dropdown.scss
@@ -1,5 +1,5 @@
 .o_dropdown {
-  display: block;
+  display: inline-block;
   position: relative;
 }
 


### PR DESCRIPTION
Before this commit when multiple actions menus exists they are display
one on top of the other.

Now, the actions menus are display inline