### PR TITLE
[IMP] web: add helpers to web.tests_assets bundle

### DIFF
--- a/addons/project/static/src/js/project_graph.js
+++ b/addons/project/static/src/js/project_graph.js
@@ -53,9 +53,9 @@ class ProjectControlPanel extends ControlPanel {
         });
     }
 }
-ControlPanel.template = "web.ControlPanel"; /** @todo should be something good that inherits from web.ControlPanel */
+ProjectControlPanel.template = "web.ControlPanel"; /** @todo */
 
 class ProjectGraphView extends GraphView {}
-GraphView.ControlPanel = ProjectControlPanel;
+ProjectGraphView.ControlPanel = ProjectControlPanel;
 
 viewRegistry.add("project_graph", ProjectGraphView);

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -455,6 +455,7 @@ This module provides the core of the Odoo Web Client.
 
             # 'web/static/tests/legacy/main_tests.js',
             'web/static/tests/helpers/**/*.js',
+            'web/static/tests/search/helpers.js',
             'web/static/tests/webclient/**/helpers.js',
             'web/static/tests/qunit.js',
             'web/static/tests/main.js',
@@ -476,6 +477,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/tests/core/**/*.js',
             'web/static/tests/fields/**/*.js',
             'web/static/tests/search/**/*.js',
+            ('remove', 'web/static/tests/search/helpers.js'),
             'web/static/tests/views/**/*.js',
             'web/static/tests/webclient/**/*.js',
             ('remove', 'web/static/tests/webclient/**/helpers.js'),


### PR DESCRIPTION
This commit adds search helpers to web.tests_assets bundle
so we can use them in other module tests.