### PR TITLE
[IMP] web: focused command gray change

### DIFF
--- a/addons/web/static/src/webclient/commands/command_palette.scss
+++ b/addons/web/static/src/webclient/commands/command_palette.scss
@@ -58,7 +58,7 @@
       line-height: 1.8em;
 
       &.focused {
-        background: $o-brand-secondary;
+        background: $o-gray-200;
       }
 
       kbd {


### PR DESCRIPTION
Before this commit, the $o-brand-secondary was way too dark for the web_enterprise version.

Using $o-gray-200 we now ensure the gray difference between community and enterprise is thin.