### PR TITLE
[FIX] web: Handle ALL errors

### DIFF
--- a/addons/web/doc/crash_manager_and_errors.md
+++ b/addons/web/doc/crash_manager_and_errors.md
@@ -10,7 +10,7 @@ Note: if you're a backend dev just willing to display a different dialog from an
 
 ## The net and the dispatcher
 
-Any error that is not caugh (meaning that is is not handled by a try / catch block for example) will eventually bubble up all the way until it reaches what we call the net. The net is made of event listeners on the global window object, listening for errors and rejected promises. The net is an analogy to a safety net that would catch things at the last moment. Once caught, the error is cast if needed to an instance of OdooError and send with the bus to the error dispatcher.
+Any error that is not caught (meaning that is is not handled by a try / catch block for example) will eventually bubble up all the way until it reaches what we call the net. The net is made of event listeners on the global window object, listening for errors and rejected promises. The net is an analogy to a safety net that would catch things at the last moment. Once caught, the error is cast if needed to an instance of OdooError and send with the bus to the error dispatcher.
 
 ```js
 // this is pseudo code

--- a/addons/web/static/src/actions/action_service.js
+++ b/addons/web/static/src/actions/action_service.js
@@ -10,6 +10,7 @@ import { sprintf } from "../utils/strings";
 import { viewRegistry } from "../views/view_registry";
 import { serviceRegistry } from "../webclient/service_registry";
 import { actionRegistry } from "./action_registry";
+import { OdooError } from "../errors/odoo_error";
 
 const { Component, hooks, tags } = owl;
 
@@ -22,17 +23,15 @@ export function clearUncommittedChanges(env) {
 // -----------------------------------------------------------------------------
 // Errors
 // -----------------------------------------------------------------------------
-export class ViewNotFoundError extends Error {
+export class ViewNotFoundError extends OdooError {
   constructor() {
-    super(...arguments);
-    this.name = "ViewNotFoundError";
+    super("ViewNotFoundError", ...arguments);
   }
 }
 
-export class ControllerNotFoundError extends Error {
+export class ControllerNotFoundError extends OdooError {
   constructor() {
-    super(...arguments);
-    this.name = "ControllerNotFoundError";
+    super("ControllerNotFoundError", ...arguments);
   }
 }
 

--- a/addons/web/static/src/actions/action_service.js
+++ b/addons/web/static/src/actions/action_service.js
@@ -2,6 +2,7 @@
 
 import { browser } from "../core/browser";
 import { makeContext } from "../core/context";
+import { ControllerNotFoundError, ViewNotFoundError } from "../errors/odoo_error";
 import { evaluateExpr } from "../py_js/py";
 import { KeepLast } from "../utils/concurrency";
 import { download } from "../utils/download";
@@ -10,7 +11,6 @@ import { sprintf } from "../utils/strings";
 import { viewRegistry } from "../views/view_registry";
 import { serviceRegistry } from "../webclient/service_registry";
 import { actionRegistry } from "./action_registry";
-import { OdooError } from "../errors/odoo_error";
 
 const { Component, hooks, tags } = owl;
 
@@ -18,21 +18,6 @@ export function clearUncommittedChanges(env) {
   const callbacks = [];
   env.bus.trigger("CLEAR-UNCOMMITTED-CHANGES", callbacks);
   return Promise.all(callbacks.map((fn) => fn()));
-}
-
-// -----------------------------------------------------------------------------
-// Errors
-// -----------------------------------------------------------------------------
-export class ViewNotFoundError extends OdooError {
-  constructor() {
-    super("ViewNotFoundError", ...arguments);
-  }
-}
-
-export class ControllerNotFoundError extends OdooError {
-  constructor() {
-    super("ControllerNotFoundError", ...arguments);
-  }
 }
 
 // -----------------------------------------------------------------------------

--- a/addons/web/static/src/core/browser.js
+++ b/addons/web/static/src/core/browser.js
@@ -16,13 +16,14 @@ try {
 }
 
 export const browser = Object.assign({}, owl.browser, {
+  alert: window.alert.bind(window), // Alert needs the window context
   console: window.console,
+  localStorage,
   location: window.location,
   navigator: navigator,
   open: window.open.bind(window),
-  XMLHttpRequest: window.XMLHttpRequest,
-  localStorage,
   sessionStorage,
+  XMLHttpRequest: window.XMLHttpRequest,
 });
 
 // -----------------------------------------------------------------------------

--- a/addons/web/static/src/errors/error_handlers.js
+++ b/addons/web/static/src/errors/error_handlers.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { browser } from "../core/browser";
+import { ConnectionLostError, RPCError } from "../services/rpc_service";
 import {
   ClientErrorDialog,
   ErrorDialog,
@@ -12,7 +13,8 @@ import { errorHandlerRegistry } from "./error_handler_registry";
 
 /**
  * @typedef {import("../env").OdooEnv} OdooEnv
- * @typedef {(error: any) => boolean | void} ErrorHandler
+ * @typedef {import("./odoo_error").OdooError} OdooError
+ * @typedef {(error: OdooError) => boolean | void} ErrorHandler
  */
 
 // -----------------------------------------------------------------------------
@@ -92,7 +94,7 @@ errorHandlerRegistry.add("emptyRejectionErrorHandler", emptyRejectionErrorHandle
  */
 function rpcErrorHandler(env) {
   return (error) => {
-    if (error.name === "RPC_ERROR") {
+    if (error instanceof RPCError) {
       // When an error comes from the server, it can have an exeption name.
       // (or any string truly). It is used as key in the error dialog from
       // server registry to know which dialog component to use.
@@ -132,7 +134,7 @@ errorHandlerRegistry.add("rpcErrorHandler", rpcErrorHandler, { sequence: 98 });
 function lostConnectionHandler(env) {
   let connectionLostNotifId;
   return (error) => {
-    if (error.name === "CONNECTION_LOST_ERROR") {
+    if (error instanceof ConnectionLostError) {
       if (connectionLostNotifId) {
         // notification already displayed (can occur if there were several
         // concurrent rpcs when the connection was lost)
@@ -185,7 +187,6 @@ function defaultHandler(env) {
     } else {
       browser.alert(error.message);
     }
-    browser.console.error(error.originalError);
     return true;
   };
 }

--- a/addons/web/static/src/errors/error_service.js
+++ b/addons/web/static/src/errors/error_service.js
@@ -3,14 +3,46 @@
 import { browser, isBrowserChrome } from "../core/browser";
 import { serviceRegistry } from "../webclient/service_registry";
 import { errorHandlerRegistry } from "./error_handler_registry";
-import { OdooError } from "./odoo_error";
+import { UncaughtClientError, UnknownCorsError } from "./odoo_error";
+/** @owlnext */
+// import { UncaughtEmptyRejectionError, UncaughtObjectRejectionError } from "./odoo_error";
 
 export const errorService = {
   start(env) {
     const handlers = errorHandlerRegistry.getAll().map((builder) => builder(env));
 
+    /**
+     * Returns a traceback built from a given error. This traceback is formatted
+     * the same way as a stack trace in chromium-based browsers. Example:
+     *
+     *  Traceback:
+     *
+     *  Error: Can't write value
+     *      at _onOpenFormView (http://localhost:8069/web/content/425-baf33f1/web.assets.js:1064:30)
+     *      ...
+     *
+     * @param {Error} error
+     * @returns {string}
+     */
+    function buildTraceback(error) {
+      let stack;
+      if (error.stack && isBrowserChrome()) {
+        stack = error.stack;
+      } else {
+        const chromiumStackLines = (error.stack || "")
+          .split("\n")
+          .filter(Boolean)
+          .map((l) => `\n    ${l.replace(/(.*)@(.*)/g, "at $1 ($2)").replace(/\/</g, "")}`);
+        stack = `${error.name}: ${error.message}` + chromiumStackLines.join("");
+      }
+      return `${env._t("Traceback")}:\n\n${stack}`;
+    }
+
     function handleError(error) {
       browser.console.error(error);
+      if (!error.traceback) {
+        error.traceback = buildTraceback(error);
+      }
       try {
         for (let handler of handlers) {
           if (handler(error, env)) {
@@ -20,9 +52,7 @@ export const errorService = {
         env.bus.trigger("ERROR_DISPATCHED", error);
       } catch (subError) {
         // Handles error occurring in error handlers.
-        browser.console.error(
-          env._t("An additional error occurred while handling the error above:")
-        );
+        browser.console.error(env._t("Another error occurred while handling the error above:"));
         browser.console.error(subError);
       }
     }
@@ -31,29 +61,20 @@ export const errorService = {
       const { colno, error: eventError, filename, lineno, message } = ev;
       let error;
       if (!filename && !lineno && !colno) {
-        error = new OdooError("UNKNOWN_CORS_ERROR");
+        error = new UnknownCorsError();
         error.traceback = env._t(
-          `Unknown CORS error\n\n` +
-            `An unknown CORS error occured.\n` +
-            `The error probably originates from a JavaScript file served from a different origin.\n` +
-            `(Opening your browser console might give you a hint on the error.)`
+          `Unknown CORS error
+
+An unknown CORS error occured.
+The error probably originates from a JavaScript file served from a different origin.
+(Opening your browser console might give you a hint on the error.)`
         );
       } else {
         // ignore Chrome video internal error: https://crbug.com/809574
         if (!eventError && message === "ResizeObserver loop limit exceeded") {
           return;
         }
-        let stack = eventError ? eventError.stack : "";
-        if (!isBrowserChrome()) {
-          // transforms the stack into a chromium stack
-          // Chromium stack example:
-          // Error: Mock: Can't write value
-          //     _onOpenFormView@http://localhost:8069/web/content/425-baf33f1/web.assets.js:1064:30
-          //     ...
-          stack = `${message}\n${stack}`.replace(/\n/g, "\n    ");
-        }
-        error = new OdooError("UNCAUGHT_CLIENT_ERROR");
-        error.traceback = `${message}\n\n${filename}:${lineno}\n${env._t("Traceback")}:\n${stack}`;
+        error = eventError || new UncaughtClientError(message);
       }
       handleError(error);
     });
@@ -68,21 +89,21 @@ export const errorService = {
       if (ev.reason instanceof Error) {
         // the thrown error was originally an instance of "Error"
         handleError(ev.reason);
+      } else {
+        ev.stopPropagation();
+        ev.stopImmediatePropagation();
+        ev.preventDefault();
       }
-      ev.stopPropagation();
-      ev.stopImmediatePropagation();
-      ev.preventDefault();
 
-      /** @next */
+      /** @owlnext */
       // const eventError = ev.reason;
       // let error;
       // if (eventError && eventError.message) {
       //   // the thrown value was originally a non-Error instance or a raw js object
-      //   error = new OdooError("UNCAUGHT_OBJECT_REJECTION_ERROR");
+      //   error = new UncaughtObjectRejectionError();
       //   error.traceback = JSON.stringify(eventError, Object.getOwnPropertyNames(eventError), 4);
       // } else {
-      //   error = new OdooError(
-      //     "UNCAUGHT_EMPTY_REJECTION_ERROR",
+      //   error = new UncaughtEmptyRejectionError(
       //     "A Promise reject call with no argument is not getting caught."
       //   );
       // }

--- a/addons/web/static/src/errors/odoo_error.js
+++ b/addons/web/static/src/errors/odoo_error.js
@@ -1,8 +1,17 @@
 /** @odoo-module **/
 
 export default class OdooError extends Error {
-  constructor(name) {
+  constructor(name, originalError) {
     super();
     this.name = name;
+    if (originalError) {
+      const { message, stack } = originalError;
+      this.message = message;
+      this.traceback = stack;
+      this.stack = stack;
+      this.originalError = originalError;
+    } else {
+      this.originalError = this;
+    }
   }
 }

--- a/addons/web/static/src/errors/odoo_error.js
+++ b/addons/web/static/src/errors/odoo_error.js
@@ -1,17 +1,20 @@
 /** @odoo-module **/
 
-export default class OdooError extends Error {
-  constructor(name, originalError) {
-    super();
+/**
+ * Odoo Error
+ *
+ * The point of this class is to properly extend an error: changes on properties
+ * (`name` or `message`) outside the constructor will not be reflected in the stack
+ * or the appearance of the error in the console, whereas assigning them directly
+ * on instanciation will have the expected result.
+ */
+export class OdooError extends Error {
+  /**
+   * @param {string} name
+   * @param {string} message
+   */
+  constructor(name, message) {
+    super(message);
     this.name = name;
-    if (originalError) {
-      const { message, stack } = originalError;
-      this.message = message;
-      this.traceback = stack;
-      this.stack = stack;
-      this.originalError = originalError;
-    } else {
-      this.originalError = this;
-    }
   }
 }

--- a/addons/web/static/src/errors/odoo_error.js
+++ b/addons/web/static/src/errors/odoo_error.js
@@ -1,20 +1,57 @@
 /** @odoo-module **/
 
-/**
- * Odoo Error
- *
- * The point of this class is to properly extend an error: changes on properties
- * (`name` or `message`) outside the constructor will not be reflected in the stack
- * or the appearance of the error in the console, whereas assigning them directly
- * on instanciation will have the expected result.
- */
-export class OdooError extends Error {
-  /**
-   * @param {string} name
-   * @param {string} message
-   */
-  constructor(name, message) {
-    super(message);
-    this.name = name;
+export class ConnectionLostError extends Error {
+  constructor() {
+    super(...arguments);
+    this.name = "CONNECTION_LOST_ERROR";
+  }
+}
+
+export class ControllerNotFoundError extends Error {
+  constructor() {
+    super(...arguments);
+    this.name = "CONTROLLER_NOT_FOUND_ERROR";
+  }
+}
+
+export class RPCError extends Error {
+  constructor() {
+    super(...arguments);
+    this.name = "RPC_ERROR";
+    this.type = "server";
+  }
+}
+
+export class UncaughtClientError extends Error {
+  constructor() {
+    super(...arguments);
+    this.name = "UNCAUGHT_CLIENT_ERROR";
+  }
+}
+
+export class UnknownCorsError extends Error {
+  constructor() {
+    super(...arguments);
+    this.name = "UNKNOWN_CORS_ERROR";
+  }
+}
+
+export class UncaughtEmptyRejectionError extends Error {
+  constructor() {
+    super(...arguments);
+    this.name = "UNCAUGHT_EMPTY_REJECTION_ERROR";
+  }
+}
+
+export class UncaughtObjectRejectionError extends Error {
+  constructor() {
+    super(...arguments);
+    this.name = "UNCAUGHT_OBJECT_REJECTION_ERROR";
+  }
+}
+export class ViewNotFoundError extends Error {
+  constructor() {
+    super(...arguments);
+    this.name = "VIEW_NOT_FOUND_ERROR";
   }
 }

--- a/addons/web/static/src/legacy/utils.js
+++ b/addons/web/static/src/legacy/utils.js
@@ -138,7 +138,7 @@ export function mapLegacyEnvToWowlEnv(legacyEnv, wowlEnv) {
       const [route, params, settings] = args;
       wowlEnv.services.rpc(route, params, settings).then(resolve).catch((reason) => {
         error = reason;
-        if (isPrototypeOf.call(RPCError.prototype, reason)) {
+        if (reason instanceof RPCError) {
           event = $.Event();
           reject({ message: reason, event });
         }

--- a/addons/web/static/src/legacy/utils.js
+++ b/addons/web/static/src/legacy/utils.js
@@ -2,7 +2,7 @@
 
 import { browser } from "../core/browser";
 import AbstractStorageService from "web.AbstractStorageService";
-import { RPCError } from "../services/rpc_service";
+import { RPCError } from "../errors/odoo_error";
 
 export function mapDoActionOptionAPI(legacyOptions) {
   legacyOptions = Object.assign(legacyOptions || {});

--- a/addons/web/static/src/services/dialog_service.js
+++ b/addons/web/static/src/services/dialog_service.js
@@ -67,13 +67,7 @@ export const dialogService = {
     function open(dialogClass, props, options) {
       bus.trigger("UPDATE", dialogClass, props, options);
     }
-    return {
-      open,
-      bus,
-      get isReady() {
-        return document.getElementsByClassName("o_dialog_manager").length;
-      },
-    };
+    return { bus, open };
   },
 };
 

--- a/addons/web/static/src/services/dialog_service.js
+++ b/addons/web/static/src/services/dialog_service.js
@@ -62,12 +62,18 @@ DialogContainer.template = tags.xml`
 mainComponentRegistry.add("DialogContainer", DialogContainer);
 
 export const dialogService = {
-  start(env) {
+  start() {
     const bus = new EventBus();
     function open(dialogClass, props, options) {
       bus.trigger("UPDATE", dialogClass, props, options);
     }
-    return { open, bus };
+    return {
+      open,
+      bus,
+      get isReady() {
+        return document.getElementsByClassName("o_dialog_manager").length;
+      },
+    };
   },
 };
 

--- a/addons/web/static/src/services/rpc_service.js
+++ b/addons/web/static/src/services/rpc_service.js
@@ -1,24 +1,8 @@
 /** @odoo-module **/
 
 import { browser } from "../core/browser";
-import { OdooError } from "../errors/odoo_error";
+import { ConnectionLostError, RPCError } from "../errors/odoo_error";
 import { serviceRegistry } from "../webclient/service_registry";
-
-// -----------------------------------------------------------------------------
-// Errors
-// -----------------------------------------------------------------------------
-export class RPCError extends OdooError {
-  constructor() {
-    super("RPC_ERROR", ...arguments);
-    this.type = "server";
-  }
-}
-
-export class ConnectionLostError extends OdooError {
-  constructor() {
-    super("CONNECTION_LOST_ERROR", ...arguments);
-  }
-}
 
 // -----------------------------------------------------------------------------
 // Main RPC method

--- a/addons/web/static/src/services/rpc_service.js
+++ b/addons/web/static/src/services/rpc_service.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { browser } from "../core/browser";
-import OdooError from "../errors/odoo_error";
+import { OdooError } from "../errors/odoo_error";
 import { serviceRegistry } from "../webclient/service_registry";
 
 // -----------------------------------------------------------------------------
@@ -9,14 +9,14 @@ import { serviceRegistry } from "../webclient/service_registry";
 // -----------------------------------------------------------------------------
 export class RPCError extends OdooError {
   constructor() {
-    super("RPC_ERROR");
+    super("RPC_ERROR", ...arguments);
     this.type = "server";
   }
 }
 
 export class ConnectionLostError extends OdooError {
   constructor() {
-    super("CONNECTION_LOST_ERROR");
+    super("CONNECTION_LOST_ERROR", ...arguments);
   }
 }
 
@@ -30,11 +30,10 @@ function makeErrorFromResponse(reponse) {
   const { context: data_context, name: data_name } = errorData || {};
   const { exception_class } = data_context || {};
   const exception_class_name = exception_class || data_name;
-  const error = new RPCError();
+  const error = new RPCError(message);
   error.exceptionName = exception_class_name;
   error.subType = subType;
   error.data = errorData;
-  error.message = message;
   error.code = code;
   return error;
 }

--- a/addons/web/static/src/utils/download.js
+++ b/addons/web/static/src/utils/download.js
@@ -1,7 +1,24 @@
 /** @odoo-module **/
 
 import { NetworkErrorDialog, ServerErrorDialog } from "../errors/error_dialogs";
-import { OdooError } from "../errors/odoo_error";
+
+// -----------------------------------------------------------------------------
+// Errors
+// -----------------------------------------------------------------------------
+
+class XHRServerError extends Error {
+  constructor() {
+    super(...arguments);
+    this.name = "XHR_SERVER_ERROR";
+  }
+}
+
+class XHRNetworkError extends Error {
+  constructor() {
+    super(...arguments);
+    this.name = "XHR_NETWORK_ERROR";
+  }
+}
 
 // -----------------------------------------------------------------------------
 // Content Disposition Library
@@ -491,11 +508,11 @@ download._download = (options) => {
           try {
             // Case of a serialized Odoo Exception: It is Json Parsable
             const node = nodes[1] || nodes[0];
-            error = new OdooError("XHR_SERVER_ERROR", "Serialized Python Exception");
+            error = new XHRServerError("Serialized Python Exception");
             error.traceback = JSON.parse(node.textContent);
           } catch (e) {
             // Arbitrary uncaught python side exception
-            error = new OdooError("XHR_SERVER_ERROR", "Arbitrary Uncaught Python Exception");
+            error = new XHRServerError("Arbitrary Uncaught Python Exception");
             error.traceback = `${xhr.status}
                         ${nodes.length > 0 ? nodes[0].textContent : ""}
                         ${nodes.length > 1 ? nodes[1].textContent : ""}
@@ -508,7 +525,7 @@ download._download = (options) => {
       }
     };
     xhr.onerror = () => {
-      const error = new OdooError("XHR_NETWORK_ERROR");
+      const error = new XHRNetworkError();
       error.Component = NetworkErrorDialog;
       reject(error);
     };

--- a/addons/web/static/src/utils/download.js
+++ b/addons/web/static/src/utils/download.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { NetworkErrorDialog, ServerErrorDialog } from "../errors/error_dialogs";
-import OdooError from "../errors/odoo_error";
+import { OdooError } from "../errors/odoo_error";
 
 // -----------------------------------------------------------------------------
 // Content Disposition Library
@@ -487,21 +487,21 @@ download._download = (options) => {
           const contents = decoder.result;
           const doc = new DOMParser().parseFromString(contents, "text/html");
           const nodes = doc.body.children.length === 0 ? doc.body.childNodes : doc.body.children;
-          const error = new OdooError("XHR_SERVER_ERROR");
-          error.Component = ServerErrorDialog;
+          let error;
           try {
             // Case of a serialized Odoo Exception: It is Json Parsable
             const node = nodes[1] || nodes[0];
-            error.message = "Serialized Python Exception";
+            error = new OdooError("XHR_SERVER_ERROR", "Serialized Python Exception");
             error.traceback = JSON.parse(node.textContent);
           } catch (e) {
             // Arbitrary uncaught python side exception
-            error.message = "Arbitrary Uncaught Python Exception";
+            error = new OdooError("XHR_SERVER_ERROR", "Arbitrary Uncaught Python Exception");
             error.traceback = `${xhr.status}
                         ${nodes.length > 0 ? nodes[0].textContent : ""}
                         ${nodes.length > 1 ? nodes[1].textContent : ""}
                     `;
           }
+          error.Component = ServerErrorDialog;
           reject(error);
         };
         decoder.readAsText(xhr.response);

--- a/addons/web/static/tests/actions/helpers.js
+++ b/addons/web/static/tests/actions/helpers.js
@@ -186,8 +186,7 @@ export function getActionManagerTestConfig() {
   patchWithCleanup(
     browser,
     {
-      setTimeout: window.setTimeout.bind(window),
-      clearTimeout: window.clearTimeout.bind(window),
+      alert: browser.console.warn,
       localStorage: makeRAMLocalStorage(),
       sessionStorage: makeRAMLocalStorage(),
     },

--- a/addons/web/static/tests/errors/error_dialogs_tests.js
+++ b/addons/web/static/tests/errors/error_dialogs_tests.js
@@ -9,7 +9,6 @@ import {
   SessionExpiredDialog,
   WarningDialog,
 } from "@web/errors/error_dialogs";
-import { OdooError } from "@web/errors/odoo_error";
 import { hotkeyService } from "@web/hotkeys/hotkey_service";
 import { uiService } from "@web/services/ui_service";
 import { serviceRegistry } from "@web/webclient/service_registry";
@@ -138,7 +137,7 @@ QUnit.test("Client ErrorDialog with traceback", async (assert) => {
 
 QUnit.test("button clipboard copy error traceback", async (assert) => {
   assert.expect(1);
-  const error = new OdooError("ERROR_NAME", "This is the message");
+  const error = new Error("This is the message");
   error.traceback = "This is a traceback";
   patchWithCleanup(browser, {
     navigator: {

--- a/addons/web/static/tests/errors/error_dialogs_tests.js
+++ b/addons/web/static/tests/errors/error_dialogs_tests.js
@@ -1,8 +1,6 @@
 /** @odoo-module **/
 
 import { browser } from "@web/core/browser";
-import { serviceRegistry } from "@web/webclient/service_registry";
-import { makeFakeLocalizationService } from "../helpers/mock_services";
 import {
   ClientErrorDialog,
   Error504Dialog,
@@ -11,11 +9,13 @@ import {
   SessionExpiredDialog,
   WarningDialog,
 } from "@web/errors/error_dialogs";
-import OdooError from "@web/errors/odoo_error";
-import { uiService } from "@web/services/ui_service";
-import { makeTestEnv } from "../helpers/mock_env";
-import { click, getFixture, nextTick, patchWithCleanup } from "../helpers/utils";
+import { OdooError } from "@web/errors/odoo_error";
 import { hotkeyService } from "@web/hotkeys/hotkey_service";
+import { uiService } from "@web/services/ui_service";
+import { serviceRegistry } from "@web/webclient/service_registry";
+import { makeTestEnv } from "../helpers/mock_env";
+import { makeFakeLocalizationService } from "../helpers/mock_services";
+import { click, getFixture, nextTick, patchWithCleanup } from "../helpers/utils";
 
 const { Component, mount, tags } = owl;
 let target;
@@ -138,8 +138,7 @@ QUnit.test("Client ErrorDialog with traceback", async (assert) => {
 
 QUnit.test("button clipboard copy error traceback", async (assert) => {
   assert.expect(1);
-  const error = new OdooError("ERROR_NAME");
-  error.message = "This is the message";
+  const error = new OdooError("ERROR_NAME", "This is the message");
   error.traceback = "This is a traceback";
   patchWithCleanup(browser, {
     navigator: {
@@ -155,7 +154,7 @@ QUnit.test("button clipboard copy error traceback", async (assert) => {
     constructor() {
       super(...arguments);
       this.message = error.message;
-      this.name = "ERROR_NAME";
+      this.name = error.name;
       this.traceback = "This is a traceback";
     }
   }

--- a/addons/web/static/tests/errors/error_service_tests.js
+++ b/addons/web/static/tests/errors/error_service_tests.js
@@ -5,10 +5,9 @@ import { RPCErrorDialog } from "@web/errors/error_dialogs";
 import { errorDialogRegistry } from "@web/errors/error_dialog_registry";
 import { errorHandlerRegistry } from "@web/errors/error_handler_registry";
 import { errorService } from "@web/errors/error_service";
-import { OdooError } from "@web/errors/odoo_error";
+import { ConnectionLostError, RPCError } from "@web/errors/odoo_error";
 import { notificationService } from "@web/notifications/notification_service";
 import { dialogService } from "@web/services/dialog_service";
-import { ConnectionLostError, RPCError } from "@web/services/rpc_service";
 import { serviceRegistry } from "@web/webclient/service_registry";
 import { makeTestEnv } from "../helpers/mock_env";
 import {
@@ -159,10 +158,10 @@ QUnit.test("default handler", async (assert) => {
     alert: (message) => assert.step(`alert ${message}`),
   });
   await makeTestEnv();
-  const error = new OdooError("BOOM", "boom :)");
+  const error = new Error("boom");
   const errorEvent = new PromiseRejectionEvent("error", { reason: error, promise: null });
   unhandledRejectionCb(errorEvent);
-  assert.verifySteps(["alert boom :)"]);
+  assert.verifySteps(["alert boom"]);
 });
 
 QUnit.test("will let handlers from the registry handle errors first", async (assert) => {
@@ -192,11 +191,11 @@ QUnit.test("error in error handler", async (assert) => {
     throw new Error("Handler broke");
   });
   await makeTestEnv();
-  const error = new OdooError("BOOM");
+  const error = new Error("boom");
   const errorEvent = new PromiseRejectionEvent("error", { reason: error, promise: null });
   unhandledRejectionCb(errorEvent);
   assert.verifySteps([
-    "BOOM",
+    "Error: boom",
     "An additional error occurred while handling the error above:",
     "Error: Handler broke",
   ]);


### PR DESCRIPTION
## Justifications:

### ~~dialog_service > dialogService (isReady)~~
- ~~Tells the rest of the environment whether the dialog manager is able to display a dialog~~

### ~~error_handlers > defaultHandler (alert if no dialog manager)~~
- ~~Rare cases (only errors during startup will display an alert)~~
- ~~No way to display a proper dialog anyway, IMHO still better than a blank screen~~

### error_handlers > defaultHandler (console.error in all cases)
- Helpful to get to source error in one click
- Only visible to devs anyway

### odoo_error > ~~OdooError (new param):~~ Remove OdooError
- Allows the console to display the "proper" error (Not the "converted" error, e.g. "DEFAULT_ERROR")
- ~~Fills in default OdooError properties with original Error properties (message, stack, stack > traceback)~~