### PR TITLE
[REF] web, web_tour: refactoring of dialog api

### DIFF
--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
@@ -1,37 +1,30 @@
 /** @odoo-module */
 
-export class ConfirmationDialog extends owl.Component {
-    _close() {
-        this.trigger("dialog-closed");
-    }
+import { Dialog } from "../dialog/dialog";
 
+export class ConfirmationDialog extends Dialog {
+    setup() {
+        super.setup();
+        this.title = this.props.title;
+    }
     _cancel() {
         if (this.props.cancel) {
             this.props.cancel();
         }
-        this._close();
+        this.close();
     }
 
     _confirm() {
         this.props.confirm();
-        this._close();
-    }
-
-    get dialogProps() {
-        const propsArray = Object.entries(this.props).filter(
-            ([k, v]) => !(k in this.constructor.props)
-        );
-
-        const props = {};
-        propsArray.forEach(([k, v]) => {
-            props[k] = v;
-        });
-        return props;
+        this.close();
     }
 }
 ConfirmationDialog.props = {
+    title: String,
+    body: String,
     confirm: Function,
     cancel: Function,
 };
 
-ConfirmationDialog.template = "web.ConfirmationDialog";
+ConfirmationDialog.bodyTemplate = "web.ConfirmationDialogBody";
+ConfirmationDialog.footerTemplate = "web.ConfirmationDialogFooter";

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <t t-name="web.ConfirmationDialog" owl="1">
-    <Dialog t-props="dialogProps">
-      <t t-esc="props.body" />
-      <t t-set-slot="buttons">
-        <button class="btn btn-primary" t-on-click="_confirm">
-          Ok
-        </button>
-        <button class="btn btn-secondary" t-on-click="_close">
-          Cancel
-        </button>
-      </t>
-    </Dialog>
+  <t t-name="web.ConfirmationDialogBody" owl="1">
+    <t t-esc="props.body" />
+  </t>
+
+  <t t-name="web.ConfirmationDialogFooter" owl="1">
+    <button class="btn btn-primary" t-on-click="_confirm">
+      Ok
+    </button>
+    <button class="btn btn-secondary" t-on-click="_cancel">
+      Cancel
+    </button>
   </t>
 
 </templates>

--- a/addons/web/static/src/core/debug/debug_menu_items.xml
+++ b/addons/web/static/src/core/debug/debug_menu_items.xml
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.DebugManager.SetDefault" owl="1">
-        <Dialog title="title">
-            <t t-call="web.DebugManager.setDefault"/>
-            <t t-set-slot="buttons">
-                <button class="btn btn-secondary" t-on-click="trigger('dialog-closed')">Close</button>
-                <button class="btn btn-secondary" t-on-click="saveDefault">Save default</button>
-            </t>
-        </Dialog>
+    <t t-name="web.DebugManager.SetDefaultFooter" owl="1">
+        <button class="btn btn-secondary" t-on-click="trigger('dialog-closed')">Close</button>
+        <button class="btn btn-secondary" t-on-click="saveDefault">Save default</button>
     </t>
 
-    <t t-name="web.DebugManager.setDefault" owl="1">
+    <t t-name="web.DebugManager.setDefaultBody" owl="1">
         <table style="width: 100%">
             <tr>
                 <td>
@@ -67,13 +62,7 @@
         </table>
     </t>
 
-    <t t-name="web.DebugManager.GetMetadata" owl="1">
-        <Dialog title="title">
-            <t t-call="web.DebugManager.getMetadata"/>
-        </Dialog>
-    </t>
-
-    <t t-name="web.DebugManager.getMetadata" owl="1">
+    <t t-name="web.DebugManager.getMetadataBody" owl="1">
         <table class="table table-sm table-striped">
             <tr>
                 <th>ID:</th>

--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -3,11 +3,19 @@
 import { useHotkey } from "../hotkey_hook";
 import { useActiveElement } from "../ui_service";
 
-const { Component, hooks, misc, QWeb } = owl;
+const { Component, hooks, misc } = owl;
 const { useRef, useSubEnv } = hooks;
 const { Portal } = misc;
 
 export class Dialog extends Component {
+    constructor(...args) {
+        super(...args);
+        if (this.constructor === Dialog) {
+            throw new Error(
+                "Dialog should not be used by itself. Please use the dialog service with a Dialog subclass."
+            );
+        }
+    }
     setup() {
         this.modalRef = useRef("modal");
         useActiveElement("modal");
@@ -21,6 +29,14 @@ export class Dialog extends Component {
             { altIsOptional: true }
         );
         useSubEnv({ inDialog: true });
+        this.close = this.close.bind(this);
+        this.contentClass = this.constructor.contentClass;
+        this.fullscreen = this.constructor.fullscreen;
+        this.renderFooter = this.constructor.renderFooter;
+        this.renderHeader = this.constructor.renderHeader;
+        this.size = this.constructor.size;
+        this.technical = this.constructor.technical;
+        this.title = this.constructor.title;
     }
 
     mounted() {
@@ -57,26 +73,13 @@ export class Dialog extends Component {
 }
 
 Dialog.components = { Portal };
-Dialog.props = {
-    contentClass: { type: String, optional: true },
-    fullscreen: Boolean,
-    renderFooter: Boolean,
-    renderHeader: Boolean,
-    size: {
-        type: String,
-        validate: (s) => ["modal-xl", "modal-lg", "modal-md", "modal-sm"].includes(s),
-    },
-    technical: Boolean,
-    title: String,
-};
-Dialog.defaultProps = {
-    fullscreen: false,
-    renderFooter: true,
-    renderHeader: true,
-    size: "modal-lg",
-    technical: true,
-    title: "Odoo",
-};
 Dialog.template = "web.Dialog";
-
-QWeb.registerComponent("Dialog", Dialog);
+Dialog.contentClass = null;
+Dialog.fullscreen = false;
+Dialog.renderFooter = true;
+Dialog.renderHeader = true;
+Dialog.size = "modal-lg";
+Dialog.technical = true;
+Dialog.title = "Odoo";
+Dialog.bodyTemplate = owl.tags.xml`<div/>`;
+Dialog.footerTemplate = "web.DialogFooterDefault";

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -6,26 +6,22 @@
             <div class="o_dialog">
                 <div role="dialog" class="modal"
                     tabindex="-1"
-                    t-att-class="{ o_technical_modal: props.technical, o_modal_full: props.fullscreen }"
+                    t-att-class="{ o_technical_modal: technical, o_modal_full: fullscreen }"
                     t-ref="modal"
                     >
-                    <div class="modal-dialog" t-att-class="props.size">
-                        <div class="modal-content" t-att-class="props.contentClass">
-                            <header t-if="props.renderHeader" class="modal-header">
+                    <div class="modal-dialog" t-att-class="size">
+                        <div class="modal-content" t-att-class="contentClass">
+                            <header t-if="renderHeader" class="modal-header">
                                 <h4 class="modal-title">
-                                    <t t-esc="props.title"/>
+                                    <t t-esc="title"/>
                                 </h4>
                                 <button type="button" class="close" aria-label="Close" tabindex="-1" t-on-click="close">×</button>
                             </header>
                             <main class="modal-body">
-                                <t t-slot="default"/>
+                                <t t-call="{{ constructor.bodyTemplate }}"/>
                             </main>
-                            <footer t-if="props.renderFooter" class="modal-footer">
-                                <t t-slot="buttons">
-                                    <button class="btn btn-primary" t-on-click="close">
-                                        <t>Ok</t>
-                                    </button>
-                                </t>
+                            <footer t-if="renderFooter" class="modal-footer">
+                                <t t-call="{{ constructor.footerTemplate }}" />
                             </footer>
                         </div>
                     </div>
@@ -34,4 +30,9 @@
         </Portal>
     </t>
 
+    <t t-name="web.DialogFooterDefault" owl="1">
+        <button class="btn btn-primary" t-on-click="close">
+            <t>Ok</t>
+        </button>
+    </t>
 </templates>

--- a/addons/web/static/src/core/dialog/dialog_service.js
+++ b/addons/web/static/src/core/dialog/dialog_service.js
@@ -2,6 +2,7 @@
 
 import { registry } from "../registry";
 import { useService } from "../service_hook";
+import { Dialog } from "./dialog";
 
 const { Component, core, tags, useState } = owl;
 const { EventBus } = core;
@@ -25,6 +26,9 @@ export class DialogContainer extends Component {
     }
 
     addDialog(dialogClass, props, options) {
+        if (!(dialogClass.prototype instanceof Dialog)) {
+            throw new Error(dialogClass.name + " must be a subclass of Dialog");
+        }
         const id = this.dialogId++;
         this.dialogs[id] = {
             id,

--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -1,12 +1,13 @@
 /** @odoo-module **/
 
 import { browser } from "../browser/browser";
+import { Dialog } from "../dialog/dialog";
 import { _lt } from "../l10n/translation";
 import { registry } from "../registry";
 import { useService } from "../service_hook";
 import { capitalize } from "../utils/strings";
 
-const { Component, hooks } = owl;
+const { hooks } = owl;
 const { useState } = hooks;
 
 const odooExceptionTitleMap = new Map();
@@ -20,10 +21,9 @@ odooExceptionTitleMap.set("odoo.exceptions.ValidationError", _lt("Validation Err
 // -----------------------------------------------------------------------------
 // Generic Error Dialog
 // -----------------------------------------------------------------------------
-export class ErrorDialog extends Component {
-    constructor() {
-        super(...arguments);
-        this.title = this.env._t("Odoo Error");
+export class ErrorDialog extends Dialog {
+    setup() {
+        super.setup();
         this.state = useState({
             showTraceback: false,
         });
@@ -34,44 +34,34 @@ export class ErrorDialog extends Component {
         );
     }
 }
-ErrorDialog.template = "web.ErrorDialog";
+ErrorDialog.contentClass = "o_dialog_error";
+ErrorDialog.bodyTemplate = "web.ErrorDialogBody";
+ErrorDialog.title = _lt("Odoo Error");
 
 // -----------------------------------------------------------------------------
 // Client Error Dialog
 // -----------------------------------------------------------------------------
-export class ClientErrorDialog extends ErrorDialog {
-    constructor() {
-        super(...arguments);
-        this.title = this.env._t("Odoo Client Error");
-    }
-}
+export class ClientErrorDialog extends ErrorDialog {}
+ClientErrorDialog.title = _lt("Odoo Client Error");
 
 // -----------------------------------------------------------------------------
 // Server Error Dialog
 // -----------------------------------------------------------------------------
-export class ServerErrorDialog extends ErrorDialog {
-    constructor() {
-        super(...arguments);
-        this.title = this.env._t("Odoo Server Error");
-    }
-}
+export class ServerErrorDialog extends ErrorDialog {}
+ServerErrorDialog.title = _lt("Odoo Server Error");
 
 // -----------------------------------------------------------------------------
 // Network Error Dialog
 // -----------------------------------------------------------------------------
-export class NetworkErrorDialog extends ErrorDialog {
-    constructor() {
-        super(...arguments);
-        this.title = this.env._t("Odoo Network Error");
-    }
-}
+export class NetworkErrorDialog extends ErrorDialog {}
+NetworkErrorDialog.title = _lt("Odoo Network Error");
 
 // -----------------------------------------------------------------------------
 // RPC Error Dialog
 // -----------------------------------------------------------------------------
-export class RPCErrorDialog extends Component {
-    constructor() {
-        super(...arguments);
+export class RPCErrorDialog extends Dialog {
+    setup() {
+        super.setup();
         this.title = this.env._t("Odoo Error");
         this.state = useState({
             showTraceback: false,
@@ -102,20 +92,21 @@ export class RPCErrorDialog extends Component {
                 break;
         }
     }
+
     onClickClipboard() {
         browser.navigator.clipboard.writeText(
             `${this.props.name}\n${this.props.message}\n${this.traceback}`
         );
     }
 }
-RPCErrorDialog.template = "web.ErrorDialog";
+RPCErrorDialog.bodyTemplate = "web.ErrorDialogBody";
 
 // -----------------------------------------------------------------------------
 // Warning Dialog
 // -----------------------------------------------------------------------------
-export class WarningDialog extends Component {
-    constructor() {
-        super(...arguments);
+export class WarningDialog extends Dialog {
+    setup() {
+        super.setup();
         this.title = this.env._t("Odoo Warning");
         this.inferTitle();
         const { data, message } = this.props;
@@ -131,14 +122,14 @@ export class WarningDialog extends Component {
         }
     }
 }
-WarningDialog.template = "web.WarningDialog";
+WarningDialog.bodyTemplate = "web.WarningDialogBody";
 
 // -----------------------------------------------------------------------------
 // Redirect Warning Dialog
 // -----------------------------------------------------------------------------
-export class RedirectWarningDialog extends Component {
-    constructor() {
-        super(...arguments);
+export class RedirectWarningDialog extends Dialog {
+    setup() {
+        super.setup();
         this.actionService = useService("action");
         const { data, subType } = this.props;
         const [message, actionId, buttonText, additional_context] = data.arguments;
@@ -152,38 +143,33 @@ export class RedirectWarningDialog extends Component {
         await this.actionService.doAction(this.actionId, {
             additionalContext: this.additionalContext,
         });
-        this.trigger("dialog-closed");
+        this.close();
     }
     onCancel() {
-        this.trigger("dialog-closed");
+        this.close();
     }
 }
-RedirectWarningDialog.template = "web.RedirectWarningDialog";
+RedirectWarningDialog.bodyTemplate = "web.RedirectWarningDialogBody";
+RedirectWarningDialog.footerTemplate = "web.RedirectWarningDialogFooter";
 
 // -----------------------------------------------------------------------------
 // Error 504 Dialog
 // -----------------------------------------------------------------------------
-export class Error504Dialog extends Component {
-    constructor() {
-        super(...arguments);
-        this.title = this.env._t("Request timeout");
-    }
-}
-Error504Dialog.template = "web.Error504Dialog";
+export class Error504Dialog extends Dialog {}
+Error504Dialog.bodyTemplate = "web.Error504DialogBody";
+Error504Dialog.title = _lt("Request timeout");
 
 // -----------------------------------------------------------------------------
 // Expired Session Error Dialog
 // -----------------------------------------------------------------------------
-export class SessionExpiredDialog extends Component {
-    constructor() {
-        super(...arguments);
-        this.title = this.env._t("Odoo Session Expired");
-    }
+export class SessionExpiredDialog extends Dialog {
     onClick() {
         browser.location.reload();
     }
 }
-SessionExpiredDialog.template = "web.SessionExpiredDialog";
+SessionExpiredDialog.bodyTemplate = "web.SessionExpiredDialogBody";
+SessionExpiredDialog.footerTemplate = "web.SessionExpiredDialogFooter";
+SessionExpiredDialog.title = _lt("Odoo Session Expired");
 
 registry
     .category("error_dialogs")

--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -1,71 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.WarningDialog" owl="1">
-      <Dialog title="title">
-        <div role="alert" class="o_dialog_warning">
-          <p t-esc="message" style="white-space: pre-wrap;"/>
-        </div>
-      </Dialog>
+    <t t-name="web.WarningDialogBody" owl="1">
+      <div role="alert" class="o_dialog_warning">
+        <p t-esc="message" style="white-space: pre-wrap;"/>
+      </div>
     </t>
 
-    <t t-name="web.RedirectWarningDialog" owl="1">
-      <Dialog title="title">
+    <t t-name="web.RedirectWarningDialogBody" owl="1">
+      <div role="alert">
+        <p t-esc="message" style="white-space: pre-wrap;"/>
+      </div>
+    </t>
+
+    <t t-name="web.RedirectWarningDialogFooter" owl="1">
+      <button  class="btn btn-primary" t-on-click="onClick"><t t-esc="env._t(buttonText)"/></button>
+      <button  class="btn btn-secondary" t-on-click="onCancel">Cancel</button>
+    </t>
+
+    <t t-name="web.Error504DialogBody" owl="1">
         <div role="alert">
-          <p t-esc="message" style="white-space: pre-wrap;"/>
+            <p style="white-space: pre-wrap;">
+            The operation was interrupted. This usually means that the current operation is taking too much time.
+            </p>
         </div>
-        <t t-set="buttons">
-          <button t-on-click="onClick"><t t-esc="env._t(buttonText)"/></button>
-          <button t-on-click="onCancel">Cancel</button>
-        </t>
-      </Dialog>
     </t>
 
-    <t t-name="web.Error504Dialog" owl="1">
-        <Dialog title="title">
-          <div role="alert">
-              <p style="white-space: pre-wrap;">
-              The operation was interrupted. This usually means that the current operation is taking too much time.
-              </p>
+    <t t-name="web.SessionExpiredDialogBody" owl="1">
+      <div role="alert">
+        <p style="white-space: pre-wrap;">
+          Your Odoo session expired. The current page is about to be refreshed.
+        </p>
+      </div>
+    </t>
+
+    <t t-name="web.SessionExpiredDialogFooter" owl="1">
+        <button class="btn btn-primary" t-on-click="onClick">Ok</button>
+    </t>
+
+     <t t-name="web.ErrorDialogBody" owl="1">
+      <div class="alert alert-warning clearfix" role="alert">
+          <div class="float-right ml8 btn-group-vertical">
+              <button class="btn btn-primary" t-on-click="onClickClipboard">
+                  <i class="fa fa-clipboard mr8"/><t>Copy the full error to clipboard</t>
+              </button>
           </div>
-        </Dialog>
-    </t>
-
-    <t t-name="web.SessionExpiredDialog" owl="1">
-      <Dialog title="title">
-        <div role="alert">
-          <p style="white-space: pre-wrap;">
-            Your Odoo session expired. The current page is about to be refreshed.
-          </p>
-        </div>
-        <t t-set="buttons">
-          <button t-on-click="onClick">Ok</button>
-        </t>
-      </Dialog>
-    </t>
-
-     <t t-name="web.ErrorDialog" owl="1">
-      <Dialog title="title" contentClass="'o_dialog_error'">
-        <div class="alert alert-warning clearfix" role="alert">
-            <div class="float-right ml8 btn-group-vertical">
-                <button class="btn btn-primary" t-on-click="onClickClipboard">
-                    <i class="fa fa-clipboard mr8"/><t>Copy the full error to clipboard</t>
-                </button>
-            </div>
-            <p><b>An error occurred</b></p>
-            <p>Please use the copy button to report the error to your support service.</p>
-        </div>
+          <p><b>An error occurred</b></p>
+          <p>Please use the copy button to report the error to your support service.</p>
+      </div>
 
 
-        <button class="btn btn-link" t-on-click="state.showTraceback = !state.showTraceback">See details</button>
-        <div t-if="state.showTraceback and (props.name or props.message)" class="alert clearfix" style="background-color:#ececec;" role="alert">
-          <code t-if="props.name" t-esc="props.name"></code>
-          <p t-if="props.message" t-esc="props.message"></p>
-        </div>
-        <div t-if="state.showTraceback" class="alert alert-danger o_error_detail" role="alert">
-            <pre t-esc="props.traceback"/>
-        </div>
-      </Dialog>
+      <button class="btn btn-link" t-on-click="state.showTraceback = !state.showTraceback">See details</button>
+      <div t-if="state.showTraceback and (props.name or props.message)" class="alert clearfix" style="background-color:#ececec;" role="alert">
+        <code t-if="props.name" t-esc="props.name"></code>
+        <p t-if="props.message" t-esc="props.message"></p>
+      </div>
+      <div t-if="state.showTraceback" class="alert alert-danger o_error_detail" role="alert">
+          <pre t-esc="props.traceback"/>
+      </div>
     </t>
 
 </templates>

--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -12,6 +12,7 @@ import { ComponentAdapter } from "web.OwlCompatibility";
 import { mapDoActionOptionAPI } from "./utils";
 import { setupDebugAction, setupDebugViewForm, setupDebugView } from "./debug_manager";
 import { cleanDomFromBootstrap } from "./utils";
+import { Dialog } from "../core/dialog/dialog";
 
 const { Component, tags } = owl;
 
@@ -93,12 +94,13 @@ class ActionAdapter extends ComponentAdapter {
             this.title.setParts({ [part]: title || null });
         } else if (ev.name === "warning") {
             if (payload.type === "dialog") {
-                class WarningDialog extends Component {}
-                WarningDialog.template = tags.xml`
-            <Dialog title="props.title">
-              <t t-esc="props.message"/>
-            </Dialog>
-            `;
+                class WarningDialog extends Dialog {
+                    setup() {
+                        super.setup();
+                        this.title = this.props.title;
+                    }
+                }
+                WarningDialog.bodyTemplate = tags.xml`<t t-esc="props.message"/>`;
                 this.dialogs.open(WarningDialog, {
                     title: payload.title,
                     message: payload.message,

--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -4,6 +4,8 @@ import { editModelDebug } from "../core/debug/debug_service";
 import { json_node_to_xml } from "../views/view_utils";
 import { formatMany2one } from "../fields/format";
 import { parseDateTime, formatDateTime } from "../core/l10n/dates";
+import { Dialog } from "../core/dialog/dialog";
+import { _lt } from "../core/l10n/translation";
 
 const { Component, hooks, tags } = owl;
 const { useState } = hooks;
@@ -168,20 +170,14 @@ export function setupDebugAction(accessRights, env, action) {
     return result;
 }
 
-class FieldViewGetDialog extends Component {
-    constructor() {
-        super(...arguments);
-        this.title = this.env._t("Fields View Get");
-    }
-}
-FieldViewGetDialog.template = tags.xml`
-  <Dialog title="title">
-    <pre t-esc="props.arch"/>
-  </Dialog>`;
+class FieldViewGetDialog extends Dialog {}
+FieldViewGetDialog.props = Object.assign({}, Dialog.props, { arch: { type: String } });
+FieldViewGetDialog.bodyTemplate = tags.xml`<pre t-esc="props.arch"/>`;
+FieldViewGetDialog.title = _lt("Fields View Get");
 
-class GetMetadataDialog extends Component {
+class GetMetadataDialog extends Dialog {
     setup() {
-        this.title = this.env._t("View Metadata");
+        super.setup();
         this.state = useState({});
     }
 
@@ -212,12 +208,12 @@ class GetMetadataDialog extends Component {
         this.state.write_date = formatDateTime(parseDateTime(metadata.write_date));
     }
 }
-GetMetadataDialog.template = "web.DebugManager.GetMetadata";
+GetMetadataDialog.bodyTemplate = "web.DebugManager.getMetadataBody";
+GetMetadataDialog.title = _lt("View Metadata");
 
-class SetDefaultDialog extends Component {
-    constructor() {
-        super(...arguments);
-        this.title = this.env._t("Set Default");
+class SetDefaultDialog extends Dialog {
+    setup() {
+        super.setup();
         this.state = {
             fieldToSet: "",
             condition: "",
@@ -356,7 +352,9 @@ class SetDefaultDialog extends Component {
         this.trigger("dialog-closed");
     }
 }
-SetDefaultDialog.template = "web.DebugManager.SetDefault";
+SetDefaultDialog.bodyTemplate = "web.DebugManager.setDefaultBody";
+SetDefaultDialog.footerTemplate = "web.DebugManager.SetDefaultFooter";
+SetDefaultDialog.title = _lt("Set Default");
 
 export function setupDebugView(accessRights, env, component, action) {
     const viewId = component.props.viewInfo.view_id;

--- a/addons/web/static/src/webclient/actions/action_dialog.js
+++ b/addons/web/static/src/webclient/actions/action_dialog.js
@@ -22,14 +22,16 @@ class ActionDialog extends Dialog {
         const actionProps = this.props && this.props.actionProps;
         const action = actionProps && actionProps.action;
         this.actionType = action && action.type;
+        this.title = "title" in this.props ? this.props.title : this.constructor.title;
     }
 }
 ActionDialog.components = { ...Dialog.components, DebugManager };
 ActionDialog.template = "web.ActionDialog";
+ActionDialog.bodyTemplate = "web.ActionDialogBody";
 ActionDialog.props = {
-    ...Dialog.props,
     ActionComponent: { optional: true },
     actionProps: { optional: true },
+    title: { optional: true },
 };
 
 /**
@@ -37,13 +39,16 @@ ActionDialog.props = {
  * The "ActionDialog" class should get exported from this file when the cleaning will occur.
  */
 class LegacyAdaptedActionDialog extends ActionDialog {
+    constructor(...args) {
+        super(...args);
+    }
     setup() {
         super.setup();
         const actionProps = this.props && this.props.actionProps;
         const action = actionProps && actionProps.action;
         const actionContext = action && action.context;
         const actionDialogSize = actionContext && actionContext.dialog_size;
-        this.props.size = LEGACY_SIZE_CLASSES[actionDialogSize] || (this.props && this.props.size);
+        this.size = LEGACY_SIZE_CLASSES[actionDialogSize] || this.constructor.size;
         const ControllerComponent = this.props && this.props.ActionComponent;
         const Controller = ControllerComponent && ControllerComponent.Component;
         this.isLegacy = Controller && Controller.isLegacy;
@@ -61,6 +66,6 @@ class LegacyAdaptedActionDialog extends ActionDialog {
         }, () => []); // TODO: should this depend on actionRef.comp?
     }
 }
-LegacyAdaptedActionDialog.template = "web.LegacyAdaptedActionDialog";
+LegacyAdaptedActionDialog.footerTemplate = "web.LegacyAdaptedActionDialogFooter";
 
 export { LegacyAdaptedActionDialog as ActionDialog };

--- a/addons/web/static/src/webclient/actions/action_dialog.xml
+++ b/addons/web/static/src/webclient/actions/action_dialog.xml
@@ -10,23 +10,20 @@
         {"o_act_window": actionType === "ir.actions.act_window"}
       </attribute>
     </xpath>
-    <xpath expr="//t[@t-slot='default']" position="replace">
-      <t t-if="props.ActionComponent" t-component="props.ActionComponent" t-props="props.actionProps" t-ref="actionRef"/>
-    </xpath>
   </t>
 
-  <t t-name="web.LegacyAdaptedActionDialog" t-inherit="web.ActionDialog" t-inherit-mode="primary" owl="1">
-    <xpath expr="//footer[@class='modal-footer']" position="replace">
-      <footer t-if="props.renderFooter" class="modal-footer">
-        <t t-if="!isLegacy">
-          <t t-slot="buttons">
-            <button class="btn btn-primary" t-on-click="_close">
-              <t>Ok</t>
-            </button>
-          </t>
-        </t>
-      </footer>
-    </xpath>
+  <t t-name="web.ActionDialogBody" owl="1">
+    <t t-if="props.ActionComponent" t-component="props.ActionComponent" t-props="props.actionProps" t-ref="actionRef"/>
+  </t>
+
+  <t t-name="web.LegacyAdaptedActionDialogFooter" owl="1">
+    <t t-if="!isLegacy">
+      <t t-slot="buttons">
+        <button class="btn btn-primary" t-on-click="_close">
+          <t>Ok</t>
+        </button>
+      </t>
+    </t>
   </t>
 
 </templates>

--- a/addons/web/static/src/webclient/commands/command_palette.js
+++ b/addons/web/static/src/webclient/commands/command_palette.js
@@ -118,7 +118,7 @@ export class CommandPalette extends Component {
 
     executeSelectedCommand() {
         if (this.state.selectedCommand) {
-            this.trigger("dialog-closed");
+            this.props.closeMe();
             this.state.selectedCommand.action();
         }
     }

--- a/addons/web/static/src/webclient/commands/command_palette_dialog.js
+++ b/addons/web/static/src/webclient/commands/command_palette_dialog.js
@@ -1,17 +1,18 @@
 /** @odoo-module **/
 
+import { Dialog } from "@web/core/dialog/dialog";
 import { CommandPalette } from "./command_palette";
 
-const { Component, hooks } = owl;
-const { useExternalListener, useRef } = hooks;
+const { hooks } = owl;
+const { useExternalListener } = hooks;
 
 /**
  * @typedef {import("./command_service").Command} Command
  */
 
-export class CommandPaletteDialog extends Component {
+export class CommandPaletteDialog extends Dialog {
     setup() {
-        this.dialogRef = useRef("dialogRef");
+        super.setup();
         useExternalListener(window, "mousedown", this.onWindowMouseDown);
     }
 
@@ -20,11 +21,17 @@ export class CommandPaletteDialog extends Component {
      */
     onWindowMouseDown(ev) {
         const element = ev.target.parentElement;
-        const gotClickedInside = this.dialogRef.comp.modalRef.el.contains(element);
+        const gotClickedInside = this.modalRef.el.contains(element);
         if (!gotClickedInside) {
-            this.trigger("dialog-closed");
+            this.close();
         }
     }
 }
-CommandPaletteDialog.template = "web.CommandPaletteDialog";
-CommandPaletteDialog.components = { CommandPalette };
+CommandPaletteDialog.renderHeader = false;
+CommandPaletteDialog.renderFooter = false;
+CommandPaletteDialog.contentClass = "o_command_palette";
+CommandPaletteDialog.bodyTemplate = "web.CommandPaletteDialogBody";
+CommandPaletteDialog.components = Object.assign({}, Dialog.components, { CommandPalette });
+CommandPaletteDialog.props = {
+    commands: { type: Array, element: { type: Object } },
+};

--- a/addons/web/static/src/webclient/commands/command_palette_dialog.xml
+++ b/addons/web/static/src/webclient/commands/command_palette_dialog.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-  <t t-name="web.CommandPaletteDialog" owl="1">
-    <Dialog contentClass="'o_command_palette'" renderHeader="false" renderFooter="false" t-ref="dialogRef">
-      <CommandPalette t-props="props"/>
-    </Dialog>
+  <t t-name="web.CommandPaletteDialogBody" owl="1">
+    <CommandPalette t-props="props" closeMe="close"/>
   </t>
 
 </templates>

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -1,9 +1,9 @@
 /** @odoo-module **/
 
+import { Dialog } from "../../core/dialog/dialog";
 import { browser } from "../../core/browser/browser";
 import { registry } from "../../core/registry";
-
-const { Component } = owl;
+import { _lt } from "../../core/l10n/translation";
 
 function documentationItem(env) {
     const documentationURL = "https://www.odoo.com/documentation/14.0";
@@ -33,8 +33,9 @@ function supportItem(env) {
     };
 }
 
-class ShortCutsDialog extends Component {}
-ShortCutsDialog.template = "web.UserMenu.ShortCutsDialog";
+class ShortCutsDialog extends Dialog {}
+ShortCutsDialog.bodyTemplate = "web.UserMenu.shortcutsTable";
+ShortCutsDialog.title = _lt("Shortcuts");
 
 function shortCutsItem(env) {
     return {
@@ -42,8 +43,7 @@ function shortCutsItem(env) {
         id: "shortcuts",
         description: env._t("Shortcuts"),
         callback: () => {
-            const title = env._t("Shortcuts");
-            env.services.dialog.open(ShortCutsDialog, { title });
+            env.services.dialog.open(ShortCutsDialog);
         },
         sequence: 30,
     };

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.UserMenu.ShortCutsDialog" owl="1">
-        <Dialog title="props.title">
-            <t t-call="web.UserMenu.shortcutsTable"/>
-        </Dialog>
-    </t>
-
     <t t-name="web.UserMenu.shortcutsTable" owl="1">
         <div>
             <div class="container-fluid">

--- a/addons/web/static/tests/core/debug/debug_manager_tests.js
+++ b/addons/web/static/tests/core/debug/debug_manager_tests.js
@@ -122,7 +122,7 @@ QUnit.module("DebugManager", (hooks) => {
         dialogContainer.classList.add("o_dialog_container");
         target.append(dialogContainer);
         const env = await makeTestEnv(testConfig);
-        const actionDialog = await mount(ActionDialog, { env, target });
+        const actionDialog = await mount(ActionDialog, { env, target, props: {} });
         registerCleanup(() => {
             actionDialog.destroy();
             target.querySelector(".o_dialog_container").remove();

--- a/addons/web/static/tests/core/dialog_service_tests.js
+++ b/addons/web/static/tests/core/dialog_service_tests.js
@@ -11,6 +11,7 @@ import { registerCleanup } from "../helpers/cleanup";
 import { clearRegistryWithCleanup, makeTestEnv } from "../helpers/mock_env";
 import { makeFakeLocalizationService, makeFakeRPCService } from "../helpers/mock_services";
 import { click, getFixture, makeDeferred, nextTick, patchWithCleanup } from "../helpers/utils";
+import { Dialog } from "../../src/core/dialog/dialog";
 
 const { Component, mount, tags } = owl;
 
@@ -52,8 +53,8 @@ QUnit.module("DialogManager", {
 });
 QUnit.test("Simple rendering with a single dialog", async (assert) => {
     assert.expect(9);
-    class CustomDialog extends Component {}
-    CustomDialog.template = tags.xml`<Dialog title="'Welcome'"/>`;
+    class CustomDialog extends Dialog {}
+    CustomDialog.title = "Welcome";
     pseudoWebClient = await mount(PseudoWebClient, { env, target });
     assert.containsOnce(target, ".o_dialog_manager");
     assert.containsNone(target, ".o_dialog_manager portal");
@@ -70,8 +71,12 @@ QUnit.test("Simple rendering with a single dialog", async (assert) => {
 });
 QUnit.test("rendering with two dialogs", async (assert) => {
     assert.expect(12);
-    class CustomDialog extends Component {}
-    CustomDialog.template = tags.xml`<Dialog title="props.title"/>`;
+    class CustomDialog extends Dialog {
+        setup() {
+            super.setup();
+            this.title = this.props.title;
+        }
+    }
     pseudoWebClient = await mount(PseudoWebClient, { env, target });
     assert.containsOnce(target, ".o_dialog_manager");
     assert.containsNone(target, ".o_dialog_manager portal");
@@ -97,8 +102,12 @@ QUnit.test("rendering with two dialogs", async (assert) => {
 
 QUnit.test("multiple dialogs can become the UI active element", async (assert) => {
     assert.expect(3);
-    class CustomDialog extends Component {}
-    CustomDialog.template = tags.xml`<Dialog title="props.title"/>`;
+    class CustomDialog extends Dialog {
+        setup() {
+            super.setup();
+            this.title = this.props.title;
+        }
+    }
     pseudoWebClient = await mount(PseudoWebClient, { env, target });
 
     env.services.dialog.open(CustomDialog, { title: "Hello" });
@@ -129,12 +138,13 @@ QUnit.test("multiple dialogs can become the UI active element", async (assert) =
 QUnit.test("dialog component crashes", async (assert) => {
     assert.expect(4);
 
-    class FailingDialog extends Component {
+    class FailingDialog extends Dialog {
         setup() {
+            super.setup();
             throw new Error("Some Error");
         }
     }
-    FailingDialog.template = tags.xml`<Dialog title="'Error'"/>`;
+    FailingDialog.title = "Error";
 
     const prom = makeDeferred();
     patchWithCleanup(ErrorDialog.prototype, {

--- a/addons/web/static/tests/legacy/core/owl_dialog_tests.js
+++ b/addons/web/static/tests/legacy/core/owl_dialog_tests.js
@@ -286,7 +286,12 @@ odoo.define('web.owl_dialog_tests', function (require) {
                     this._super();
                 }
             });
-
+            class WowlDialogSubClass extends WowlDialog{
+                setup(){
+                    super.setup();
+                    this.contentClass = this.props.contentClass;
+                }
+            }
             class Parent extends Component {
                 setup() {
                     super.setup();
@@ -307,11 +312,11 @@ odoo.define('web.owl_dialog_tests', function (require) {
                 </div>`;
             const parent = await mount(Parent, { env, target: getFixture() });
 
-            parent.dialogs.push({ id: 1, class: WowlDialog });
+            parent.dialogs.push({ id: 1, class: WowlDialogSubClass });
             await nextTick();
             parent.dialogs.push({ id: 2, class: Dialog });
             await nextTick();
-            parent.dialogs.push({ id: 3, class: WowlDialog });
+            parent.dialogs.push({ id: 3, class: WowlDialogSubClass });
             await nextTick();
 
             assert.verifySteps([]);

--- a/addons/web_tour/static/src/debug/tour_dialog_component.js
+++ b/addons/web_tour/static/src/debug/tour_dialog_component.js
@@ -1,43 +1,39 @@
 /** @odoo-module **/
 
 import { useService } from "@web/core/service_hook";
+import { Dialog } from "@web/core/dialog/dialog";
+import { _lt } from "@web/core/l10n/translation";
 
-export default class ToursDialog extends owl.Component {
-  setup() {
-    this.tourService = useService("tour");
-    this.onboardingTours = this.tourService.getOnboardingTours();
-    this.testingTours = this.tourService.getTestingTours();
-  }
+export default class ToursDialog extends Dialog {
+    setup() {
+        super.setup();
+        this.tourService = useService("tour");
+        this.onboardingTours = this.tourService.getOnboardingTours();
+        this.testingTours = this.tourService.getTestingTours();
+    }
 
-  //--------------------------------------------------------------------------
-  // Getters
-  //--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
 
-  get dialogTitle() {
-    return this.env._t("Tours");
-  }
-
-  //--------------------------------------------------------------------------
-  // Handlers
-  //--------------------------------------------------------------------------
-
-  /**
-   * Resets the given tour to its initial step, in onboarding mode.
-   *
-   * @private
-   * @param {MouseEvent} ev
-   */
-  _onStartTour(ev) {
-    this.tourService.reset(ev.target.dataset.name);
-  }
-  /**
-   * Starts the given tour in test mode.
-   *
-   * @private
-   * @param {MouseEvent} ev
-   */
-  _onTestTour(ev) {
-    this.tourService.run(ev.target.dataset.name);
-  }
+    /**
+     * Resets the given tour to its initial step, in onboarding mode.
+     *
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onStartTour(ev) {
+        this.tourService.reset(ev.target.dataset.name);
+    }
+    /**
+     * Starts the given tour in test mode.
+     *
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onTestTour(ev) {
+        this.tourService.run(ev.target.dataset.name);
+    }
 }
-ToursDialog.template = "web_tour.ToursDialog";
+ToursDialog.bodyTemplate = "web_tour.ToursDialog";
+ToursDialog.title = _lt("Tours");

--- a/addons/web_tour/static/src/debug/tour_dialog_component.xml
+++ b/addons/web_tour/static/src/debug/tour_dialog_component.xml
@@ -2,18 +2,16 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="web_tour.ToursDialog" owl="1">
-    <Dialog title="dialogTitle">
-        <div>
-            <t t-call="web_tour.ToursDialog.Table">
-                <t t-set="caption">Onboarding tours</t>
-                <t t-set="tours" t-value="onboardingTours"/>
-            </t>
-            <t t-if="testingTours.length" t-call="web_tour.ToursDialog.Table">
-                <t t-set="caption">Testing tours</t>
-                <t t-set="tours" t-value="testingTours"/>
-            </t>
-        </div>
-    </Dialog>
+    <div>
+        <t t-call="web_tour.ToursDialog.Table">
+            <t t-set="caption">Onboarding tours</t>
+            <t t-set="tours" t-value="onboardingTours"/>
+        </t>
+        <t t-if="testingTours.length" t-call="web_tour.ToursDialog.Table">
+            <t t-set="caption">Testing tours</t>
+            <t t-set="tours" t-value="testingTours"/>
+        </t>
+    </div>
 </t>
 
 <t t-name="web_tour.ToursDialog.Table" owl="1">


### PR DESCRIPTION
This commit, refactor the dialog api (dialog.js), to easier the creation
of dialog subclasses; force the use of dialog subclass when calling the
dialog service; forbid the use of dialog itself and promotes the use of
dialog subclasses.