### PR TITLE
[FIX] point_of_sale: infinite loop update-render due to get_unit_disp…

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1908,13 +1908,15 @@ class Orderline extends PosModel {
     }
     get_unit_display_price(){
         if (this.pos.config.iface_tax_included === 'total') {
-            // TODO-REF
-            // var quantity = this.quantity;
-            // this.quantity = 1.0;
-            // var price = this.get_all_prices().priceWithTax;
-            // this.quantity = quantity;
-            // return price;
-            return this.get_unit_price();
+            let price;
+            //Todo-ref: this is used to update the attribute object without triggering the rendering of the components
+            reactivity.inSilentContext(() => {
+                let quantity = this.quantity;
+                this.quantity = 1.0;
+                price = this.get_all_prices().priceWithTax;
+                this.quantity = quantity;
+            });
+            return price;
         } else {
             return this.get_unit_price();
         }

--- a/addons/point_of_sale/static/src/js/reactivity.js
+++ b/addons/point_of_sale/static/src/js/reactivity.js
@@ -6,6 +6,14 @@ const TARGET = Symbol('Target');
 // Special key to subscribe to, to be notified of key creation/deletion
 const KEYCHANGES = Symbol('Key changes');
 
+let silent = false;
+
+export function inSilentContext(cb) {
+    silent = true;
+    cb();
+    silent = false;
+}
+
 /**
  * Checks whether a given value can be made into a reactive object.
  *
@@ -59,6 +67,7 @@ function observeTargetKey(target, key, callback) {
  *   or deleted)
  */
 function notifyReactives(target, key) {
+    if (silent) return;
     const keyToCallbacks = targetToKeysToCallbacks.get(target);
     if (!keyToCallbacks) {
         return;


### PR DESCRIPTION
…lay_price

This is a temporary fix.
The orderline component was calling a getter to get the unit display price. The getter updates (that shouldn't happen) the quantity of the orderline temporarily in order to call `get_all_prices()` (which use the quantity of the orderline). Due to the update of an attribute, this was triggering the render call of the component. => Infinite loop