### PR TITLE
[FIX] web: fix call to load_menus

### DIFF
--- a/addons/web/models/ir_ui_menu.py
+++ b/addons/web/models/ir_ui_menu.py
@@ -7,7 +7,7 @@ class IrUiMenu(models.Model):
     _inherit = "ir.ui.menu"
 
     def load_web_menus(self, debug):
-        menus = super(IrUiMenu, self).load_menus(debug)
+        menus = self.load_menus(debug)
 
         web_menus = {}
         for menu in menus.values():


### PR DESCRIPTION
before this commit, we called super().load_menus() in ir_ui_menus
it was harmless but still incorrect in the long run

after this commit, we call just self.load_menus