### PR TITLE
[IMP] web: remove the Portal from dialog 

### DIFF
--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -4,29 +4,23 @@ import { useHotkey } from "../hotkey_hook";
 import { useService } from "../service_hook";
 import { useActiveElement } from "../ui/ui_service";
 
-const { Component, hooks, misc } = owl;
+const { Component, hooks } = owl;
 const { useRef, useSubEnv } = hooks;
-const { Portal } = misc;
 
 export class Dialog extends Component {
-    constructor(...args) {
-        super(...args);
+    setup() {
         if (this.constructor === Dialog) {
             throw new Error(
                 "Dialog should not be used by itself. Please use the dialog service with a Dialog subclass."
             );
         }
-    }
-    setup() {
         this.modalRef = useRef("modal");
         this.dialogService = useService("dialog");
         useActiveElement("modal");
         useHotkey(
             "escape",
             () => {
-                if (!this.modalRef.el.classList.contains("o_inactive_modal")) {
-                    this.close();
-                }
+                this.close();
             },
             { altIsOptional: true }
         );
@@ -42,30 +36,6 @@ export class Dialog extends Component {
         this.__id = null;
     }
 
-    mounted() {
-        const dialogContainer = document.querySelector(".o_dialog_container");
-        const modals = dialogContainer.querySelectorAll(".o_dialog .modal");
-        const len = modals.length;
-        for (let i = 0; i < len - 1; i++) {
-            const modal = modals[i];
-            modal.classList.add("o_inactive_modal");
-        }
-        dialogContainer.classList.add("modal-open");
-    }
-
-    willUnmount() {
-        const dialogContainer = document.querySelector(".o_dialog_container");
-        const modals = dialogContainer.querySelectorAll(".o_dialog .modal");
-        const len = modals.length;
-        if (len >= 2) {
-            const modal = this.modalRef.el === modals[len - 1] ? modals[len - 2] : modals[len - 1];
-            modal.focus();
-            modal.classList.remove("o_inactive_modal");
-        } else {
-            dialogContainer.classList.remove("modal-open");
-        }
-    }
-
     /**
      * Send an event signaling that the dialog should be closed.
      * @private
@@ -75,7 +45,6 @@ export class Dialog extends Component {
     }
 }
 
-Dialog.components = { Portal };
 Dialog.template = "web.Dialog";
 Dialog.contentClass = null;
 Dialog.fullscreen = false;

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -2,32 +2,30 @@
 <templates xml:space="preserve">
 
     <t t-name="web.Dialog" owl="1">
-        <Portal target="'.o_dialog_container'">
-            <div class="o_dialog">
-                <div role="dialog" class="modal"
-                    tabindex="-1"
-                    t-att-class="{ o_technical_modal: technical, o_modal_full: fullscreen }"
-                    t-ref="modal"
-                    >
-                    <div class="modal-dialog" t-att-class="size">
-                        <div class="modal-content" t-att-class="contentClass">
-                            <header t-if="renderHeader" class="modal-header">
-                                <h4 class="modal-title">
-                                    <t t-esc="title"/>
-                                </h4>
-                                <button type="button" class="close" aria-label="Close" tabindex="-1" t-on-click="close">×</button>
-                            </header>
-                            <main class="modal-body">
-                                <t t-call="{{ constructor.bodyTemplate }}"/>
-                            </main>
-                            <footer t-if="renderFooter" class="modal-footer">
-                                <t t-call="{{ constructor.footerTemplate }}" />
-                            </footer>
-                        </div>
+        <div class="o_dialog">
+            <div role="dialog" class="modal"
+                tabindex="-1"
+                t-att-class="{ o_technical_modal: technical, o_modal_full: fullscreen }"
+                t-ref="modal"
+                >
+                <div class="modal-dialog" t-att-class="size">
+                    <div class="modal-content" t-att-class="contentClass">
+                        <header t-if="renderHeader" class="modal-header">
+                            <h4 class="modal-title">
+                                <t t-esc="title"/>
+                            </h4>
+                            <button type="button" class="close" aria-label="Close" tabindex="-1" t-on-click="close">×</button>
+                        </header>
+                        <main class="modal-body">
+                            <t t-call="{{ constructor.bodyTemplate }}"/>
+                        </main>
+                        <footer t-if="renderFooter" class="modal-footer">
+                            <t t-call="{{ constructor.footerTemplate }}" />
+                        </footer>
                     </div>
                 </div>
             </div>
-        </Portal>
+        </div>
     </t>
 
     <t t-name="web.DialogFooterDefault" owl="1">

--- a/addons/web/static/src/core/dialog/dialog_container.js
+++ b/addons/web/static/src/core/dialog/dialog_container.js
@@ -51,9 +51,10 @@ export class DialogContainer extends Component {
 }
 DialogContainer.components = { ErrorHandler };
 DialogContainer.template = tags.xml`
-    <div class="o_dialog_manager">
+    <div class="o_dialog_container" t-att-class="{'modal-open': Object.keys(dialogs).length > 0}">
       <t t-foreach="Object.values(dialogs)" t-as="dialog" t-key="dialog.id">
-        <ErrorHandler dialog="dialog" t-on-dialog-closed="onDialogClosed(dialog.id)" callback="errorCallBack(dialog.id)" />
+        <ErrorHandler dialog="dialog" t-on-dialog-closed="onDialogClosed(dialog.id)" callback="errorCallBack(dialog.id)"
+            t-att-class="{o_inactive_modal: !dialog_last}"/>
       </t>
     </div>
     `;

--- a/addons/web/static/src/webclient/webclient.xml
+++ b/addons/web/static/src/webclient/webclient.xml
@@ -5,7 +5,6 @@
         <body class="o_web_client" t-att-class="{'o_is_superuser': user.userId === 1}">
             <NavBar/>
             <ActionContainer/>
-            <div class="o_dialog_container"/>
             <div>
                 <t t-foreach="Components" t-as="C" t-key="C[0]">
                     <t t-component="C[1].Component" t-props="C[1].props"/>

--- a/addons/web/static/tests/core/debug/debug_manager_tests.js
+++ b/addons/web/static/tests/core/debug/debug_manager_tests.js
@@ -122,16 +122,12 @@ QUnit.module("DebugMenu", (hooks) => {
     });
 
     QUnit.test("Don't display the DebugMenu if debug mode is disabled", async (assert) => {
-        const dialogContainer = document.createElement("div");
-        dialogContainer.classList.add("o_dialog_container");
-        target.append(dialogContainer);
         const env = await makeTestEnv(testConfig);
         const actionDialog = await mount(ActionDialog, { env, target, props: {} });
         registerCleanup(() => {
             actionDialog.destroy();
-            target.querySelector(".o_dialog_container").remove();
         });
-        assert.containsOnce(target, "div.o_dialog_container .o_dialog");
+        assert.containsOnce(target, ".o_dialog");
         assert.containsNone(target, ".o_dialog .o_debug_manager .fa-bug");
     });
 
@@ -139,9 +135,6 @@ QUnit.module("DebugMenu", (hooks) => {
         "Display the DebugMenu correctly in a ActionDialog if debug mode is enabled",
         async (assert) => {
             assert.expect(8);
-            const dialogContainer = document.createElement("div");
-            dialogContainer.classList.add("o_dialog_container");
-            target.append(dialogContainer);
             debugRegistry.add("global", () => {
                 return {
                     type: "item",
@@ -188,12 +181,11 @@ QUnit.module("DebugMenu", (hooks) => {
             const actionDialog = await mount(Parent, { env, target });
             registerCleanup(() => {
                 actionDialog.destroy();
-                target.querySelector(".o_dialog_container").remove();
             });
-            assert.containsOnce(target, "div.o_dialog_container .o_dialog");
+            assert.containsOnce(target, ".o_dialog");
             assert.containsOnce(target, ".o_dialog .o_debug_manager .fa-bug");
             await click(target, ".o_dialog .o_debug_manager button");
-            const debugManagerEl = target.querySelector(".o_dialog_container .o_debug_manager");
+            const debugManagerEl = target.querySelector(".o_debug_manager");
             assert.containsN(debugManagerEl, "ul.o_dropdown_menu li.o_dropdown_item", 2);
             // Check that global debugManager elements are not displayed (global_1)
             const items =

--- a/addons/web/static/tests/core/errors/error_dialogs_tests.js
+++ b/addons/web/static/tests/core/errors/error_dialogs_tests.js
@@ -25,9 +25,6 @@ const serviceRegistry = registry.category("services");
 QUnit.module("Error dialogs", {
     async beforeEach() {
         target = getFixture();
-        const dialogContainer = document.createElement("div");
-        dialogContainer.classList.add("o_dialog_container");
-        target.append(dialogContainer);
         serviceRegistry.add("ui", uiService);
         serviceRegistry.add("hotkey", hotkeyService);
         serviceRegistry.add("localization", makeFakeLocalizationService());
@@ -54,7 +51,7 @@ QUnit.test("ErrorDialog with traceback", async (assert) => {
     assert.containsNone(target, ".o_dialog");
     env = await makeTestEnv();
     parent = await mount(Parent, { env, target });
-    assert.containsOnce(target, "div.o_dialog_container .o_dialog");
+    assert.containsOnce(target, ".o_dialog");
     assert.strictEqual(target.querySelector("header .modal-title").textContent, "Odoo Error");
     const mainButtons = target.querySelectorAll("main button");
     assert.deepEqual(
@@ -106,7 +103,7 @@ QUnit.test("Client ErrorDialog with traceback", async (assert) => {
     assert.containsNone(target, ".o_dialog");
     env = await makeTestEnv();
     parent = await mount(Parent, { env, target });
-    assert.containsOnce(target, "div.o_dialog_container .o_dialog");
+    assert.containsOnce(target, ".o_dialog");
     assert.strictEqual(
         target.querySelector("header .modal-title").textContent,
         "Odoo Client Error"
@@ -196,7 +193,7 @@ QUnit.test("WarningDialog", async (assert) => {
     assert.containsNone(target, ".o_dialog");
     env = await makeTestEnv();
     parent = await mount(Parent, { env, target });
-    assert.containsOnce(target, "div.o_dialog_container .o_dialog");
+    assert.containsOnce(target, ".o_dialog");
     assert.strictEqual(target.querySelector("header .modal-title").textContent, "User Error");
     assert.containsOnce(target, "main .o_dialog_warning");
     assert.strictEqual(target.querySelector("main").textContent, "Some strange unreadable message");
@@ -242,7 +239,7 @@ QUnit.test("RedirectWarningDialog", async (assert) => {
     env = await makeTestEnv();
     assert.containsNone(target, ".o_dialog");
     parent = await mount(Parent, { env, target });
-    assert.containsOnce(target, "div.o_dialog_container .o_dialog");
+    assert.containsOnce(target, ".o_dialog");
     assert.strictEqual(target.querySelector("header .modal-title").textContent, "Odoo Warning");
     assert.strictEqual(target.querySelector("main").textContent, "Some strange unreadable message");
     let footerButtons = target.querySelectorAll("footer button");
@@ -265,7 +262,7 @@ QUnit.test("Error504Dialog", async (assert) => {
     assert.containsNone(target, ".o_dialog");
     env = await makeTestEnv();
     parent = await mount(Parent, { env, target });
-    assert.containsOnce(target, "div.o_dialog_container .o_dialog");
+    assert.containsOnce(target, ".o_dialog");
     assert.strictEqual(target.querySelector("header .modal-title").textContent, "Request timeout");
     assert.strictEqual(
         target.querySelector("main p").textContent,
@@ -289,7 +286,7 @@ QUnit.test("SessionExpiredDialog", async (assert) => {
     env = await makeTestEnv();
     assert.containsNone(target, ".o_dialog");
     parent = await mount(Parent, { env, target });
-    assert.containsOnce(target, "div.o_dialog_container .o_dialog");
+    assert.containsOnce(target, ".o_dialog");
     assert.strictEqual(
         target.querySelector("header .modal-title").textContent,
         "Odoo Session Expired"


### PR DESCRIPTION
In this commit, we simplify the dialog template by removing the Portal.
The Portal is no longer used, as now we always use the dialog service to
open a new dialog.

also:

- remove the dialog container class from the webclient;
- add the dialog container class to the dialog container;
- move the management of the inactive modal class to the dialog container;
- remove the dialog manager class from the dialog container;