### PR TITLE
[FIX] web: domains with (=)(i)like operators

### DIFF
--- a/addons/web/static/src/core/domain.js
+++ b/addons/web/static/src/core/domain.js
@@ -204,17 +204,24 @@ function matchCondition(record, condition) {
             }
             return !value.includes(fieldValue);
         case "like":
-            return fieldValue.toLowerCase().indexOf(value.toLowerCase()) >= 0;
-        case "=like":
-            return new RegExp(
-                value
-                    .toLowerCase()
-                    .replace(/([.[]\{\}\+\*])/g, "\\$1")
-                    .replace(/%/g, ".*")
-            ).test(fieldValue.toLowerCase());
-        case "ilike":
+            if (fieldValue === false) {
+                return false;
+            }
             return fieldValue.indexOf(value) >= 0;
+        case "=like":
+            if (fieldValue === false) {
+                return false;
+            }
+            return new RegExp(value.replace(/%/g, '.*')).test(fieldValue);
+        case "ilike":
+            if (fieldValue === false) {
+                return false;
+            }
+            return fieldValue.toLowerCase().indexOf(value.toLowerCase()) >= 0;
         case "=ilike":
+            if (fieldValue === false) {
+                return false;
+            }
             return new RegExp(value.replace(/%/g, ".*"), "i").test(fieldValue);
     }
     throw new Error("could not match domain");

--- a/addons/web/static/tests/core/domain_tests.js
+++ b/addons/web/static/tests/core/domain_tests.js
@@ -86,6 +86,30 @@ QUnit.module("domain", {}, () => {
         assert.ok(new Domain(["!", ["group_method", "=", "count"]]).contains(record));
     });
 
+    QUnit.test("like, =like, ilike and =ilike", function (assert) {
+        assert.expect(16);
+
+        assert.ok(new Domain([['a', 'like', 'value']]).contains({ a: 'value' }));
+        assert.ok(new Domain([['a', 'like', 'value']]).contains({ a: 'some value' }));
+        assert.notOk(new Domain([['a', 'like', 'value']]).contains({ a: 'Some Value' }));
+        assert.notOk(new Domain([['a', 'like', 'value']]).contains({ a: false }));
+
+        assert.ok(new Domain([['a', '=like', '%value']]).contains({ a: 'value' }));
+        assert.ok(new Domain([['a', '=like', '%value']]).contains({ a: 'some value' }));
+        assert.notOk(new Domain([['a', '=like', '%value']]).contains({ a: 'Some Value' }));
+        assert.notOk(new Domain([['a', '=like', '%value']]).contains({ a: false }));
+
+        assert.ok(new Domain([['a', 'ilike', 'value']]).contains({ a: 'value' }));
+        assert.ok(new Domain([['a', 'ilike', 'value']]).contains({ a: 'some value' }));
+        assert.ok(new Domain([['a', 'ilike', 'value']]).contains({ a: 'Some Value' }));
+        assert.notOk(new Domain([['a', 'ilike', 'value']]).contains({ a: false }));
+
+        assert.ok(new Domain([['a', '=ilike', '%value']]).contains({ a: 'value' }));
+        assert.ok(new Domain([['a', '=ilike', '%value']]).contains({ a: 'some value' }));
+        assert.ok(new Domain([['a', '=ilike', '%value']]).contains({ a: 'Some Value' }));
+        assert.notOk(new Domain([['a', '=ilike', '%value']]).contains({ a: false }));
+    });
+
     QUnit.test("complex domain", function (assert) {
         const domain = new Domain(["&", "!", ["a", "=", 1], "|", ["a", "=", 2], ["a", "=", 3]]);
 


### PR DESCRIPTION
This commit applies [1] to the new implementation of Domain as a
native Class (former code was naively copy/pasted).

[1] https://github.com/odoo/odoo/pull/70951