### PR TITLE
[FIX] web: actionService: handle async client actions

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -740,7 +740,7 @@ function makeActionManager(env) {
                 onClose: options.onClose,
             });
         } else {
-            const next = clientAction(env, action);
+            const next = await clientAction(env, action);
             if (next) {
                 return doAction(next, options);
             }

--- a/addons/web/static/tests/webclient/actions/client_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/client_action_tests.js
@@ -122,6 +122,18 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps(["/web/webclient/load_menus"]);
     });
 
+    QUnit.test("async client action (function) returning another action", async function (assert) {
+        assert.expect(1);
+
+        registry.category("actions").add("my_action", async () => {
+            await Promise.resolve();
+            return 1; // execute action 1
+        });
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, "my_action");
+        assert.containsOnce(webClient, ".o_kanban_view");
+    });
+
     QUnit.test("client action with control panel (legacy)", async function (assert) {
         assert.expect(4);
         // LPE Fixme: at this time we don't really know the API that wowl ClientActions implement


### PR DESCRIPTION
A client action can be a function. This function may return another
action to be executed afterwards. This function may also be async.
This is for instance the case of the studio client action. Before
this commit, the code handling it directly called doAction with the
promise as action, which could lead to unexpected results. For
instance, studio tours sometimes fail to load the studio client
action.