### PR TITLE
[DRAFT] Makes dispatching pluggable by routing type ... illustration

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -98,8 +98,8 @@ class IrHttp(models.AbstractModel):
                 args[key] = val.with_user(request.env.uid)
 
     @classmethod
-    def _post_dispatch(cls, response):
-        request._post_dispatch(response)
+    def _post_dispatch(cls, rule, args, response):
+        request._post_dispatch(rule, args, response)
 
     @classmethod
     def _is_cors_preflight(cls, endpoint):
@@ -176,14 +176,6 @@ class IrHttp(models.AbstractModel):
         if isinstance(result, Response) and result.is_qweb:
             result.flatten()
         return result
-
-    @classmethod
-    def _http_handle_error(cls, exception):
-        return request._http_handle_error(exception)
-
-    @classmethod
-    def _json_handle_error(cls, exception):
-        return request._json_handle_error(exception)
 
     @classmethod
     def _redirect(cls, location, code=303):


### PR DESCRIPTION
@Julien00859 Here it's a draft on how we could make the routing type plugable 

The main idea is to be able to register a dedicated request dispatcher by routing type. 
The current implementation is still a little bit tricky since when your process a request for a specific db, some part of the process are delegated to ir.http and the implementation into ir.http call the logic into Request. I understand that's a way to give the possibility to extend some part of the process via the odoo model inheritance mechanism but IMO that make the code a little bit too complex. (We end up with a unclear separation of responsabilities between the different layers..) If you take a look at https://github.com/lmignon/extendable, you could see that it could be possible to make the 'Request' class extendable without using the Odoo inheritance mechanism (even if you can find some similarities into the concept)

I've no time to make this branch running but the idea are there...

Regards.