### PR TITLE
[IMP] web: close action service dialog using the 'x' button

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -548,10 +548,21 @@ function makeActionManager(env) {
             }
 
             const { onClose } = dialog;
-            if (dialog.id) {
-                env.services.dialog.close(dialog.id);
+            const oldDialogId = dialog.id;
+            if (oldDialogId) {
+                dialog = {};
+                env.services.dialog.close(oldDialogId);
             }
-            const dialogId = env.services.dialog.open(ActionDialog, actionDialogProps);
+            const dialogId = env.services.dialog.open(ActionDialog, actionDialogProps, {
+                onCloseCallback: () => {
+                    if (dialog.id) {
+                        if (dialog.onClose) {
+                            dialog.onClose();
+                        }
+                        dialog = {};
+                    }
+                },
+            });
             dialog = {
                 id: dialogId,
                 onClose: onClose || options.onClose,
@@ -910,13 +921,14 @@ function makeActionManager(env) {
     async function _executeCloseAction(params = {}) {
         cleanDomFromBootstrap();
         let onClose;
-        if (dialog.id) {
+        const dialogId = dialog.id;
+        if (dialogId) {
             onClose = dialog.onClose;
-            env.services.dialog.close(dialog.id);
+            dialog = {};
+            env.services.dialog.close(dialogId);
         } else {
             onClose = params.onClose;
         }
-        dialog = {};
         if (onClose) {
             await onClose(params.onCloseInfo);
         }


### PR DESCRIPTION
Until now, if a dialog was opened using the action service with an
on_close callback, this callback wasn't called if the dialog was closed
without using the action "ir.actions.act_window_close".

Now, the on_close callback is called after the dialog is closed.