### PR TITLE
[FIX] web: traceback when assets loading fails

### DIFF
--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -4,6 +4,8 @@ const { useEnv, onWillStart } = owl.hooks;
 import { memoize } from "./utils/functions";
 import { browser } from "./browser/browser";
 
+class AssetsLoadingError extends Error {}
+
 //------------------------------------------------------------------------------
 // Types
 //------------------------------------------------------------------------------
@@ -59,7 +61,9 @@ const loadJS = memoize(function loadJS(url) {
     document.head.appendChild(scriptEl);
     return new Promise((resolve, reject) => {
         scriptEl.addEventListener("load", resolve);
-        scriptEl.addEventListener("error", reject);
+        scriptEl.addEventListener("error", () => {
+            reject(new AssetsLoadingError(`The loading of ${url} failed`));
+        });
     });
 });
 /**
@@ -83,7 +87,9 @@ const loadCSS = memoize(function loadCSS(url) {
     document.head.appendChild(linkEl);
     return new Promise(function (resolve, reject) {
         linkEl.addEventListener("load", resolve);
-        linkEl.addEventListener("error", reject);
+        linkEl.addEventListener("error", () => {
+            reject(new AssetsLoadingError(`The loading of ${url} failed`));
+        });
     });
 });
 /**

--- a/addons/web/static/tests/core/utils/assets_tests.js
+++ b/addons/web/static/tests/core/utils/assets_tests.js
@@ -10,6 +10,7 @@ QUnit.module("utils", () => {
     QUnit.test("loadAssets: load invalid JS lib", function (assert) {
         assert.rejects(
             loadAssets({ jsLibs: ["/some/invalid/file.js"] }),
+            new RegExp("The loading of /some/invalid/file.js failed"),
             "Trying to load an invalid file rejects the promise"
         );
         assert.ok(
@@ -21,6 +22,7 @@ QUnit.module("utils", () => {
     QUnit.test("loadAssets: load invalid CSS lib", function (assert) {
         assert.rejects(
             loadAssets({ cssLibs: ["/some/invalid/file.css"] }),
+            new RegExp("The loading of /some/invalid/file.css failed"),
             "Trying to load an invalid file rejects the promise"
         );
         assert.ok(


### PR DESCRIPTION
Before this commit, if the loading of a js or a css asset would fail
(via useAssets), a traceback with an incorrect message would appear.
This was due to the fact that a promise was rejected with an event as
parameter. We correct this by rejecting the promise with a custom error