### PR TITLE
[IMP/FIX/REF] web: sample server and mock server

### DIFF
--- a/addons/web/static/src/search/favorite_menu/custom_favorite_item.js
+++ b/addons/web/static/src/search/favorite_menu/custom_favorite_item.js
@@ -26,7 +26,7 @@ export class CustomFavoriteItem extends Component {
      */
     saveFavorite(ev) {
         if (!this.state.description.length) {
-            this.notificationService.create(
+            this.notificationService.add(
                 this.env._t("A name for your favorite filter is required."),
                 { type: "danger" }
             );
@@ -37,12 +37,9 @@ export class CustomFavoriteItem extends Component {
             (s) => s.type === "favorite" && s.description === this.state.description
         );
         if (favorites.length) {
-            this.notificationService.create(
-                this.env._t("A filter with same name already exists."),
-                {
-                    type: "danger",
-                }
-            );
+            this.notificationService.add(this.env._t("A filter with same name already exists."), {
+                type: "danger",
+            });
             ev.stopPropagation();
             return this.descriptionRef.el.focus();
         }

--- a/addons/web/static/src/views/helpers/sample_server.js
+++ b/addons/web/static/src/views/helpers/sample_server.js
@@ -2,6 +2,7 @@
 
 import { groupBy as arrayGroupBy, sortBy as arraySortBy } from "@web/core/utils/arrays";
 import { registry } from "@web/core/registry";
+import { ORM } from "../../core/orm_service";
 
 class UnimplementedRouteError extends Error {}
 
@@ -691,3 +692,13 @@ SampleServer.PEOPLE_MODELS = [
 ];
 
 SampleServer.UnimplementedRouteError = UnimplementedRouteError;
+
+export function buildSampleORM(resModel, fields, user) {
+    const sampleServer = new SampleServer(resModel, fields);
+    const fakeRPC = async (_, params) => {
+        const { kwargs, method, model } = params;
+        const { groupby: groupBy } = kwargs;
+        return sampleServer.mockRpc({ method, model, ...kwargs, groupBy });
+    };
+    return new ORM(fakeRPC, user);
+}

--- a/addons/web/static/src/views/helpers/sample_server.js
+++ b/addons/web/static/src/views/helpers/sample_server.js
@@ -3,6 +3,7 @@
 import { groupBy as arrayGroupBy, sortBy as arraySortBy } from "@web/core/utils/arrays";
 import { registry } from "@web/core/registry";
 import { ORM } from "../../core/orm_service";
+import { parseDate } from "@web/core/l10n/dates";
 
 class UnimplementedRouteError extends Error {}
 
@@ -183,7 +184,7 @@ export class SampleServer {
         const { type, interval, relation } = options;
         if (["date", "datetime"].includes(type)) {
             const fmt = SampleServer.FORMATS[interval];
-            return moment(value).format(fmt);
+            return parseDate(value).toFormat(fmt);
         } else if (type === "many2one") {
             const rec = this.data[relation].records.find(({ id }) => id === value);
             return [value, rec.display_name];
@@ -235,7 +236,7 @@ export class SampleServer {
                 return false;
             case "date":
             case "datetime": {
-                const format = field.type === "date" ? "YYYY-MM-DD" : "YYYY-MM-DD HH:mm:ss";
+                const format = field.type === "date" ? "yyyy-MM-dd" : "yyyy-MM-dd HH:mm:ss";
                 return this._getRandomDate(format);
             }
             case "float":
@@ -307,7 +308,7 @@ export class SampleServer {
      */
     _getRandomDate(format) {
         const delta = Math.floor((Math.random() - Math.random()) * SampleServer.DATE_DELTA);
-        return new moment().add(delta, "hour").format(format);
+        return luxon.DateTime.local().plus({ hours: delta }).toFormat(format);
     }
 
     /**
@@ -450,7 +451,7 @@ export class SampleServer {
             result = arraySortBy(result, (group) => {
                 const val = group[alias];
                 if (["date", "datetime"].includes(type)) {
-                    return moment(val, SampleServer.FORMATS[interval]);
+                    return parseDate(val, { format: SampleServer.FORMATS[interval] });
                 }
                 return val;
             });
@@ -649,13 +650,13 @@ export class SampleServer {
 }
 
 SampleServer.FORMATS = {
-    day: "YYYY-MM-DD",
-    week: "[W]ww YYYY",
-    month: "MMMM YYYY",
-    quarter: "[Q]Q YYYY",
-    year: "Y",
+    day: "yyyy-MM-dd",
+    week: "'W'WW kkkk",
+    month: "MMMM yyyy",
+    quarter: "'Q'q yyyy",
+    year: "y",
 };
-SampleServer.DISPLAY_FORMATS = Object.assign({}, SampleServer.FORMATS, { day: "DD MMM YYYY" });
+SampleServer.DISPLAY_FORMATS = Object.assign({}, SampleServer.FORMATS, { day: "dd MMM yyyy" });
 
 SampleServer.MAIN_RECORDSET_SIZE = 16;
 SampleServer.SUB_RECORDSET_SIZE = 5;

--- a/addons/web/static/src/views/helpers/standard_view_props.js
+++ b/addons/web/static/src/views/helpers/standard_view_props.js
@@ -24,6 +24,7 @@ export const standardViewProps = {
     domains: { type: Array, elements: Object },
     fields: { type: Object, elements: Object },
     groupBy: { type: Array, elements: String },
+    limit: { type: Number, optional: 1 },
     orderBy: { type: Array, elements: String },
     useSampleModel: { type: Boolean },
     state: { type: Object, optional: 1 },

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -389,9 +389,13 @@ function makeActionManager(env) {
         }
 
         const specialKeys = ["help", "useSampleModel", "limit", "count"];
-        for (const key in specialKeys) {
+        for (const key of specialKeys) {
             if (key in action) {
-                viewProps[key] = action;
+                if (key === "help") {
+                    viewProps.noContentHelp = action.help;
+                } else {
+                    viewProps[key] = action[key];
+                }
             }
         }
 

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -378,6 +378,17 @@ export class MockServer {
     }
 
     _performRPC(route, args) {
+        // Check if there is an handler in the mockRegistry: either specific for this model
+        // (with key 'model/method'), or global (with key 'method')
+        // This allows to mock routes/methods defined outside web.
+        const methodName = args.method || route;
+        const mockFunction =
+            registry.category("mock_server").get(`${args.model}/${methodName}`, null) ||
+            registry.category("mock_server").get(methodName, null);
+        if (mockFunction) {
+            return mockFunction.call(this, route, args);
+        }
+
         switch (route) {
             case "/web/webclient/load_menus":
                 return Promise.resolve(this.mockLoadMenus());

--- a/addons/web/static/tests/search/custom_favorite_item_tests.js
+++ b/addons/web/static/tests/search/custom_favorite_item_tests.js
@@ -463,7 +463,7 @@ QUnit.module("Search", (hooks) => {
                 {
                     start() {
                         return {
-                            create(message, options) {
+                            add(message, options) {
                                 assert.strictEqual(
                                     message,
                                     "A filter with same name already exists."

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -559,7 +559,7 @@ QUnit.module("Views", (hooks) => {
                 `,
                 domains,
             });
-            checkLabels(assert, graph, ["W5 2021", "W7 2021", "", ""]);
+            checkLabels(assert, graph, ["W05 2021", "W07 2021", "", ""]);
             checkDatasets(
                 assert,
                 graph,
@@ -585,7 +585,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "W5 2021 / February 2021", value: "14" }],
+                    lines: [{ label: "W05 2021 / February 2021", value: "14" }],
                 },
                 0,
                 0
@@ -595,7 +595,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "W1 2021 / January 2021", value: "12" }],
+                    lines: [{ label: "W01 2021 / January 2021", value: "12" }],
                 },
                 0,
                 1
@@ -605,7 +605,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "W2 2021 / January 2021", value: "5" }],
+                    lines: [{ label: "W02 2021 / January 2021", value: "5" }],
                 },
                 1,
                 1
@@ -615,7 +615,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "W3 2021 / January 2021", value: "15" }],
+                    lines: [{ label: "W03 2021 / January 2021", value: "15" }],
                 },
                 2,
                 1
@@ -625,7 +625,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "W4 2021 / January 2021", value: "2" }],
+                    lines: [{ label: "W04 2021 / January 2021", value: "2" }],
                 },
                 3,
                 1
@@ -684,40 +684,40 @@ QUnit.module("Views", (hooks) => {
                         backgroundColor: "#1f77b4",
                         borderColor: undefined,
                         data: [14, 0],
-                        label: "February 2021 / W5 2021",
+                        label: "February 2021 / W05 2021",
                     },
                     {
                         backgroundColor: "#ff7f0e",
                         borderColor: undefined,
                         data: [0, 0],
-                        label: "February 2021 / W7 2021",
+                        label: "February 2021 / W07 2021",
                     },
                     {
                         backgroundColor: "#aec7e8",
                         borderColor: undefined,
                         data: [12, 0],
-                        label: "January 2021 / W1 2021",
+                        label: "January 2021 / W01 2021",
                     },
                     {
                         backgroundColor: "#ffbb78",
                         borderColor: undefined,
                         data: [0, 5],
-                        label: "January 2021 / W2 2021",
+                        label: "January 2021 / W02 2021",
                     },
                 ]
             );
             checkLegend(assert, graph, [
-                "February 2021 / W5 2021",
-                "February 2021 / W7 2021",
-                "January 2021 / W1 2021",
-                "January 2021 / W2 2021",
+                "February 2021 / W05 2021",
+                "February 2021 / W07 2021",
+                "January 2021 / W01 2021",
+                "January 2021 / W02 2021",
             ]);
             checkTooltip(
                 assert,
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "true / February 2021 / W5 2021", value: "14" }],
+                    lines: [{ label: "true / February 2021 / W05 2021", value: "14" }],
                 },
                 0,
                 0
@@ -727,7 +727,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "true / January 2021 / W1 2021", value: "12" }],
+                    lines: [{ label: "true / January 2021 / W01 2021", value: "12" }],
                 },
                 0,
                 2
@@ -737,7 +737,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "false / January 2021 / W2 2021", value: "5" }],
+                    lines: [{ label: "false / January 2021 / W02 2021", value: "5" }],
                 },
                 1,
                 3
@@ -1041,7 +1041,7 @@ QUnit.module("Views", (hooks) => {
                 `,
                 domains,
             });
-            checkLabels(assert, graph, ["W5 2021", "W7 2021", "", ""]);
+            checkLabels(assert, graph, ["W05 2021", "W07 2021", "", ""]);
             checkDatasets(
                 assert,
                 graph,
@@ -1068,8 +1068,8 @@ QUnit.module("Views", (hooks) => {
                 {
                     title: "Revenue",
                     lines: [
-                        { label: "W5 2021 / February 2021", value: "14" },
-                        { label: "W1 2021 / January 2021", value: "12" },
+                        { label: "W05 2021 / February 2021", value: "14" },
+                        { label: "W01 2021 / January 2021", value: "12" },
                     ],
                 },
                 0
@@ -1080,8 +1080,8 @@ QUnit.module("Views", (hooks) => {
                 {
                     title: "Revenue",
                     lines: [
-                        { label: "W2 2021 / January 2021", value: "5" },
-                        { label: "W7 2021 / February 2021", value: "0" },
+                        { label: "W02 2021 / January 2021", value: "5" },
+                        { label: "W07 2021 / February 2021", value: "0" },
                     ],
                 },
                 1
@@ -1091,7 +1091,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "W3 2021 / January 2021", value: "15" }],
+                    lines: [{ label: "W03 2021 / January 2021", value: "15" }],
                 },
                 2
             );
@@ -1100,7 +1100,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "W4 2021 / January 2021", value: "2" }],
+                    lines: [{ label: "W04 2021 / January 2021", value: "2" }],
                 },
                 3
             );
@@ -1158,33 +1158,33 @@ QUnit.module("Views", (hooks) => {
                         backgroundColor: undefined,
                         borderColor: "#1f77b4",
                         data: [14, 0],
-                        label: "February 2021 / W5 2021",
+                        label: "February 2021 / W05 2021",
                     },
                     {
                         backgroundColor: undefined,
                         borderColor: "#ff7f0e",
                         data: [0, 0],
-                        label: "February 2021 / W7 2021",
+                        label: "February 2021 / W07 2021",
                     },
                     {
                         backgroundColor: undefined,
                         borderColor: "#aec7e8",
                         data: [12, 0],
-                        label: "January 2021 / W1 2021",
+                        label: "January 2021 / W01 2021",
                     },
                     {
                         backgroundColor: undefined,
                         borderColor: "#ffbb78",
                         data: [0, 5],
-                        label: "January 2021 / W2 2021",
+                        label: "January 2021 / W02 2021",
                     },
                 ]
             );
             checkLegend(assert, graph, [
-                "February 2021 / W5 2021",
-                "February 2021 / W7 2021",
-                "January 2021 / W1 2021",
-                "January 2021 / W2 2021",
+                "February 2021 / W05 2021",
+                "February 2021 / W07 2021",
+                "January 2021 / W01 2021",
+                "January 2021 / W02 2021",
             ]);
             checkTooltip(
                 assert,
@@ -1192,10 +1192,10 @@ QUnit.module("Views", (hooks) => {
                 {
                     title: "Revenue",
                     lines: [
-                        { label: "true / February 2021 / W5 2021", value: "14" },
-                        { label: "true / January 2021 / W1 2021", value: "12" },
-                        { label: "true / February 2021 / W7 2021", value: "0" },
-                        { label: "true / January 2021 / W2 2021", value: "0" },
+                        { label: "true / February 2021 / W05 2021", value: "14" },
+                        { label: "true / January 2021 / W01 2021", value: "12" },
+                        { label: "true / February 2021 / W07 2021", value: "0" },
+                        { label: "true / January 2021 / W02 2021", value: "0" },
                     ],
                 },
                 0
@@ -1206,10 +1206,10 @@ QUnit.module("Views", (hooks) => {
                 {
                     title: "Revenue",
                     lines: [
-                        { label: "false / January 2021 / W2 2021", value: "5" },
-                        { label: "false / February 2021 / W5 2021", value: "0" },
-                        { label: "false / February 2021 / W7 2021", value: "0" },
-                        { label: "false / January 2021 / W1 2021", value: "0" },
+                        { label: "false / January 2021 / W02 2021", value: "5" },
+                        { label: "false / February 2021 / W05 2021", value: "0" },
+                        { label: "false / February 2021 / W07 2021", value: "0" },
+                        { label: "false / January 2021 / W01 2021", value: "0" },
                     ],
                 },
                 1
@@ -1494,10 +1494,10 @@ QUnit.module("Views", (hooks) => {
                 domains,
             });
             checkLabels(assert, graph, [
-                "W5 2021, W1 2021",
-                "W7 2021, W2 2021",
-                "W3 2021",
-                "W4 2021",
+                "W05 2021, W01 2021",
+                "W07 2021, W02 2021",
+                "W03 2021",
+                "W04 2021",
             ]);
             checkDatasets(
                 assert,
@@ -1519,16 +1519,16 @@ QUnit.module("Views", (hooks) => {
                 ]
             );
             checkLegend(assert, graph, [
-                "W5 2021, W1 2021",
-                "W7 2021, W2 2021",
-                "W3 2021",
-                "W4 2021",
+                "W05 2021, W01 2021",
+                "W07 2021, W02 2021",
+                "W03 2021",
+                "W04 2021",
             ]);
             checkTooltip(
                 assert,
                 graph,
                 {
-                    lines: [{ label: "February 2021 / W5 2021", value: "1" }],
+                    lines: [{ label: "February 2021 / W05 2021", value: "1" }],
                 },
                 0,
                 0
@@ -1537,7 +1537,7 @@ QUnit.module("Views", (hooks) => {
                 assert,
                 graph,
                 {
-                    lines: [{ label: "January 2021 / W1 2021", value: "1" }],
+                    lines: [{ label: "January 2021 / W01 2021", value: "1" }],
                 },
                 0,
                 1
@@ -1546,7 +1546,7 @@ QUnit.module("Views", (hooks) => {
                 assert,
                 graph,
                 {
-                    lines: [{ label: "February 2021 / W7 2021", value: "1" }],
+                    lines: [{ label: "February 2021 / W07 2021", value: "1" }],
                 },
                 1,
                 0
@@ -1555,7 +1555,7 @@ QUnit.module("Views", (hooks) => {
                 assert,
                 graph,
                 {
-                    lines: [{ label: "January 2021 / W2 2021", value: "1" }],
+                    lines: [{ label: "January 2021 / W02 2021", value: "1" }],
                 },
                 1,
                 1
@@ -1564,7 +1564,7 @@ QUnit.module("Views", (hooks) => {
                 assert,
                 graph,
                 {
-                    lines: [{ label: "January 2021 / W3 2021", value: "1" }],
+                    lines: [{ label: "January 2021 / W03 2021", value: "1" }],
                 },
                 2,
                 1
@@ -1573,7 +1573,7 @@ QUnit.module("Views", (hooks) => {
                 assert,
                 graph,
                 {
-                    lines: [{ label: "January 2021 / W4 2021", value: "1" }],
+                    lines: [{ label: "January 2021 / W04 2021", value: "1" }],
                 },
                 3,
                 1
@@ -1622,7 +1622,7 @@ QUnit.module("Views", (hooks) => {
                 `,
                 domains,
             });
-            checkLabels(assert, graph, ["true / W5 2021", "true / W1 2021", "false / W2 2021"]);
+            checkLabels(assert, graph, ["true / W05 2021", "true / W01 2021", "false / W02 2021"]);
             checkDatasets(
                 assert,
                 graph,
@@ -1642,13 +1642,13 @@ QUnit.module("Views", (hooks) => {
                     },
                 ]
             );
-            checkLegend(assert, graph, ["true / W5 2021", "true / W1 2021", "false / W2 2021"]);
+            checkLegend(assert, graph, ["true / W05 2021", "true / W01 2021", "false / W02 2021"]);
             checkTooltip(
                 assert,
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "February 2021 / true / W5 2021", value: "14" }],
+                    lines: [{ label: "February 2021 / true / W05 2021", value: "14" }],
                 },
                 0,
                 0
@@ -1658,7 +1658,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "January 2021 / true / W1 2021", value: "12" }],
+                    lines: [{ label: "January 2021 / true / W01 2021", value: "12" }],
                 },
                 1,
                 1
@@ -1668,7 +1668,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "January 2021 / false / W2 2021", value: "5" }],
+                    lines: [{ label: "January 2021 / false / W02 2021", value: "5" }],
                 },
                 2,
                 1


### PR DESCRIPTION
[FIX] web: special key props not available on the views 

Before this commit, the special key props were not available on the
views.

---------------------
 
[FIX] web: search function on registry 

Before this commit, an error was raised when the model/method is not
find on the registry. This issue raise because the registry throws an
exception on the get function if the key is not found.

This commit also refactor the code to use the registry category.

-----------------------------------
 
[IMP] web: add util to build Sample ORM 

----------------------------------

[REF] web: migrate from moment to luxon 

migrate the code of pare and format dates of sample server and mock
server from moment to luxon.


-----------------------------------
 
[IMP] web: mock routes/methods defined outside web 

Add a registry on the mockServer to allow mocking routes/methods
defined outside web

---------------------------------

[FIX] web: search favorite menu same name
Before this commit, when saving a new favorite that have the same name
as an existing favorite, an traceback was raised.

Now, a danger notification is shown.
