### PR TITLE
[REF] web: change effect service API

### DIFF
--- a/addons/web/static/src/legacy/legacy_service_provider.js
+++ b/addons/web/static/src/legacy/legacy_service_provider.js
@@ -8,10 +8,10 @@ export const legacyServiceProvider = {
     dependencies: ["effect"],
     start({ services }) {
         browser.addEventListener("show-effect", (ev) => {
-            services.effect.create(ev.detail.type, ev.detail);
+            services.effect.add(ev.detail.type, ev.detail);
         });
         bus.on("show-effect", this, (payload) => {
-            services.effect.create(payload.type, payload);
+            services.effect.add(payload.type, payload);
         });
     },
 };

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1058,7 +1058,7 @@ function makeActionManager(env) {
             await _executeCloseAction();
         }
         if (effect) {
-            env.services.effect.create(effect.type, effect);
+            env.services.effect.add(effect.type, effect);
         }
     }
 

--- a/addons/web/static/src/webclient/effects/effect_service.js
+++ b/addons/web/static/src/webclient/effects/effect_service.js
@@ -91,7 +91,7 @@ export const effectService = {
          *    All the options for the effect.
          *    The options get passed to the more specific effect methods.
          */
-        function create(type, params = {}) {
+        function add(type, params = {}) {
             switch (type.replace("_", "").toLowerCase()) {
                 case "rainbowman":
                     return rainbowMan(params);
@@ -100,7 +100,7 @@ export const effectService = {
             }
         }
 
-        return { create, rainbowMan };
+        return { add };
     },
 };
 

--- a/addons/web/static/tests/webclient/actions/effects_tests.js
+++ b/addons/web/static/tests/webclient/actions/effects_tests.js
@@ -26,7 +26,7 @@ QUnit.module("ActionManager", (hooks) => {
         await doAction(webClient, 1);
         assert.containsOnce(webClient.el, ".o_kanban_view");
         assert.containsNone(webClient.el, ".o_reward");
-        webClient.env.services.effect.rainbowMan({ message: "", fadeout: "no" });
+        webClient.env.services.effect.add("rainbowman", { message: "", fadeout: "no" });
         await nextTick();
         await legacyExtraNextTick();
         assert.containsOnce(webClient.el, ".o_reward");
@@ -35,7 +35,7 @@ QUnit.module("ActionManager", (hooks) => {
         await legacyExtraNextTick();
         assert.containsNone(webClient.el, ".o_reward");
         assert.containsOnce(webClient.el, ".o_kanban_view");
-        webClient.env.services.effect.rainbowMan({ message: "", fadeout: "no" });
+        webClient.env.services.effect.add("rainbowman", { message: "", fadeout: "no" });
         await nextTick();
         await legacyExtraNextTick();
         assert.containsOnce(webClient.el, ".o_reward");
@@ -55,7 +55,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.containsOnce(webClient.el, ".o_kanban_view");
         assert.containsNone(webClient.el, ".o_reward");
         assert.containsNone(webClient.el, ".o_notification");
-        webClient.env.services.effect.rainbowMan({ message: "", fadeout: "no" });
+        webClient.env.services.effect.add("rainbowman", { message: "", fadeout: "no" });
         await nextTick();
         await legacyExtraNextTick();
         assert.containsOnce(webClient.el, ".o_kanban_view");

--- a/addons/web/static/tests/webclient/effects/rainbow_man_tests.js
+++ b/addons/web/static/tests/webclient/effects/rainbow_man_tests.js
@@ -42,7 +42,7 @@ QUnit.module("RainbowMan", (hooks) => {
         RainbowMan.rainbowFadeouts = { nextTick: 0 };
         const env = await makeTestEnv({ serviceRegistry });
         const parent = await mount(Parent, { env, target });
-        env.services.effect.rainbowMan(rainbowManDefault);
+        env.services.effect.add("rainbowman", rainbowManDefault);
         await nextTick();
         assert.containsOnce(target, ".o_reward");
         assert.containsOnce(parent.el, ".o_reward_rainbow");
@@ -64,7 +64,7 @@ QUnit.module("RainbowMan", (hooks) => {
         rainbowManDefault.fadeout = "no";
         const env = await makeTestEnv({ serviceRegistry });
         const parent = await mount(Parent, { env, target });
-        env.services.effect.rainbowMan(rainbowManDefault);
+        env.services.effect.add("rainbowman", rainbowManDefault);
         await nextTick();
         assert.containsOnce(parent.el, ".o_reward");
         assert.containsOnce(parent.el, ".o_reward_rainbow");


### PR DESCRIPTION
Before this commit, effect service provided two functions:
  create(type, params)
  rainbowMan(params)

Now, it provides one function add which is create but renamed
rainbowMan function can be called by doing:
  service.add("rainbowman", ...);