### PR TITLE
[FIX] web: implement missing pyjs operation

### DIFF
--- a/addons/web/static/src/core/py_js/py_date.js
+++ b/addons/web/static/src/core/py_js/py_date.js
@@ -447,6 +447,23 @@ export class PyRelativeDelta {
         return new PyDateTime(s.year, s.month, s.day, s.hour, s.minute, s.second, 0);
     }
 
+    /**
+     * @param {PyDate} date
+     * @param {PyRelativeDelta} delta
+     * @returns {PyDateTime}
+     */
+    static substract(date, delta) {
+        const s = tmxxx(
+            date.year,
+            date.month,
+            date.day - delta.day,
+            -delta.hour,
+            -delta.minute,
+            -delta.second
+        );
+        return new PyDateTime(s.year, s.month, s.day, s.hour, s.minute, s.second, 0);
+    }
+
     constructor() {
         this.year = 0;
         this.month = 0;

--- a/addons/web/static/src/core/py_js/py_interpreter.js
+++ b/addons/web/static/src/core/py_js/py_interpreter.js
@@ -126,7 +126,7 @@ function applyBinaryOp(ast, context) {
     const left = evaluate(ast.left, context);
     const right = evaluate(ast.right, context);
     switch (ast.op) {
-        case "+":
+        case "+": {
             const isLeftDelta = left instanceof PyRelativeDelta;
             const isRightDelta = right instanceof PyRelativeDelta;
             if (isLeftDelta || isRightDelta) {
@@ -135,8 +135,14 @@ function applyBinaryOp(ast, context) {
                 return PyRelativeDelta.add(date, delta);
             }
             return left + right;
-        case "-":
+        }
+        case "-": {
+            const isRightDelta = right instanceof PyRelativeDelta;
+            if (isRightDelta) {
+                return PyRelativeDelta.substract(left, right);
+            }
             return left - right;
+        }
         case "*":
             return left * right;
         case "/":

--- a/addons/web/static/tests/core/domain_tests.js
+++ b/addons/web/static/tests/core/domain_tests.js
@@ -1,6 +1,8 @@
 /** @odoo-module **/
 
 import { Domain } from "@web/core/domain";
+import { PyDate } from "../../src/core/py_js/py_date";
+import { patchWithCleanup } from "../helpers/utils";
 
 QUnit.module("domain", {}, () => {
     // ---------------------------------------------------------------------------
@@ -236,6 +238,17 @@ QUnit.module("domain", {}, () => {
         assert.deepEqual(new Domain(`[('date', '!=', 1 + 2)]`).toList(), [["date", "!=", 3]]);
         assert.ok(new Domain(`[('a', '==', 1 + 2)]`).contains({ a: 3 }));
         assert.notOk(new Domain(`[('a', '==', 1 + 2)]`).contains({ a: 2 }));
+    });
+
+    QUnit.test("some expression with date stuff", function (assert) {
+        patchWithCleanup(PyDate, {
+            today() {
+                return new PyDate(2013, 4, 24);
+            },
+        });
+        const domainStr =
+            "[('date','>=', (context_today() - datetime.timedelta(days=30)).strftime('%Y-%m-%d'))]";
+        assert.deepEqual(new Domain(domainStr).toList(), [["date", ">=", "2013-03-25"]]);
     });
 
     QUnit.test("Check that there is no dependency between two domains", function (assert) {

--- a/addons/web/static/tests/core/py_js/py_date_tests.js
+++ b/addons/web/static/tests/core/py_js/py_date_tests.js
@@ -112,6 +112,21 @@ QUnit.module("py", {}, () => {
             assert.strictEqual(evaluateExpr(expr), "2001-04-02");
         });
 
+        QUnit.test("substracting date and relative delta", (assert) => {
+            const expr1 =
+                "(datetime.date(day=3,month=4,year=2001) - relativedelta(days=-1)).strftime('%Y-%m-%d')";
+            assert.strictEqual(evaluateExpr(expr1), "2001-04-04");
+            const expr2 =
+                "(datetime.date(day=3,month=4,year=2001) - relativedelta(weeks=-1)).strftime('%Y-%m-%d')";
+            assert.strictEqual(evaluateExpr(expr2), "2001-04-10");
+            const expr3 =
+                "(datetime.date(day=3,month=4,year=2001) - relativedelta(days=1)).strftime('%Y-%m-%d')";
+            assert.strictEqual(evaluateExpr(expr3), "2001-04-02");
+            const expr4 =
+                "(datetime.date(day=3,month=4,year=2001) - relativedelta(weeks=1)).strftime('%Y-%m-%d')";
+            assert.strictEqual(evaluateExpr(expr4), "2001-03-27");
+        });
+
         QUnit.module("datetime.timedelta");
 
         QUnit.test("adding date and time delta", (assert) => {


### PR DESCRIPTION
The new py interpreter was missing the subtraction of a date with a
relativedelta