### PR TITLE
[FIX] web: close, already closed dialog

### DIFF
--- a/addons/web/static/src/core/dialog/dialog_container.js
+++ b/addons/web/static/src/core/dialog/dialog_container.js
@@ -31,11 +31,13 @@ export class DialogContainer extends Component {
     }
 
     closeDialog(id) {
-        if (this.dialogs[id].options && this.dialogs[id].options.onCloseCallback) {
-            this.dialogs[id].options.onCloseCallback();
+        if (this.dialogs[id]) {
+            if (this.dialogs[id].options && this.dialogs[id].options.onCloseCallback) {
+                this.dialogs[id].options.onCloseCallback();
+            }
+            delete this.dialogs[id];
+            this.render();
         }
-        delete this.dialogs[id];
-        this.render();
     }
 
     errorCallBack(id) {

--- a/addons/web/static/tests/core/dialog_service_tests.js
+++ b/addons/web/static/tests/core/dialog_service_tests.js
@@ -72,6 +72,29 @@ QUnit.test("Simple rendering with a single dialog", async (assert) => {
     assert.containsNone(target, ".o_dialog_manager portal");
     assert.containsNone(target, ".o_dialog_container .o_dialog");
 });
+QUnit.test("Simple rendering and close a single dialog", async (assert) => {
+    assert.expect(9);
+    class CustomDialog extends Dialog {}
+    CustomDialog.title = "Welcome";
+    pseudoWebClient = await mount(PseudoWebClient, { env, target });
+    assert.containsOnce(target, ".o_dialog_manager");
+    assert.containsNone(target, ".o_dialog_manager portal");
+    assert.containsNone(target, ".o_dialog_container .o_dialog");
+    const dialogId = env.services.dialog.open(CustomDialog);
+    await nextTick();
+    assert.containsOnce(target, ".o_dialog_manager portal");
+    assert.containsOnce(target, ".o_dialog_container .o_dialog");
+    assert.strictEqual(target.querySelector("header .modal-title").textContent, "Welcome");
+    env.services.dialog.close(dialogId);
+    await nextTick();
+    assert.containsOnce(target, ".o_dialog_manager");
+    assert.containsNone(target, ".o_dialog_manager portal");
+    assert.containsNone(target, ".o_dialog_container .o_dialog");
+    //call a second time, the close on the dialog.
+    //As the dialog is already close, this call is just ignored. No error should be raised.
+    env.services.dialog.close(dialogId);
+    await nextTick();
+});
 QUnit.test("rendering with two dialogs", async (assert) => {
     assert.expect(12);
     class CustomDialog extends Dialog {


### PR DESCRIPTION
Before this commit, when trying to close an already closed dialog, an
error is raised.