### PR TITLE
[IMP] account: add shortcuts to account.report.line

### DIFF
--- a/addons/l10n_ae/data/account_tax_report_data.xml
+++ b/addons/l10n_ae/data/account_tax_report_data.xml
@@ -15,24 +15,12 @@
         <field name="line_ids">
             <record id="tax_report_line_base_all_sales" model="account.report.line">
                 <field name="name">VAT on Sales and all other Outputs (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_base_all_sales_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">1_STANDARD_RATED_SUPPLIES_BASE.balance + TAX_REF_TOUR_SCHEME_BASE.balance + REVERSE_CHARGE_PRO_BASE.balance + ZERO_RATE_SUPP_BASE.balance + EXAMPT_SUPP_BASE.balance + OUT_OF_SCOPE_BASE_0.balance + GOODS_IMPORT_IN_UAE_BASE.balance + ADJUST_GOODS_IMPORT_IN_UAE_BASE.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">1_STANDARD_RATED_SUPPLIES_BASE.balance + TAX_REF_TOUR_SCHEME_BASE.balance + REVERSE_CHARGE_PRO_BASE.balance + ZERO_RATE_SUPP_BASE.balance + EXAMPT_SUPP_BASE.balance + OUT_OF_SCOPE_BASE_0.balance + GOODS_IMPORT_IN_UAE_BASE.balance + ADJUST_GOODS_IMPORT_IN_UAE_BASE.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_standard_rated_supplies_base" model="account.report.line">
                         <field name="name">1. Standard Rated supplies (Base)</field>
                         <field name="code">1_STANDARD_RATED_SUPPLIES_BASE</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_standard_rated_supplies_base_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">STD_RATE_SUPP_BASE_AB.balance + STD_RATE_SUPP_BASE_DB.balance + STD_RATE_SUPP_BASE_SJ.balance + STD_RATE_SUPP_BASE_AJ.balance + STD_RATE_SUPP_BASE_UM.balance + STD_RATE_SUPP_BASE_RA.balance + STD_RATE_SUPP_BASE_FU.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">STD_RATE_SUPP_BASE_AB.balance + STD_RATE_SUPP_BASE_DB.balance + STD_RATE_SUPP_BASE_SJ.balance + STD_RATE_SUPP_BASE_AJ.balance + STD_RATE_SUPP_BASE_UM.balance + STD_RATE_SUPP_BASE_RA.balance + STD_RATE_SUPP_BASE_FU.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_line_standard_rated_supplies_base_abu_dhabi" model="account.report.line">
                                 <field name="name">a. Abu Dhabi</field>
@@ -113,13 +101,7 @@
                             </record>
                             <record id="tax_report_line_standard_rated_supplies_base_subtotal" model="account.report.line">
                                 <field name="name">Sub Total</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_line_standard_rated_supplies_base_subtotal_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">STD_RATE_SUPP_BASE_AB.balance + STD_RATE_SUPP_BASE_DB.balance + STD_RATE_SUPP_BASE_SJ.balance + STD_RATE_SUPP_BASE_AJ.balance + STD_RATE_SUPP_BASE_UM.balance + STD_RATE_SUPP_BASE_RA.balance + STD_RATE_SUPP_BASE_FU.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">STD_RATE_SUPP_BASE_AB.balance + STD_RATE_SUPP_BASE_DB.balance + STD_RATE_SUPP_BASE_SJ.balance + STD_RATE_SUPP_BASE_AJ.balance + STD_RATE_SUPP_BASE_UM.balance + STD_RATE_SUPP_BASE_RA.balance + STD_RATE_SUPP_BASE_FU.balance</field>
                             </record>
                         </field>
                     </record>
@@ -204,25 +186,13 @@
                     </record>
                     <record id="tax_report_line_base_all_sales_total" model="account.report.line">
                         <field name="name">9. Total</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_base_all_sales_total_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">ADJUST_GOODS_IMPORT_IN_UAE_BASE.balance + GOODS_IMPORT_IN_UAE_BASE.balance + OUT_OF_SCOPE_BASE_0.balance + EXAMPT_SUPP_BASE.balance + ZERO_RATE_SUPP_BASE.balance + REVERSE_CHARGE_PRO_BASE.balance + TAX_REF_TOUR_SCHEME_BASE.balance + (STD_RATE_SUPP_BASE_AB.balance + STD_RATE_SUPP_BASE_DB.balance + STD_RATE_SUPP_BASE_SJ.balance + STD_RATE_SUPP_BASE_AJ.balance + STD_RATE_SUPP_BASE_UM.balance + STD_RATE_SUPP_BASE_RA.balance + STD_RATE_SUPP_BASE_FU.balance)</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">ADJUST_GOODS_IMPORT_IN_UAE_BASE.balance + GOODS_IMPORT_IN_UAE_BASE.balance + OUT_OF_SCOPE_BASE_0.balance + EXAMPT_SUPP_BASE.balance + ZERO_RATE_SUPP_BASE.balance + REVERSE_CHARGE_PRO_BASE.balance + TAX_REF_TOUR_SCHEME_BASE.balance + (STD_RATE_SUPP_BASE_AB.balance + STD_RATE_SUPP_BASE_DB.balance + STD_RATE_SUPP_BASE_SJ.balance + STD_RATE_SUPP_BASE_AJ.balance + STD_RATE_SUPP_BASE_UM.balance + STD_RATE_SUPP_BASE_RA.balance + STD_RATE_SUPP_BASE_FU.balance)</field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_line_base_all_expense" model="account.report.line">
                 <field name="name">VAT on Expenses and all other Inputs (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_base_all_expense_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">STD_RATE_EXPENSES_BASE.balance + SUPP_REV_CHARGE_PRO_BASE.balance + OUT_OF_SCOPE_1_BASE.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">STD_RATE_EXPENSES_BASE.balance + SUPP_REV_CHARGE_PRO_BASE.balance + OUT_OF_SCOPE_1_BASE.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_standard_rated_expense_base" model="account.report.line">
                         <field name="name">10. Standard rated expenses</field>
@@ -260,36 +230,18 @@
                     </record>
                     <record id="tax_report_line_base_all_expense_total" model="account.report.line">
                         <field name="name">13. Totals</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_base_all_expense_total_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">OUT_OF_SCOPE_1_BASE.balance + SUPP_REV_CHARGE_PRO_BASE.balance + STD_RATE_EXPENSES_BASE.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">OUT_OF_SCOPE_1_BASE.balance + SUPP_REV_CHARGE_PRO_BASE.balance + STD_RATE_EXPENSES_BASE.balance</field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_line_vat_all_sales" model="account.report.line">
                 <field name="name">VAT on Sales and all other Outputs (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_vat_all_sales_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">1_STANDARD_RATED_SUPPLIES_TAX.balance + TAX_REF_TOUR_SCHEME_TAX.balance + REVERSE_CHARGE_PRO_TAX.balance + ZERO_RATE_SUPP_TAX.balance + EXAMPT_SUPP_TAX.balance + OUT_OF_SCOPE_TAX_0.balance + GOODS_IMPORT_IN_UAE_TAX.balance + ADJUST_GOODS_IMPORT_IN_UAE_TAX.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">1_STANDARD_RATED_SUPPLIES_TAX.balance + TAX_REF_TOUR_SCHEME_TAX.balance + REVERSE_CHARGE_PRO_TAX.balance + ZERO_RATE_SUPP_TAX.balance + EXAMPT_SUPP_TAX.balance + OUT_OF_SCOPE_TAX_0.balance + GOODS_IMPORT_IN_UAE_TAX.balance + ADJUST_GOODS_IMPORT_IN_UAE_TAX.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_standard_rated_supplies_vat" model="account.report.line">
                         <field name="name">1. Standard Rated supplies (Tax)</field>
                         <field name="code">1_STANDARD_RATED_SUPPLIES_TAX</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_standard_rated_supplies_vat_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_line_standard_rated_supplies_vat_abu_dhabi" model="account.report.line">
                                 <field name="name">a. Abu Dhabi</field>
@@ -370,13 +322,7 @@
                             </record>
                             <record id="tax_report_line_standard_rated_supplies_vat_subtotal" model="account.report.line">
                                 <field name="name">Sub Total</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_line_standard_rated_supplies_vat_subtotal_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance</field>
                             </record>
                         </field>
                     </record>
@@ -461,25 +407,13 @@
                     </record>
                     <record id="tax_report_line_vat_all_sales_total" model="account.report.line">
                         <field name="name">9. Total</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_vat_all_sales_total_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">(STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance) + OUT_OF_SCOPE_TAX_0.balance + ADJUST_GOODS_IMPORT_IN_UAE_TAX.balance + GOODS_IMPORT_IN_UAE_TAX.balance + EXAMPT_SUPP_TAX.balance + ZERO_RATE_SUPP_TAX.balance + REVERSE_CHARGE_PRO_TAX.balance + TAX_REF_TOUR_SCHEME_TAX.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">(STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance) + OUT_OF_SCOPE_TAX_0.balance + ADJUST_GOODS_IMPORT_IN_UAE_TAX.balance + GOODS_IMPORT_IN_UAE_TAX.balance + EXAMPT_SUPP_TAX.balance + ZERO_RATE_SUPP_TAX.balance + REVERSE_CHARGE_PRO_TAX.balance + TAX_REF_TOUR_SCHEME_TAX.balance</field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_line_vat_all_expense" model="account.report.line">
                 <field name="name">VAT on Expenses and all other Inputs (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_vat_all_expense_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">STD_RATE_EXPENSES_TAX.balance + SUPP_REV_CHARGE_PRO_TAX.balance + OUT_OF_SCOPE_1_TAX.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">STD_RATE_EXPENSES_TAX.balance + SUPP_REV_CHARGE_PRO_TAX.balance + OUT_OF_SCOPE_1_TAX.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_standard_rated_expense_vat" model="account.report.line">
                         <field name="name">10. Standard rated expenses</field>
@@ -517,55 +451,25 @@
                     </record>
                     <record id="tax_report_line_vat_all_expense_total" model="account.report.line">
                         <field name="name">13. Totals</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_vat_all_expense_total_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">OUT_OF_SCOPE_1_TAX.balance + SUPP_REV_CHARGE_PRO_TAX.balance + STD_RATE_EXPENSES_TAX.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">OUT_OF_SCOPE_1_TAX.balance + SUPP_REV_CHARGE_PRO_TAX.balance + STD_RATE_EXPENSES_TAX.balance</field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_line_net_vat_due" model="account.report.line">
                 <field name="name">Net VAT Due</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_net_vat_due_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">((STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance) + OUT_OF_SCOPE_TAX_0.balance + ADJUST_GOODS_IMPORT_IN_UAE_TAX.balance + GOODS_IMPORT_IN_UAE_TAX.balance + EXAMPT_SUPP_TAX.balance + ZERO_RATE_SUPP_TAX.balance + REVERSE_CHARGE_PRO_TAX.balance + TAX_REF_TOUR_SCHEME_TAX.balance) - (OUT_OF_SCOPE_1_TAX.balance + SUPP_REV_CHARGE_PRO_TAX.balance + STD_RATE_EXPENSES_TAX.balance)</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">((STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance) + OUT_OF_SCOPE_TAX_0.balance + ADJUST_GOODS_IMPORT_IN_UAE_TAX.balance + GOODS_IMPORT_IN_UAE_TAX.balance + EXAMPT_SUPP_TAX.balance + ZERO_RATE_SUPP_TAX.balance + REVERSE_CHARGE_PRO_TAX.balance + TAX_REF_TOUR_SCHEME_TAX.balance) - (OUT_OF_SCOPE_1_TAX.balance + SUPP_REV_CHARGE_PRO_TAX.balance + STD_RATE_EXPENSES_TAX.balance)</field>
                 <field name="children_ids">
                     <record id="tax_report_line_total_value_due_tax_period" model="account.report.line">
                         <field name="name">14. Total value of due tax for the period</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_total_value_due_tax_period_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">(STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance) + OUT_OF_SCOPE_TAX_0.balance + ADJUST_GOODS_IMPORT_IN_UAE_TAX.balance + GOODS_IMPORT_IN_UAE_TAX.balance + EXAMPT_SUPP_TAX.balance + ZERO_RATE_SUPP_TAX.balance + REVERSE_CHARGE_PRO_TAX.balance + TAX_REF_TOUR_SCHEME_TAX.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">(STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance) + OUT_OF_SCOPE_TAX_0.balance + ADJUST_GOODS_IMPORT_IN_UAE_TAX.balance + GOODS_IMPORT_IN_UAE_TAX.balance + EXAMPT_SUPP_TAX.balance + ZERO_RATE_SUPP_TAX.balance + REVERSE_CHARGE_PRO_TAX.balance + TAX_REF_TOUR_SCHEME_TAX.balance</field>
                     </record>
                     <record id="tax_report_line_total_value_recoverable_tax_period" model="account.report.line">
                         <field name="name">15. Total value of recoverable tax for the period</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_total_value_recoverable_tax_period_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">OUT_OF_SCOPE_1_TAX.balance + SUPP_REV_CHARGE_PRO_TAX.balance + STD_RATE_EXPENSES_TAX.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">OUT_OF_SCOPE_1_TAX.balance + SUPP_REV_CHARGE_PRO_TAX.balance + STD_RATE_EXPENSES_TAX.balance</field>
                     </record>
                     <record id="tax_report_line_net_vat_due_period" model="account.report.line">
                         <field name="name">16. Net VAT due (or reclaimed) for the period</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_net_vat_due_period_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">((STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance) + OUT_OF_SCOPE_TAX_0.balance + ADJUST_GOODS_IMPORT_IN_UAE_TAX.balance + GOODS_IMPORT_IN_UAE_TAX.balance + EXAMPT_SUPP_TAX.balance + ZERO_RATE_SUPP_TAX.balance + REVERSE_CHARGE_PRO_TAX.balance + TAX_REF_TOUR_SCHEME_TAX.balance) - (OUT_OF_SCOPE_1_TAX.balance + SUPP_REV_CHARGE_PRO_TAX.balance + STD_RATE_EXPENSES_TAX.balance)</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">((STD_RATE_SUPP_TAX_AB.balance + STD_RATE_SUPP_TAX_DB.balance + STD_RATE_SUPP_TAX_SJ.balance + STD_RATE_SUPP_TAX_AJ.balance + STD_RATE_SUPP_TAX_UM.balance + STD_RATE_SUPP_TAX_RA.balance + STD_RATE_SUPP_TAX_FU.balance) + OUT_OF_SCOPE_TAX_0.balance + ADJUST_GOODS_IMPORT_IN_UAE_TAX.balance + GOODS_IMPORT_IN_UAE_TAX.balance + EXAMPT_SUPP_TAX.balance + ZERO_RATE_SUPP_TAX.balance + REVERSE_CHARGE_PRO_TAX.balance + TAX_REF_TOUR_SCHEME_TAX.balance) - (OUT_OF_SCOPE_1_TAX.balance + SUPP_REV_CHARGE_PRO_TAX.balance + STD_RATE_EXPENSES_TAX.balance)</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_at/data/account_tax_report_data.xml
+++ b/addons/l10n_at/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="tax_report_line_l10n_at_tva_sale_report_title" model="account.report.line">
                 <field name="name">4. Berechnung der Umsatzsteuer (U1/U30)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_l10n_at_tva_sale_report_title_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">(AT_022_tax.balance + AT_029_tax.balance + AT_006_tax.balance + AT_037_tax.balance + AT_052_tax.balance + AT_007_tax.balance + AT_056.balance + AT_057.balance + AT_048.balance + AT_044.balance + AT_032.balance + AT_072_tax.balance + AT_073_tax.balance + AT_008_tax.balance + AT_088_tax.balance)</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">(AT_022_tax.balance + AT_029_tax.balance + AT_006_tax.balance + AT_037_tax.balance + AT_052_tax.balance + AT_007_tax.balance + AT_056.balance + AT_057.balance + AT_048.balance + AT_044.balance + AT_032.balance + AT_072_tax.balance + AT_073_tax.balance + AT_008_tax.balance + AT_088_tax.balance)</field>
                 <field name="children_ids">
                     <record id="tax_report_line_l10n_at_tva_line_4_1" model="account.report.line">
                         <field name="name">4.1 Gesamtbetrag der Bemessungsgrundlage für Lieferungen und sonstige Leistungen [000]</field>
@@ -58,23 +52,11 @@
                     </record>
                     <record id="tax_report_line_l10n_at_tva_line_4_4" model="account.report.line">
                         <field name="name">4.4 Summe</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_l10n_at_tva_line_4_4_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">AT_000.balance + AT_001.balance - AT_021.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">AT_000.balance + AT_001.balance - AT_021.balance</field>
                     </record>
                     <record id="tax_report_line_l10n_at_tva_sale_01_report_title" model="account.report.line">
                         <field name="name">Davon steuerfrei MIT Vorsteuerabzug gemäß</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_l10n_at_tva_sale_01_report_title_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">AT_011.balance + AT_012.balance + AT_015.balance + AT_017.balance + AT_018.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">AT_011.balance + AT_012.balance + AT_015.balance + AT_017.balance + AT_018.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_5" model="account.report.line">
                                 <field name="name">4.5 § 6 Abs. 1 Z 1 iVm § 7 (Ausfuhrlieferungen) [011]</field>
@@ -135,13 +117,7 @@
                     </record>
                     <record id="tax_report_line_l10n_at_tva_sale_02_report_title" model="account.report.line">
                         <field name="name">Davon steuerfrei OHNE Vorsteuerabzug gemäß</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_l10n_at_tva_sale_02_report_title_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">AT_019.balance + AT_016.balance + AT_020.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">AT_019.balance + AT_016.balance + AT_020.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_10" model="account.report.line">
                                 <field name="name">4.10 § 6 Abs. 1 Z 9 lit. a (Grundstücksumsätze) [019]</field>
@@ -180,23 +156,11 @@
                     </record>
                     <record id="tax_report_line_l10n_at_tva_line_4_13" model="account.report.line">
                         <field name="name">4.13 Gesamtbetrag der steuerpflichtigen Lieferungen, sonstigen Leistungen und Eigenverbrauch (einschließlich steuerpflichtiger Anzahlungen)</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_l10n_at_tva_line_4_13_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">(AT_000.balance + AT_001.balance - AT_021.balance) - AT_011.balance - AT_012.balance - AT_015.balance - AT_017.balance - AT_018.balance - AT_019.balance - AT_016.balance - AT_020.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">(AT_000.balance + AT_001.balance - AT_021.balance) - AT_011.balance - AT_012.balance - AT_015.balance - AT_017.balance - AT_018.balance - AT_019.balance - AT_016.balance - AT_020.balance</field>
                     </record>
                     <record id="tax_report_line_at_base_title_umsatz_base_4_14_19" model="account.report.line">
                         <field name="name">Bemessungsgrundlage</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_at_base_title_umsatz_base_4_14_19_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">AT_022_base.balance + AT_029_base.balance + AT_006_base.balance + AT_037_base.balance + AT_052_base.balance + AT_007_base.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">AT_022_base.balance + AT_029_base.balance + AT_006_base.balance + AT_037_base.balance + AT_052_base.balance + AT_007_base.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_14_base" model="account.report.line">
                                 <field name="name">4.14 20% Normalsteuersatz [022]</field>
@@ -268,13 +232,7 @@
                     </record>
                     <record id="tax_report_line_at_tax_title_4_14_19" model="account.report.line">
                         <field name="name">Umsatzsteuer</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_at_tax_title_4_14_19_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">AT_022_tax.balance + AT_029_tax.balance + AT_006_tax.balance + AT_037_tax.balance + AT_052_tax.balance + AT_007_tax.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">AT_022_tax.balance + AT_029_tax.balance + AT_006_tax.balance + AT_037_tax.balance + AT_052_tax.balance + AT_007_tax.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_14_tax" model="account.report.line">
                                 <field name="name">4.14 20% Normalsteuersatz</field>
@@ -401,13 +359,7 @@
                     </record>
                     <record id="tax_report_line_l10n_at_tva_sale_03_report_title" model="account.report.line">
                         <field name="name">Innergemeinschaftliche Erwerb</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_l10n_at_tva_sale_03_report_title_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">AT_070.balance + AT_071.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">AT_070.balance + AT_071.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_25" model="account.report.line">
                                 <field name="name">4.25 Gesamtbetrag der Bemessungsgrundlagen für innergemeinschaftliche Erwerbe [070]</field>
@@ -433,35 +385,17 @@
                             </record>
                             <record id="tax_report_line_l10n_at_tva_line_4_27" model="account.report.line">
                                 <field name="name">4.27 Gesamtbetrag der steuerpflichtigen innergemeinschaftlichen Erwerbe</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_line_l10n_at_tva_line_4_27_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">AT_070.balance - AT_071.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">AT_070.balance - AT_071.balance</field>
                             </record>
                         </field>
                     </record>
                     <record id="tax_report_line_l10n_at_tva_sale_04_report_title" model="account.report.line">
                         <field name="name">Davon sind zu versteuern mit</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_l10n_at_tva_sale_04_report_title_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">AT_072_base.balance + AT_073_base.balance + AT_008_base.balance + AT_088_base.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">AT_072_base.balance + AT_073_base.balance + AT_008_base.balance + AT_088_base.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_line_at_base_title_umsatz_base_4_28_31" model="account.report.line">
                                 <field name="name">Bemessungsgrundlage</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_line_at_base_title_umsatz_base_4_28_31_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">AT_072_base.balance + AT_073_base.balance + AT_008_base.balance + AT_088_base.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">AT_072_base.balance + AT_073_base.balance + AT_008_base.balance + AT_088_base.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_28_base" model="account.report.line">
                                         <field name="name">4.28 20% Normalsteuersatz [072]</field>
@@ -511,13 +445,7 @@
                             </record>
                             <record id="tax_report_line_at_tax_title_4_28_31" model="account.report.line">
                                 <field name="name">Umsatzsteuer</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_line_at_tax_title_4_28_31_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">AT_072_tax.balance + AT_073_tax.balance + AT_008_tax.balance + AT_088_tax.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">AT_072_tax.balance + AT_073_tax.balance + AT_008_tax.balance + AT_088_tax.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_28_tax" model="account.report.line">
                                         <field name="name">4.28 20% Normalsteuersatz</field>
@@ -569,13 +497,7 @@
                     </record>
                     <record id="tax_report_line_l10n_at_tva_sale_05_report_title" model="account.report.line">
                         <field name="name">Nicht zu versteuernde Erwerbe</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_l10n_at_tva_sale_05_report_title_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">AT_076.balance + AT_077.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">AT_076.balance + AT_077.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_32" model="account.report.line">
                                 <field name="name">4.32 Erwerbe gemäß Art. 3 Abs. 8 zweiter Satz, die im Mitgliedstaat des Bestimmungslandes besteuert worden sind [076]</field>
@@ -605,13 +527,7 @@
             </record>
             <record id="tax_report_line_l10n_at_tva_purchase_report_title" model="account.report.line">
                 <field name="name">5. Berechnung der abziehbaren Vorsteuer</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_l10n_at_tva_purchase_report_title_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">AT_060.balance + AT_061.balance + AT_083.balance + AT_065.balance + AT_066.balance + AT_082.balance + AT_087.balance + AT_089.balance + AT_064.balance + AT_062.balance + AT_063.balance + AT_067.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">AT_060.balance + AT_061.balance + AT_083.balance + AT_065.balance + AT_066.balance + AT_082.balance + AT_087.balance + AT_089.balance + AT_064.balance + AT_062.balance + AT_063.balance + AT_067.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_l10n_at_tva_line_5_1" model="account.report.line">
                         <field name="name">5.1 Gesamtbetrag der Vorsteuern (ohne die nachstehend gesondert anzuführenden Beträge) [060]</field>
@@ -747,25 +663,13 @@
                     </record>
                     <record id="tax_report_line_l10n_at_tva_line_5_13" model="account.report.line">
                         <field name="name">5.13 Gesamtbetrag der abziehbaren Vorsteuer</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_l10n_at_tva_line_5_13_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">AT_060.balance + AT_061.balance + AT_083.balance + AT_065.balance + AT_066.balance + AT_082.balance + AT_087.balance + AT_089.balance + AT_064.balance + AT_062.balance + AT_063.balance + AT_067.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">AT_060.balance + AT_061.balance + AT_083.balance + AT_065.balance + AT_066.balance + AT_082.balance + AT_087.balance + AT_089.balance + AT_064.balance + AT_062.balance + AT_063.balance + AT_067.balance</field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_line_l10n_at_tva_final_report_title" model="account.report.line">
                 <field name="name">6. Sonstige Berichtigungen</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_l10n_at_tva_final_report_title_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">AT_090.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">AT_090.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_l10n_at_tva_line_6" model="account.report.line">
                         <field name="name">Sonstige Berichtigungen [090]</field>
@@ -782,13 +686,7 @@
             </record>
             <record id="tax_report_line_l10n_at_tva_line_7" model="account.report.line">
                 <field name="name">7. Zahllast (-) bzw. Gutschrift/Überschuss (+) [095]</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_l10n_at_tva_line_7_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">(AT_022_tax.balance + AT_029_tax.balance + AT_006_tax.balance + AT_037_tax.balance + AT_052_tax.balance + AT_007_tax.balance + AT_056.balance + AT_057.balance + AT_048.balance + AT_044.balance + AT_032.balance + AT_072_tax.balance + AT_073_tax.balance + AT_008_tax.balance + AT_088_tax.balance + AT_060.balance + AT_061.balance + AT_083.balance + AT_065.balance + AT_066.balance + AT_082.balance + AT_087.balance + AT_089.balance + AT_064.balance + AT_062.balance + AT_063.balance + AT_067.balance) + AT_090.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">(AT_022_tax.balance + AT_029_tax.balance + AT_006_tax.balance + AT_037_tax.balance + AT_052_tax.balance + AT_007_tax.balance + AT_056.balance + AT_057.balance + AT_048.balance + AT_044.balance + AT_032.balance + AT_072_tax.balance + AT_073_tax.balance + AT_008_tax.balance + AT_088_tax.balance + AT_060.balance + AT_061.balance + AT_083.balance + AT_065.balance + AT_066.balance + AT_082.balance + AT_087.balance + AT_089.balance + AT_064.balance + AT_062.balance + AT_063.balance + AT_067.balance) + AT_090.balance</field>
             </record>
         </field>
     </record>

--- a/addons/l10n_au/data/account_tax_report_data.xml
+++ b/addons/l10n_au/data/account_tax_report_data.xml
@@ -65,24 +65,12 @@
                     <record id="account_tax_report_gstrpt_g5" model="account.report.line">
                         <field name="name">G5: G2 + G3 + G4</field>
                         <field name="code">G5</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_g5_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G2.balance+G3.balance+G4.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G2.balance+G3.balance+G4.balance</field>
                     </record>
                     <record id="account_tax_report_gstrpt_g6" model="account.report.line">
                         <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
                         <field name="code">G6</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_g6_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G1.balance-G5.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G1.balance-G5.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_gstrpt_g7" model="account.report.line">
                                 <field name="name">G7: Adjustments (if applicable)</field>
@@ -100,24 +88,12 @@
                     <record id="account_tax_report_gstrpt_g8" model="account.report.line">
                         <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
                         <field name="code">G8</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_g8_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G6.balance+G7.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G6.balance+G7.balance</field>
                     </record>
                     <record id="account_tax_report_gstrpt_g9" model="account.report.line">
                         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
                         <field name="code">G9</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_g9_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G8.balance/11</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G8.balance/11</field>
                     </record>
                 </field>
             </record>
@@ -149,13 +125,7 @@
                     <record id="account_tax_report_gstrpt_g12" model="account.report.line">
                         <field name="name">G12: G10 + G11</field>
                         <field name="code">G12</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_g12_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G10.balance+G11.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G10.balance+G11.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_gstrpt_g13" model="account.report.line">
                                 <field name="name">G13: Purchases for making input taxed sales</field>
@@ -195,24 +165,12 @@
                     <record id="account_tax_report_gstrpt_g16" model="account.report.line">
                         <field name="name">G16: G13 + G14 + G15</field>
                         <field name="code">G16</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_g16_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G13.balance+G14.balance+G15.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G13.balance+G14.balance+G15.balance</field>
                     </record>
                     <record id="account_tax_report_gstrpt_g17" model="account.report.line">
                         <field name="name">G17: Total purchases subject to GST (G12 minus G16) </field>
                         <field name="code">G17</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_g17_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G12.balance-G16.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G12.balance-G16.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_gstrpt_g18" model="account.report.line">
                                 <field name="name">G18: Adjustments (if applicable)</field>
@@ -230,24 +188,12 @@
                     <record id="account_tax_report_gstrpt_g19" model="account.report.line">
                         <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18) </field>
                         <field name="code">G19</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_g19_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G17.balance+G18.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G17.balance+G18.balance</field>
                     </record>
                     <record id="account_tax_report_gstrpt_g20a" model="account.report.line">
                         <field name="name">GST on purchases (G19 divided by eleven)</field>
                         <field name="code">GP</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_g20a_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G19.balance/11</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G19.balance/11</field>
                     </record>
                     <record id="account_tax_report_gstrpt_gstonly" model="account.report.line">
                         <field name="name">GST only purchases</field>
@@ -263,13 +209,7 @@
                     <record id="account_tax_report_gstrpt_g20b" model="account.report.line">
                         <field name="name">G20: GST on purchases</field>
                         <field name="code">G20</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_g20b_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">GP.balance+ONLY.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">GP.balance+ONLY.balance</field>
                     </record>
                 </field>
             </record>
@@ -279,34 +219,16 @@
                     <record id="account_tax_report_gstrpt_summary_1a" model="account.report.line">
                         <field name="name">1A: GST on sales</field>
                         <field name="code">1A</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_summary_1a_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G9.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G9.balance</field>
                     </record>
                     <record id="account_tax_report_gstrpt_summary_1b" model="account.report.line">
                         <field name="name">1B: GST on purchases</field>
                         <field name="code">1B</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_summary_1b_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G20.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G20.balance</field>
                     </record>
                     <record id="account_tax_report_gstrpt_summary_9" model="account.report.line">
                         <field name="name">9: Your payment</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_summary_9_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">1A.balance-1B.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">1A.balance-1B.balance</field>
                     </record>
                 </field>
             </record>
@@ -315,13 +237,7 @@
                 <field name="children_ids">
                     <record id="account_tax_report_gstrpt_comparison_worksheet" model="account.report.line">
                         <field name="name">GST from worksheet (G20-G9)</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_gstrpt_comparison_worksheet_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">G20.balance-G9.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">G20.balance-G9.balance</field>
                     </record>
                     <record id="account_tax_report_gstrpt_comparison_gl" model="account.report.line">
                         <field name="name">GST from General Ledger</field>

--- a/addons/l10n_be/data/account_tax_report_data.xml
+++ b/addons/l10n_be/data/account_tax_report_data.xml
@@ -88,13 +88,7 @@
                             <record id="tax_report_title_operations_sortie_46" model="account.report.line">
                                 <field name="name">46 - Livraisons intra-communautaires exemptées</field>
                                 <field name="code">c46</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_title_operations_sortie_46_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">c46L.balance + c46T.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">c46L.balance + c46T.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_46L" model="account.report.line">
                                         <field name="name">46L - Livraisons biens intra-communautaires exemptées</field>
@@ -134,13 +128,7 @@
                             <record id="tax_report_title_operations_sortie_48" model="account.report.line">
                                 <field name="name">48 - Notes de crédit aux opérations grilles [44] et [46]</field>
                                 <field name="code">c48</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_title_operations_sortie_48_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">c48s44.balance + c48s46L.balance + c48s46T.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">c48s44.balance + c48s46L.balance + c48s46T.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_48s44" model="account.report.line">
                                         <field name="name">48s44 - Notes de crédit aux opérations grilles [44]</field>

--- a/addons/l10n_bo/data/account_tax_report_data.xml
+++ b/addons/l10n_bo/data/account_tax_report_data.xml
@@ -26,13 +26,7 @@
             </record>
             <record id="tax_report_impuesto_trans" model="account.report.line">
                 <field name="name">Impuesto a las Transacciones IT (3%)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_impuesto_trans_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">IMPUESTO_A_LAS_TRANSACCIONES_IT_3.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">IMPUESTO_A_LAS_TRANSACCIONES_IT_3.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_impuesto_trans_3" model="account.report.line">
                         <field name="name">Impuesto a las Transacciones IT (3%)</field>
@@ -49,24 +43,12 @@
             </record>
             <record id="tax_report_impuesto_ttl" model="account.report.line">
                 <field name="name">Impuesto al Valor Agregado (IVA) Total a Pagar</field>
-                <field name="expression_ids">
-                    <record id="tax_report_impuesto_ttl_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">IMPUESTO_COBRADO.balance + IMPUESTO_PAGADO.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">IMPUESTO_COBRADO.balance + IMPUESTO_PAGADO.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_impuesto_ttl_cob" model="account.report.line">
                         <field name="name">Impuesto Cobrado</field>
                         <field name="code">IMPUESTO_COBRADO</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_impuesto_ttl_cob_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">IMPUESTO_COBRADO_FUERA_DE_AMBITO.balance + IMPUESTO_COBRADO_DE_EXONERADOS_AL_IVA.balance + IMPUESTO_COBRADO_IVA.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">IMPUESTO_COBRADO_FUERA_DE_AMBITO.balance + IMPUESTO_COBRADO_DE_EXONERADOS_AL_IVA.balance + IMPUESTO_COBRADO_IVA.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_impuesto_ttl_cob_fuera" model="account.report.line">
                                 <field name="name">Impuesto Cobrado Fuera de Ámbito</field>
@@ -108,13 +90,7 @@
                     <record id="tax_report_impuesto_ttl_pag" model="account.report.line">
                         <field name="name">Impuesto Pagado</field>
                         <field name="code">IMPUESTO_PAGADO</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_impuesto_ttl_pag_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">IMPUESTO_PAGADO_FUERA_DE_AMBITO.balance + IMPUESTO_PAGADO_DE_EXONERADOS_AL_IVA.balance + IMPUESTO_PAGADO_IVA.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">IMPUESTO_PAGADO_FUERA_DE_AMBITO.balance + IMPUESTO_PAGADO_DE_EXONERADOS_AL_IVA.balance + IMPUESTO_PAGADO_IVA.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_impuesto_ttl_pag_fuera" model="account.report.line">
                                 <field name="name">Impuesto Pagado Fuera de Ámbito</field>
@@ -157,24 +133,12 @@
             </record>
             <record id="tax_report_base_imponible" model="account.report.line">
                 <field name="name">Base Imponible</field>
-                <field name="expression_ids">
-                    <record id="tax_report_base_imponible_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">BASE_IMPONIBLE__COMPRAS.balance + BASE_IMPONIBLE__VENTAS.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">BASE_IMPONIBLE__COMPRAS.balance + BASE_IMPONIBLE__VENTAS.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_base_imponible_compras" model="account.report.line">
                         <field name="name">Base Imponible - Compras</field>
                         <field name="code">BASE_IMPONIBLE__COMPRAS</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_base_imponible_compras_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">COMPRAS_GRAVADAS_FUERA_DE_AMBITO.balance + COMPRAS_NO_GRAVADAS_EXONERADAS.balance + COMPRAS_GRAVADAS_CON_IVA.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">COMPRAS_GRAVADAS_FUERA_DE_AMBITO.balance + COMPRAS_NO_GRAVADAS_EXONERADAS.balance + COMPRAS_GRAVADAS_CON_IVA.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_base_imponible_compras_fuera" model="account.report.line">
                                 <field name="name">Compras Gravadas Fuera de Ámbito</field>
@@ -216,13 +180,7 @@
                     <record id="tax_report_base_imponible_venras" model="account.report.line">
                         <field name="name">Base Imponible - Ventas</field>
                         <field name="code">BASE_IMPONIBLE__VENTAS</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_base_imponible_venras_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">VENTAS_GRAVADAS_FUERA_DE_AMBITO.balance + VENTAS_NO_GRAVADAS_EXONERADAS.balance + IMPUESTO_AL_VALOR_AGREGADO_CON_IVA.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">VENTAS_GRAVADAS_FUERA_DE_AMBITO.balance + VENTAS_NO_GRAVADAS_EXONERADAS.balance + IMPUESTO_AL_VALOR_AGREGADO_CON_IVA.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_base_imponible_venras_fuera" model="account.report.line">
                                 <field name="name">Ventas Gravadas Fuera de Ámbito</field>

--- a/addons/l10n_br/data/account_tax_report_data.xml
+++ b/addons/l10n_br/data/account_tax_report_data.xml
@@ -15,24 +15,12 @@
         <field name="line_ids">
             <record id="tax_report_icms" model="account.report.line">
                 <field name="name">ICMS</field>
-                <field name="expression_ids">
-                    <record id="tax_report_icms_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">TRIBUTADA_INTEGRALMENTE.balance + TRIBUTADA_E_COM_COBRANCA_DO_ICMS_POR_SUBSTITUICAO_TRIBUTARIA.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">TRIBUTADA_INTEGRALMENTE.balance + TRIBUTADA_E_COM_COBRANCA_DO_ICMS_POR_SUBSTITUICAO_TRIBUTARIA.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_icms_tributada" model="account.report.line">
                         <field name="name">Tributada integralmente</field>
                         <field name="code">TRIBUTADA_INTEGRALMENTE</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_icms_tributada_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">ICMS_1.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">ICMS_1.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_icms_1" model="account.report.line">
                                 <field name="name">ICMS base</field>
@@ -50,13 +38,7 @@
                     <record id="tax_report_icms_tributada_com" model="account.report.line">
                         <field name="name">Tributada e com cobrança do ICMS por substituição tributária</field>
                         <field name="code">TRIBUTADA_E_COM_COBRANCA_DO_ICMS_POR_SUBSTITUICAO_TRIBUTARIA</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_icms_tributada_com_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">ICMS_2.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">ICMS_2.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_icms_2" model="account.report.line">
                                 <field name="name">ICMS tax</field>
@@ -75,13 +57,7 @@
             </record>
             <record id="tax_report_icmsst" model="account.report.line">
                 <field name="name">ICMS Subist</field>
-                <field name="expression_ids">
-                    <record id="tax_report_icmsst_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ICMSST_1.balance + ICMSST_2.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ICMSST_1.balance + ICMSST_2.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_icmsst_1" model="account.report.line">
                         <field name="name">ICMSST base</field>
@@ -109,13 +85,7 @@
             </record>
             <record id="tax_report_irpj" model="account.report.line">
                 <field name="name">IRPJ</field>
-                <field name="expression_ids">
-                    <record id="tax_report_irpj_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">IRPJ_1.balance + IRPJ_2.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">IRPJ_1.balance + IRPJ_2.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_irpj_1" model="account.report.line">
                         <field name="name">IRPJ base</field>
@@ -143,13 +113,7 @@
             </record>
             <record id="tax_report_ir" model="account.report.line">
                 <field name="name">IR</field>
-                <field name="expression_ids">
-                    <record id="tax_report_ir_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">IR_1.balance + IR_2.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">IR_1.balance + IR_2.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_ir_1" model="account.report.line">
                         <field name="name">IR base</field>
@@ -177,13 +141,7 @@
             </record>
             <record id="tax_report_issqn" model="account.report.line">
                 <field name="name">ISSQN</field>
-                <field name="expression_ids">
-                    <record id="tax_report_issqn_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ISSQN_1.balance + ISSQN_2.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ISSQN_1.balance + ISSQN_2.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_issqn_1" model="account.report.line">
                         <field name="name">ISSQN base</field>
@@ -211,13 +169,7 @@
             </record>
             <record id="tax_report_csll" model="account.report.line">
                 <field name="name">CSLL</field>
-                <field name="expression_ids">
-                    <record id="tax_report_csll_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">CSLL_1.balance + CSLL_2.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">CSLL_1.balance + CSLL_2.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_csll_1" model="account.report.line">
                         <field name="name">CSLL base</field>
@@ -245,24 +197,12 @@
             </record>
             <record id="tax_report_cofins" model="account.report.line">
                 <field name="name">COFINS</field>
-                <field name="expression_ids">
-                    <record id="tax_report_cofins_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">COFINS_OPERACAO_TRIBUTAVEL_COM_ALIQUOTA_BASICA.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">COFINS_OPERACAO_TRIBUTAVEL_COM_ALIQUOTA_BASICA.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_cofins_oper_bas" model="account.report.line">
                         <field name="name">Operação Tributável com Alíquota Básica</field>
                         <field name="code">COFINS_OPERACAO_TRIBUTAVEL_COM_ALIQUOTA_BASICA</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_cofins_oper_bas_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">COFINS_1.balance + COFINS_2.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">COFINS_1.balance + COFINS_2.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_cofins_1" model="account.report.line">
                                 <field name="name">COFINS base</field>
@@ -292,24 +232,12 @@
             </record>
             <record id="tax_report_pis" model="account.report.line">
                 <field name="name">PIS</field>
-                <field name="expression_ids">
-                    <record id="tax_report_pis_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">PIS_OPERACAO_TRIBUTAVEL_COM_ALIQUOTA_BASICA.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">PIS_OPERACAO_TRIBUTAVEL_COM_ALIQUOTA_BASICA.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_pis_oper_tri_basica" model="account.report.line">
                         <field name="name">Operação Tributável com Alíquota Básica</field>
                         <field name="code">PIS_OPERACAO_TRIBUTAVEL_COM_ALIQUOTA_BASICA</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_pis_oper_tri_basica_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">PIS_1.balance + PIS_2.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">PIS_1.balance + PIS_2.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_pis_1" model="account.report.line">
                                 <field name="name">PIS base</field>
@@ -340,24 +268,12 @@
             <record id="tax_report_ipi" model="account.report.line">
                 <field name="name">IPI</field>
                 <field name="code">BRTAX07</field>
-                <field name="expression_ids">
-                    <record id="tax_report_ipi_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ENTRADA_COM_RECUPERACAO_DE_CREDITO.balance + ENTRADA_TRIBUTADA_COM_ALIQUOTA_ZERO.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ENTRADA_COM_RECUPERACAO_DE_CREDITO.balance + ENTRADA_TRIBUTADA_COM_ALIQUOTA_ZERO.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_ipi_extrada_com" model="account.report.line">
                         <field name="name">Entrada com recuperação de crédito</field>
                         <field name="code">ENTRADA_COM_RECUPERACAO_DE_CREDITO</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_ipi_extrada_com_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">BRTAX07_1.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">BRTAX07_1.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_ipi_1" model="account.report.line">
                                 <field name="name">IPI base</field>
@@ -375,13 +291,7 @@
                     <record id="tax_report_ipi_extrada_tributada" model="account.report.line">
                         <field name="name">Entrada tributada com alíquota zero</field>
                         <field name="code">ENTRADA_TRIBUTADA_COM_ALIQUOTA_ZERO</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_ipi_extrada_tributada_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">IPI_2.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">IPI_2.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_ipi_2" model="account.report.line">
                                 <field name="name">IPI tax</field>
@@ -400,13 +310,7 @@
             </record>
             <record id="tax_report_ii" model="account.report.line">
                 <field name="name">II</field>
-                <field name="expression_ids">
-                    <record id="tax_report_ii_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">II_1.balance + II_2.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">II_1.balance + II_2.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_ii_1" model="account.report.line">
                         <field name="name">II base</field>
@@ -434,13 +338,7 @@
             </record>
             <record id="tax_report_inss" model="account.report.line">
                 <field name="name">INSS</field>
-                <field name="expression_ids">
-                    <record id="tax_report_inss_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">INSS_1.balance + INSS_2.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">INSS_1.balance + INSS_2.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_inss_1" model="account.report.line">
                         <field name="name">INSS base</field>

--- a/addons/l10n_ch/data/account_tax_report_data.xml
+++ b/addons/l10n_ch/data/account_tax_report_data.xml
@@ -18,24 +18,12 @@
                 <field name="children_ids">
                     <record id="account_tax_report_line_chtax_200" model="account.report.line">
                         <field name="name">200 Total amount of agreed or collected consideration incl. from supplies opted for taxation, transfer of supplies acc. to the notification procedure and supplies provided abroad (worldwide turnover)</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_chtax_200_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">tax_ch_302a.balance + tax_ch_312a.balance + tax_ch_342a.balance + tax_ch_289.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">tax_ch_302a.balance + tax_ch_312a.balance + tax_ch_342a.balance + tax_ch_289.balance</field>
                     </record>
                     <record id="account_tax_report_line_chtax_289" model="account.report.line">
                         <field name="name">289 Consideration reported in Ref. 200 from supplies exempt from the tax without credit (art. 21) where the option for their taxation according to art. 22 has been exercised</field>
                         <field name="code">tax_ch_289</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_chtax_289_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">tax_ch_220.balance + tax_ch_221.balance + tax_ch_225.balance + tax_ch_230.balance + tax_ch_235.balance + tax_ch_280.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">tax_ch_220.balance + tax_ch_221.balance + tax_ch_225.balance + tax_ch_230.balance + tax_ch_235.balance + tax_ch_280.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_chtax_220_289" model="account.report.line">
                                 <field name="name">220 Supplies exempt from the tax (e.g. export, art. 23) and supplies provided to institutional and individual beneficiaries that are exempt from liability for tax (art. 107 para. 1 lit. a)</field>
@@ -109,26 +97,14 @@
             </record>
             <record id="account_tax_report_line_chtax_299" model="account.report.line">
                 <field name="name">299 Taxable turnover (Ref. 200 minus Ref. 289)</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_chtax_299_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ch_302a.balance + tax_ch_312a.balance + tax_ch_342a.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ch_302a.balance + tax_ch_312a.balance + tax_ch_342a.balance</field>
             </record>
             <record id="account_tax_report_line_calc_impot" model="account.report.line">
                 <field name="name">II - TAX CALCULATION</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_calc_impot_chiffre" model="account.report.line">
                         <field name="name">Taxable turnover</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_calc_impot_chiffre_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">tax_ch_302a.balance + tax_ch_312a.balance + tax_ch_342a.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">tax_ch_302a.balance + tax_ch_312a.balance + tax_ch_342a.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_chtax_302a" model="account.report.line">
                                 <field name="name">302a Taxable turnover at 7.7% (TS)</field>
@@ -167,13 +143,7 @@
                     </record>
                     <record id="account_tax_report_line_calc_impot_base" model="account.report.line">
                         <field name="name">Tax base on service acquisitions</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_calc_impot_base_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">tax_ch_381A.balance + tax_ch_382A.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">tax_ch_381A.balance + tax_ch_382A.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_chtax_381a" model="account.report.line">
                                 <field name="name">381a Acquisition tax</field>
@@ -202,13 +172,7 @@
                     <record id="account_tax_report_line_chtax_399" model="account.report.line">
                         <field name="name">399 Total amount of tax due</field>
                         <field name="code">tax_ch_399</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_chtax_399_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">tax_ch_302B.balance + tax_ch_312B.balance + tax_ch_342B.balance + tax_ch_381B.balance + tax_ch_382B.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">tax_ch_302B.balance + tax_ch_312B.balance + tax_ch_342B.balance + tax_ch_381B.balance + tax_ch_382B.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_chtax_302b" model="account.report.line">
                                 <field name="name">302b Tax due at 7.7% (TS)</field>
@@ -272,13 +236,7 @@
             <record id="account_tax_report_line_chtax_479" model="account.report.line">
                 <field name="name">479 TVA préalable</field>
                 <field name="code">tax_ch_479</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_chtax_479_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ch_400.balance + tax_ch_405.balance + tax_ch_410.balance + tax_ch_415.balance + tax_ch_420.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ch_400.balance + tax_ch_405.balance + tax_ch_410.balance + tax_ch_415.balance + tax_ch_420.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_chtax_400" model="account.report.line">
                         <field name="name">400 Input tax on cost of materials and supplies of services</field>
@@ -374,13 +332,7 @@
             </record>
             <record id="account_tax_report_line_chtax_autres_mouv" model="account.report.line">
                 <field name="name">OTHER CASH FLOWS (art. 18 para. 2)</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_chtax_autres_mouv_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ch_900.balance + tax_ch_910.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ch_900.balance + tax_ch_910.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_chtax_900" model="account.report.line">
                         <field name="name">900 Subsidies, tourist funds collected by tourist offices, contributions from cantonal water, sewage or waste funds (art. 18 para. 2 lit. a to c)</field>

--- a/addons/l10n_de/data/account_account_tags_data.xml
+++ b/addons/l10n_de/data/account_account_tags_data.xml
@@ -15,46 +15,22 @@
         <field name="line_ids">
             <record id="tax_report_de_tag_01" model="account.report.line">
                 <field name="name">Bemessungsgrundlage</field>
-                <field name="expression_ids">
-                    <record id="tax_report_de_tag_01_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">I_ANMELDUNG_DER_UMSATZSTEUERVORAUSZAHLUNG_ZEILE_17_GRUNDLAGE.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">I_ANMELDUNG_DER_UMSATZSTEUERVORAUSZAHLUNG_ZEILE_17_GRUNDLAGE.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_de_tag_17" model="account.report.line">
                         <field name="name">I. Anmeldung der Umsatzsteuer-Vorauszahlung (zeile 17)</field>
                         <field name="code">I_ANMELDUNG_DER_UMSATZSTEUERVORAUSZAHLUNG_ZEILE_17_GRUNDLAGE</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_de_tag_17_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LIEFERUNGEN_UND_SONSTIGE_LEISTUNGEN_ZEILE_18_GRUNDLAGE.balance + INNERGEMEINSCHAFTLICHE_ERWERBE_ZEILE_31_GRUNDLAGE.balance + ERGANZENDE_ANGABEN_ZU_UMSATZEN_ZEILE_37_GRUNDLAGE.balance + LEISTUNGSEMPFANGER_ALS_STEUERSCHULDNER_ZEILE_46_GRUNDLAGE.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LIEFERUNGEN_UND_SONSTIGE_LEISTUNGEN_ZEILE_18_GRUNDLAGE.balance + INNERGEMEINSCHAFTLICHE_ERWERBE_ZEILE_31_GRUNDLAGE.balance + ERGANZENDE_ANGABEN_ZU_UMSATZEN_ZEILE_37_GRUNDLAGE.balance + LEISTUNGSEMPFANGER_ALS_STEUERSCHULDNER_ZEILE_46_GRUNDLAGE.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_de_tag_18" model="account.report.line">
                                 <field name="name">Lieferungen und sonstige Leistungen (zeile 18)</field>
                                 <field name="code">LIEFERUNGEN_UND_SONSTIGE_LEISTUNGEN_ZEILE_18_GRUNDLAGE</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_de_tag_18_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">STEUERFREIE_UMSATZE_MIT_VORSTEUERABZUG_ZEILE_19.balance + DE_48.balance + STEUERPFLICHTIGE_UMSATZE_ZEILE_25.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">STEUERFREIE_UMSATZE_MIT_VORSTEUERABZUG_ZEILE_19.balance + DE_48.balance + STEUERPFLICHTIGE_UMSATZE_ZEILE_25.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_19" model="account.report.line">
                                         <field name="name">Steuerfreie Umsätze mit Vorsteuerabzug (zeile 19)</field>
                                         <field name="code">STEUERFREIE_UMSATZE_MIT_VORSTEUERABZUG_ZEILE_19</field>
-                                        <field name="expression_ids">
-                                            <record id="tax_report_de_tag_19_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">DE_41.balance + DE_44.balance + DE_49.balance + DE_43.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">DE_41.balance + DE_44.balance + DE_49.balance + DE_43.balance</field>
                                         <field name="children_ids">
                                             <record id="tax_report_de_tag_41" model="account.report.line">
                                                 <field name="name">41. an Abnehmer mit USt-IdNr (zeile 20)</field>
@@ -116,13 +92,7 @@
                                     <record id="tax_report_de_tag_25" model="account.report.line">
                                         <field name="name">Steuerpflichtige Umsätze (zeile 25)</field>
                                         <field name="code">STEUERPFLICHTIGE_UMSATZE_ZEILE_25</field>
-                                        <field name="expression_ids">
-                                            <record id="tax_report_de_tag_25_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">DE_81_BASE.balance + DE_86_BASE.balance + DE_35.balance + DE_77.balance + DE_76.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">DE_81_BASE.balance + DE_86_BASE.balance + DE_35.balance + DE_77.balance + DE_76.balance</field>
                                         <field name="children_ids">
                                             <record id="tax_report_de_tag_81" model="account.report.line">
                                                 <field name="name">81. zum Steuersatz von 19 % (zeile 26)</field>
@@ -186,13 +156,7 @@
                             <record id="tax_report_de_tag_31" model="account.report.line">
                                 <field name="name">Innergemeinschaftliche Erwerbe (zeile 31)</field>
                                 <field name="code">INNERGEMEINSCHAFTLICHE_ERWERBE_ZEILE_31_GRUNDLAGE</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_de_tag_31_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">DE_91.balance + DE_89_BASE.balance + DE_93_BASE.balance + DE_95.balance + DE_94.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">DE_91.balance + DE_89_BASE.balance + DE_93_BASE.balance + DE_95.balance + DE_94.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_91" model="account.report.line">
                                         <field name="name">91. Steuerfreie innergemeinschaftliche Erwerbe (zeile 32)</field>
@@ -254,13 +218,7 @@
                             <record id="tax_report_de_tag_37" model="account.report.line">
                                 <field name="name">Ergänzende Angaben zu Umsätzen (zeile 37)</field>
                                 <field name="code">ERGANZENDE_ANGABEN_ZU_UMSATZEN_ZEILE_37_GRUNDLAGE</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_de_tag_37_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">DE_42.balance + DE_68.balance + DE_60.balance + DE_21.balance + DE_45_BASE.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">DE_42.balance + DE_68.balance + DE_60.balance + DE_21.balance + DE_45_BASE.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_42" model="account.report.line">
                                         <field name="name">42. Dreiecksgeschäften (zeile 38)</field>
@@ -322,13 +280,7 @@
                             <record id="tax_report_de_tag_46" model="account.report.line">
                                 <field name="name">Leistungsempfänger als Steuerschuldner (zeile 46)</field>
                                 <field name="code">LEISTUNGSEMPFANGER_ALS_STEUERSCHULDNER_ZEILE_46_GRUNDLAGE</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_de_tag_46_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">DE_46.balance + DE_52.balance + DE_73.balance + DE_78.balance + DE_84.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">DE_46.balance + DE_52.balance + DE_73.balance + DE_78.balance + DE_84.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_48" model="account.report.line">
                                         <field name="name">46. Steuerpflichtige sonstige Leistungen eines im übrigen Gemeinschaftsgebiet ansässigen Unternehmers (zeile 48)</field>
@@ -393,35 +345,17 @@
             </record>
             <record id="tax_report_de_tag_02" model="account.report.line">
                 <field name="name">Steuer</field>
-                <field name="expression_ids">
-                    <record id="tax_report_de_tag_02_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">I_ANMELDUNG_DER_UMSATZSTEUERVORAUSZAHLUNG_ZEILE_17_STEUER.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">I_ANMELDUNG_DER_UMSATZSTEUERVORAUSZAHLUNG_ZEILE_17_STEUER.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_de_tax_tag_17" model="account.report.line">
                         <field name="name">I. Anmeldung der Umsatzsteuer-Vorauszahlung (zeile 17)</field>
                         <field name="code">I_ANMELDUNG_DER_UMSATZSTEUERVORAUSZAHLUNG_ZEILE_17_STEUER</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_de_tax_tag_17_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LIEFERUNGEN_UND_SONSTIGE_LEISTUNGEN_ZEILE_18_STEUER.balance + INNERGEMEINSCHAFTLICHE_ERWERBE_ZEILE_31_STEUER.balance + ERGANZENDE_ANGABEN_ZU_UMSATZEN_ZEILE_37_STEUER.balance + LEISTUNGSEMPFANGER_ALS_STEUERSCHULDNER_ZEILE_46.balance + ABZIEHBARE_VORSTEUERBETRAGE_ZEILE_55.balance + ANDERE_STEUERBETRAGE_ZEILE_64.balance + UMSATZSTEUERVORAUSZAHLUNGUBERSCHUSS_ZEILE_66.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LIEFERUNGEN_UND_SONSTIGE_LEISTUNGEN_ZEILE_18_STEUER.balance + INNERGEMEINSCHAFTLICHE_ERWERBE_ZEILE_31_STEUER.balance + ERGANZENDE_ANGABEN_ZU_UMSATZEN_ZEILE_37_STEUER.balance + LEISTUNGSEMPFANGER_ALS_STEUERSCHULDNER_ZEILE_46.balance + ABZIEHBARE_VORSTEUERBETRAGE_ZEILE_55.balance + ANDERE_STEUERBETRAGE_ZEILE_64.balance + UMSATZSTEUERVORAUSZAHLUNGUBERSCHUSS_ZEILE_66.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_de_tax_tag_18" model="account.report.line">
                                 <field name="name">Lieferungen und sonstige Leistungen (zeile 18)</field>
                                 <field name="code">LIEFERUNGEN_UND_SONSTIGE_LEISTUNGEN_ZEILE_18_STEUER</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_de_tax_tag_18_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">DE_81.balance + DE_86.balance + DE_36.balance + DE_80.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">DE_81.balance + DE_86.balance + DE_36.balance + DE_80.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_26" model="account.report.line">
                                         <field name="name">81. zum Steuersatz von 19 % (zeile 26)</field>
@@ -472,13 +406,7 @@
                             <record id="tax_report_de_tax_tag_31" model="account.report.line">
                                 <field name="name">Innergemeinschaftliche Erwerbe (zeile 31)</field>
                                 <field name="code">INNERGEMEINSCHAFTLICHE_ERWERBE_ZEILE_31_STEUER</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_de_tax_tag_31_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">DE_89.balance + DE_93.balance + DE_98.balance + DE_96.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">DE_89.balance + DE_93.balance + DE_98.balance + DE_96.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_33" model="account.report.line">
                                         <field name="name">89. zum Steuersatz von 19 % (zeile 33)</field>
@@ -529,13 +457,7 @@
                             <record id="tax_report_de_tax_tag_37" model="account.report.line">
                                 <field name="name">Erganzende Angaben zu Umsatzen (zeile 37)</field>
                                 <field name="code">ERGANZENDE_ANGABEN_ZU_UMSATZEN_ZEILE_37_STEUER</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_de_tax_tag_37_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">DE_45.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">DE_45.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tax_tag_45" model="account.report.line">
                                         <field name="name">45. Ubertrag (zeile 45)</field>
@@ -553,13 +475,7 @@
                             <record id="tax_report_de_tax_tag_46" model="account.report.line">
                                 <field name="name">Leistungsempfanger als Steuerschuldner (zeile 46)</field>
                                 <field name="code">LEISTUNGSEMPFANGER_ALS_STEUERSCHULDNER_ZEILE_46</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_de_tax_tag_46_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">DE_47.balance + DE_53.balance + DE_74.balance + DE_79.balance + DE_85.balance + DE_65.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">DE_47.balance + DE_53.balance + DE_74.balance + DE_79.balance + DE_85.balance + DE_65.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_47" model="account.report.line">
                                         <field name="name">47. Steuerpflichtige sonstige Leistungen eines im übrigen Gemeinschaftsgebietansässigen Unternehmers (zeile 48)</field>
@@ -632,13 +548,7 @@
                             <record id="tax_report_de_tax_tag_55" model="account.report.line">
                                 <field name="name">Abziehbare Vorsteuerbetrage (zeile 55)</field>
                                 <field name="code">ABZIEHBARE_VORSTEUERBETRAGE_ZEILE_55</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_de_tax_tag_55_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">DE_66.balance + DE_61.balance + DE_62.balance + DE_67.balance + DE_63.balance + DE_64.balance + DE_59.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">DE_66.balance + DE_61.balance + DE_62.balance + DE_67.balance + DE_63.balance + DE_64.balance + DE_59.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_66" model="account.report.line">
                                         <field name="name">66. Vorsteuerbeträge aus Rechnungen von anderen Unternehmern (zeile 56)</field>
@@ -722,13 +632,7 @@
                             <record id="tax_report_de_tax_tag_64" model="account.report.line">
                                 <field name="name">Andere Steuerbetrage (zeile 64)</field>
                                 <field name="code">ANDERE_STEUERBETRAGE_ZEILE_64</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_de_tax_tag_64_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">DE_69.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">DE_69.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_69" model="account.report.line">
                                         <field name="name">69. In Rechnungen unrichtig oder unberechtigt ausgewiesene Steuerbeträge (zeile 65)</field>
@@ -746,13 +650,7 @@
                             <record id="tax_report_de_tax_tag_66" model="account.report.line">
                                 <field name="name">Umsatzsteuer-Vorauszahlung/Uberschuss (zeile 66)</field>
                                 <field name="code">UMSATZSTEUERVORAUSZAHLUNGUBERSCHUSS_ZEILE_66</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_de_tax_tag_66_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">DE_39.balance + DE_83.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">DE_39.balance + DE_83.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_39" model="account.report.line">
                                         <field name="name">39. Abzug der festgesetzten Sondervorauszahlung für Dauerfristverlängerung (zeile 67)</field>

--- a/addons/l10n_dk/data/account_tax_report_data.xml
+++ b/addons/l10n_dk/data/account_tax_report_data.xml
@@ -16,13 +16,7 @@
             <record id="account_tax_report_line_sales_group" model="account.report.line">
                 <field name="name">Skyldig moms</field>
                 <field name="code">DUE_VAT</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_sales_group_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">DK_SALES_VAT.balance + REVERSE_CHARGE_MERCHANDISES_PURCHASED_OUT_DK.balance + REVERSE_CHARGE_SERVICES_PURCHASED_OUT_DK.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">DK_SALES_VAT.balance + REVERSE_CHARGE_MERCHANDISES_PURCHASED_OUT_DK.balance + REVERSE_CHARGE_SERVICES_PURCHASED_OUT_DK.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_sales_tax" model="account.report.line">
                         <field name="name">Salgsmoms (udgående moms)</field>
@@ -62,13 +56,7 @@
             <record id="account_tax_report_line_deduction_group" model="account.report.line">
                 <field name="name">Fradrag</field>
                 <field name="code">VAT_TO_DEDUCED</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_deduction_group_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">PURCHASE_VAT.balance + OIL_AND_BOTTLED_GAS_TAX.balance + ELECTRICITY_TAX.balance + NATURAL_AND_CITY_GAS_TAX.balance + COAL_TAX.balance + CO2_TAX.balance + WATER_TAX.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">PURCHASE_VAT.balance + OIL_AND_BOTTLED_GAS_TAX.balance + ELECTRICITY_TAX.balance + NATURAL_AND_CITY_GAS_TAX.balance + COAL_TAX.balance + CO2_TAX.balance + WATER_TAX.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_deduction_purchase_tax" model="account.report.line">
                         <field name="name">Købsmoms (indgående moms)</field>
@@ -151,13 +139,7 @@
             </record>
             <record id="account_tax_report_line_vat_statement" model="account.report.line">
                 <field name="name">Momsangivelse (positivt beløb = betale, negativt beløb = penge tilgode)</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_vat_statement_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">DUE_VAT.balance - VAT_TO_DEDUCED.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">DUE_VAT.balance - VAT_TO_DEDUCED.balance</field>
             </record>
             <record id="account_tax_report_line_additional_info" model="account.report.line">
                 <field name="name">Supplerende oplysninger</field>

--- a/addons/l10n_do/data/account_tax_report_data.xml
+++ b/addons/l10n_do/data/account_tax_report_data.xml
@@ -15,24 +15,12 @@
         <field name="line_ids">
             <record id="account_tax_report_total_operaciones" model="account.report.line">
                 <field name="name">II-1 Total de Operaciones</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_total_operaciones_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">IIA_INGRESOS_POR_EXPORTACIONES_DE_BIENES_O_SERVICIOS_EXENTOS.balance + IIB_GRAVADAS.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">IIA_INGRESOS_POR_EXPORTACIONES_DE_BIENES_O_SERVICIOS_EXENTOS.balance + IIB_GRAVADAS.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_2A_ingrs_exprt" model="account.report.line">
                         <field name="name">II.A INGRESOS POR EXPORTACIONES DE BIENES O SERVICIOS EXENTOS</field>
                         <field name="code">IIA_INGRESOS_POR_EXPORTACIONES_DE_BIENES_O_SERVICIOS_EXENTOS</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_2A_ingrs_exprt_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">IIA2_INGRESOS_POR_EXPORTACIONES_DE_BIENES_O_SERVICIOS_EXENTOS.balance + DOTAX010102.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">IIA2_INGRESOS_POR_EXPORTACIONES_DE_BIENES_O_SERVICIOS_EXENTOS.balance + DOTAX010102.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_2A2_ingrs_exprt" model="account.report.line">
                                 <field name="name">II.A.2 INGRESOS POR EXPORTACIONES DE BIENES O SERVICIOS EXENTOS</field>
@@ -62,13 +50,7 @@
                     <record id="account_tax_report_2b_grvd" model="account.report.line">
                         <field name="name">II.B GRAVADAS</field>
                         <field name="code">IIB_GRAVADAS</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_2b_grvd_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">DOTAX010201.balance + IIB7_OPERACIONES_GRAVADAS_AL_11.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">DOTAX010201.balance + IIB7_OPERACIONES_GRAVADAS_AL_11.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_2b6_grvd" model="account.report.line">
                                 <field name="name">II.B.6 OPERACIONES GRAVADAS AL 18%</field>
@@ -99,24 +81,12 @@
             </record>
             <record id="account_tax_report_3_liquidacion" model="account.report.line">
                 <field name="name">III LIQUIDACION</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_3_liquidacion_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">III10_TOTAL_ITBIS_COBRADO_SUMAR_CASILLAS_89.balance + III14_TOTAL_ITBIS_PAGADO_SUMAR_CASILLAS_111213.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">III10_TOTAL_ITBIS_COBRADO_SUMAR_CASILLAS_89.balance + III14_TOTAL_ITBIS_PAGADO_SUMAR_CASILLAS_111213.balance</field>
                 <field name="children_ids">
                     <record id="account_financial_report_line_02_01_do_account_tax_report_total_itbs" model="account.report.line">
                         <field name="name">III.10 TOTAL ITBIS COBRADO (Sumar casillas 8+9)</field>
                         <field name="code">III10_TOTAL_ITBIS_COBRADO_SUMAR_CASILLAS_89</field>
-                        <field name="expression_ids">
-                            <record id="account_financial_report_line_02_01_do_account_tax_report_total_itbs_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">DOTAX020101.balance + III9_TBIS_COBRADO_11_DE_LA_CASILLA_7.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">DOTAX020101.balance + III9_TBIS_COBRADO_11_DE_LA_CASILLA_7.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_itbs_18_casilla" model="account.report.line">
                                 <field name="name">III.8 ITBIS COBRADO (18% de la casilla 6)</field>
@@ -146,13 +116,7 @@
                     <record id="account_tax_report_total_itbs_pgdo" model="account.report.line">
                         <field name="name">III.14 TOTAL ITBIS PAGADO (Sumar casillas 11+12+13)</field>
                         <field name="code">III14_TOTAL_ITBIS_PAGADO_SUMAR_CASILLAS_111213</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_total_itbs_pgdo_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">DOTAX020201.balance + DOTAX020202.balance + DOTAX020203.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">DOTAX020201.balance + DOTAX020202.balance + DOTAX020203.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_itbs_pgdo_locales" model="account.report.line">
                                 <field name="name">III.11 ITBIS PAGADO EN COMPRAS LOCALES</field>
@@ -193,13 +157,7 @@
             </record>
             <record id="account_tax_report_itbs_rntnd" model="account.report.line">
                 <field name="name">A,1 ITBIS RETENIDO</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_itbs_rntnd_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">DOTAX0301.balance + DOTAX0302.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">DOTAX0301.balance + DOTAX0302.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_retcn_prsn" model="account.report.line">
                         <field name="name">A.25 Servicios Sujetos a Retención Personas = Físicas y Entidad</field>

--- a/addons/l10n_eg/data/account_tax_report_data.xml
+++ b/addons/l10n_eg/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="tax_report_vat_return_sale_base" model="account.report.line">
                 <field name="name">VAT on Sales and all other Outputs (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_vat_return_sale_base_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_STD_SALE_B.balance + EG_ZERO_SALE_B.balance + EG_EXM_SALE_B.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_STD_SALE_B.balance + EG_ZERO_SALE_B.balance + EG_EXM_SALE_B.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_vat_return_sale_base_fourteen" model="account.report.line">
                         <field name="name">1. Standard Rated 14% (Base)</field>
@@ -60,13 +54,7 @@
             </record>
             <record id="tax_report_vat_return_sale_tax" model="account.report.line">
                 <field name="name">VAT on Sales and all other Outputs (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_vat_return_sale_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_STD_SALE_T.balance + EG_ZERO_SALE_T.balance + EG_EXM_SALE_T.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_STD_SALE_T.balance + EG_ZERO_SALE_T.balance + EG_EXM_SALE_T.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_vat_return_sale_tax_fourteen" model="account.report.line">
                         <field name="name">1. Standard Rated 14% (Tax)</field>
@@ -105,13 +93,7 @@
             </record>
             <record id="tax_report_vat_return_expense_base" model="account.report.line">
                 <field name="name">VAT on Expenses and all other Inputs (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_vat_return_expense_base_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_STD_PUR_B.balance + EG_ZERO_PUR_B.balance + EG_EXM_PUR_B.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_STD_PUR_B.balance + EG_ZERO_PUR_B.balance + EG_EXM_PUR_B.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_vat_return_expense_base_fourteen" model="account.report.line">
                         <field name="name">5. Standard Rated 14% Expenses (Base)</field>
@@ -150,13 +132,7 @@
             </record>
             <record id="tax_report_vat_return_expense_tax" model="account.report.line">
                 <field name="name">VAT on Expenses and all other Inputs (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_vat_return_expense_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_STD_PUR_T.balance + EG_ZERO_PUR_T.balance + EG_EXM_PUR_T.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_STD_PUR_T.balance + EG_ZERO_PUR_T.balance + EG_EXM_PUR_T.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_vat_return_expense_tax_fourteen" model="account.report.line">
                         <field name="name">5. Standard Rated 14% Expenses (Tax)</field>
@@ -198,33 +174,15 @@
                 <field name="children_ids">
                     <record id="tax_report_vat_return_net_1" model="account.report.line">
                         <field name="name">Total value of due tax for the period</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_vat_return_net_1_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">EG_STD_SALE_T.balance + EG_ZERO_SALE_T.balance + EG_EXM_SALE_T.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">EG_STD_SALE_T.balance + EG_ZERO_SALE_T.balance + EG_EXM_SALE_T.balance</field>
                     </record>
                     <record id="tax_report_vat_return_net_2" model="account.report.line">
                         <field name="name">Total value of recoverable tax for the period</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_vat_return_net_2_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">EG_STD_PUR_T.balance + EG_ZERO_PUR_T.balance + EG_EXM_PUR_T.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">EG_STD_PUR_T.balance + EG_ZERO_PUR_T.balance + EG_EXM_PUR_T.balance</field>
                     </record>
                     <record id="tax_report_vat_return_net_3" model="account.report.line">
                         <field name="name">Net VAT due (or reclaimed) for the period</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_vat_return_net_3_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">EG_STD_SALE_T.balance + EG_ZERO_SALE_T.balance + EG_EXM_SALE_T.balance - (EG_STD_PUR_T.balance + EG_ZERO_PUR_T.balance + EG_EXM_PUR_T.balance)</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">EG_STD_SALE_T.balance + EG_ZERO_SALE_T.balance + EG_EXM_SALE_T.balance - (EG_STD_PUR_T.balance + EG_ZERO_PUR_T.balance + EG_EXM_PUR_T.balance)</field>
                     </record>
                 </field>
             </record>
@@ -245,13 +203,7 @@
         <field name="line_ids">
             <record id="tax_report_withholding_tax_sale_base" model="account.report.line">
                 <field name="name">Withholding Tax on Sales (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_withholding_tax_sale_base_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_H_SALE_B.balance + EG_O_SALE_B.balance + EG_T_SALE_B.balance + EG_F_SALE_B.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_H_SALE_B.balance + EG_O_SALE_B.balance + EG_T_SALE_B.balance + EG_F_SALE_B.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_withholding_tax_sale_base_half" model="account.report.line">
                         <field name="name">Withholding Tax on Sales -0.5% (Base)</field>
@@ -301,13 +253,7 @@
             </record>
             <record id="tax_report_withholding_tax_sale_tax" model="account.report.line">
                 <field name="name">Withholding Tax on Sales (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_withholding_tax_sale_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_H_SALE_T.balance + EG_O_SALE_T.balance + EG_T_SALE_T.balance + EG_F_SALE_T.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_H_SALE_T.balance + EG_O_SALE_T.balance + EG_T_SALE_T.balance + EG_F_SALE_T.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_withholding_tax_sale_tax_half" model="account.report.line">
                         <field name="name">Withholding Tax on Sales -0.5% (Tax)</field>
@@ -357,13 +303,7 @@
             </record>
             <record id="tax_report_withholding_tax_purchase_base" model="account.report.line">
                 <field name="name">Withholding Tax on Purchases (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_withholding_tax_purchase_base_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_H_PUR_B.balance + EG_O_PUR_B.balance + EG_T_PUR_B.balance + EG_F_PUR_B.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_H_PUR_B.balance + EG_O_PUR_B.balance + EG_T_PUR_B.balance + EG_F_PUR_B.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_withholding_tax_purchase_base_half" model="account.report.line">
                         <field name="name">Withholding Tax on Purchases -0.5% (Base)</field>
@@ -413,13 +353,7 @@
             </record>
             <record id="tax_report_withholding_tax_purchase_tax" model="account.report.line">
                 <field name="name">Withholding Tax on Purchases (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_withholding_tax_purchase_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_H_PUR_T.balance + EG_O_PUR_T.balance + EG_T_PUR_T.balance + EG_F_PUR_T.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_H_PUR_T.balance + EG_O_PUR_T.balance + EG_T_PUR_T.balance + EG_F_PUR_T.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_withholding_tax_purchase_tax_half" model="account.report.line">
                         <field name="name">Withholding Tax on Purchases -0.5% (Tax)</field>
@@ -484,13 +418,7 @@
         <field name="line_ids">
             <record id="tax_report_schedule_tax_schedule_tax_sale_base" model="account.report.line">
                 <field name="name">Schedule Tax on Sales (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_schedule_tax_schedule_tax_sale_base_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_H_SALE_SB.balance + EG_O_SALE_SB.balance + EG_F_SALE_SB.balance + EG_E_SALE_SB.balance + EG_T_SALE_SB.balance + EG_FF_SALE_SB.balance + EG_TY_SALE_SB.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_H_SALE_SB.balance + EG_O_SALE_SB.balance + EG_F_SALE_SB.balance + EG_E_SALE_SB.balance + EG_T_SALE_SB.balance + EG_FF_SALE_SB.balance + EG_TY_SALE_SB.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_schedule_tax_schedule_tax_sale_base_half" model="account.report.line">
                         <field name="name">Schedule Tax on Sales 0.5% (Base)</field>
@@ -573,13 +501,7 @@
             </record>
             <record id="tax_report_schedule_tax_schedule_tax_sale_tax" model="account.report.line">
                 <field name="name">Schedule Tax on Sales (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_schedule_tax_schedule_tax_sale_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_H_SALE_ST.balance + EG_O_SALE_ST.balance + EG_F_SALE_ST.balance + EG_E_SALE_ST.balance + EG_T_SALE_ST.balance + EG_FF_SALE_ST.balance + EG_TY_SALE_ST.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_H_SALE_ST.balance + EG_O_SALE_ST.balance + EG_F_SALE_ST.balance + EG_E_SALE_ST.balance + EG_T_SALE_ST.balance + EG_FF_SALE_ST.balance + EG_TY_SALE_ST.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_schedule_tax_schedule_tax_sale_tax_half" model="account.report.line">
                         <field name="name">Schedule Tax on Sales 0.5% (Tax)</field>
@@ -662,13 +584,7 @@
             </record>
             <record id="tax_report_schedule_tax_schedule_tax_purchase_base" model="account.report.line">
                 <field name="name">Schedule Tax on Purchases (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_schedule_tax_schedule_tax_purchase_base_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_H_PUR_SB.balance + EG_O_PUR_SB.balance + EG_F_PUR_SB.balance + EG_E_PUR_SB.balance + EG_T_PUR_SB.balance + EG_FF_PUR_SB.balance + EG_TY_PUR_SB.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_H_PUR_SB.balance + EG_O_PUR_SB.balance + EG_F_PUR_SB.balance + EG_E_PUR_SB.balance + EG_T_PUR_SB.balance + EG_FF_PUR_SB.balance + EG_TY_PUR_SB.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_schedule_tax_schedule_tax_purchase_base_half" model="account.report.line">
                         <field name="name">Schedule Tax on Purchases 0.5% (Base)</field>
@@ -751,13 +667,7 @@
             </record>
             <record id="tax_report_schedule_tax_schedule_tax_purchase_tax" model="account.report.line">
                 <field name="name">Schedule Tax on Purchases (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_schedule_tax_schedule_tax_purchase_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_H_PUR_ST.balance + EG_O_PUR_ST.balance + EG_F_PUR_ST.balance + EG_E_PUR_ST.balance + EG_T_PUR_ST.balance + EG_FF_PUR_ST.balance + EG_TY_PUR_ST.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_H_PUR_ST.balance + EG_O_PUR_ST.balance + EG_F_PUR_ST.balance + EG_E_PUR_ST.balance + EG_T_PUR_ST.balance + EG_FF_PUR_ST.balance + EG_TY_PUR_ST.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_schedule_tax_schedule_tax_purchase_tax_half" model="account.report.line">
                         <field name="name">Schedule Tax on Purchases 0.5% (Tax)</field>
@@ -855,13 +765,7 @@
         <field name="line_ids">
             <record id="tax_report_other_taxes_stamp_tax_base" model="account.report.line">
                 <field name="name">Stamp Tax Sales (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_other_taxes_stamp_tax_base_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_STMP_TW_SB.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_STMP_TW_SB.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_other_taxes_stamp_tax_base_sales" model="account.report.line">
                         <field name="name">Stamp Tax Sales 20% (Base)</field>
@@ -878,13 +782,7 @@
             </record>
             <record id="tax_report_other_taxes_stamp_tax_tax" model="account.report.line">
                 <field name="name">Stamp Tax Sales (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_other_taxes_stamp_tax_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_STMP_TW_ST.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_STMP_TW_ST.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_other_taxes_stamp_tax_tax_sales" model="account.report.line">
                         <field name="name">Stamp Tax Sales 20% (Tax)</field>
@@ -901,13 +799,7 @@
             </record>
             <record id="tax_report_other_taxes_stamp_purchase_tax_base" model="account.report.line">
                 <field name="name">Stamp Tax Purchases (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_other_taxes_stamp_purchase_tax_base_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_STMP_TW_PB.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_STMP_TW_PB.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_other_taxes_stamp_purchase_tax_base_purchase" model="account.report.line">
                         <field name="name">Stamp Tax Purchases 20% (Base)</field>
@@ -924,13 +816,7 @@
             </record>
             <record id="tax_report_other_taxes_stamp_purchase_tax_tax" model="account.report.line">
                 <field name="name">Stamp Tax Purchases (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_other_taxes_stamp_purchase_tax_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">EG_STMP_TW_PT.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">EG_STMP_TW_PT.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_other_taxes_stamp_purchase_tax_tax_purchase" model="account.report.line">
                         <field name="name">Stamp Tax Purchases 20% (Tax)</field>

--- a/addons/l10n_et/data/account_tax_report_data.xml
+++ b/addons/l10n_et/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="account_tax_report_purch_vt" model="account.report.line">
                 <field name="name">Taxable Purchases - VAT</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_purch_vt_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ET_TAXABLE_PURCHASE_VAT_OUT_OF_SCOPE.balance + ET_TAXABLE_PURCHASE_VAT_EXEMPT.balance + ET_TAXABLE_PURCHASE_VAT_RATED_0.balance + ET_TAXABLE_PURCHASE_VAT_RATED_15.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ET_TAXABLE_PURCHASE_VAT_OUT_OF_SCOPE.balance + ET_TAXABLE_PURCHASE_VAT_EXEMPT.balance + ET_TAXABLE_PURCHASE_VAT_RATED_0.balance + ET_TAXABLE_PURCHASE_VAT_RATED_15.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_purch_vt_out_scope" model="account.report.line">
                         <field name="name">Taxable Purchase VAT Out of Scope</field>
@@ -71,13 +65,7 @@
             </record>
             <record id="account_tax_report_purch_withholding" model="account.report.line">
                 <field name="name">Taxable Purchases - Witholding</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_purch_withholding_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ET_TAXABLE_ET_2_WITHHOLDING_ON_PURCHASES.balance + ET_TAXABLE_ET_35_WITHHOLDING_ON_PURCHASES.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ET_TAXABLE_ET_2_WITHHOLDING_ON_PURCHASES.balance + ET_TAXABLE_ET_35_WITHHOLDING_ON_PURCHASES.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_purch_withholding_2" model="account.report.line">
                         <field name="name">Taxable 2% Withholding on Purchases</field>
@@ -105,13 +93,7 @@
             </record>
             <record id="account_tax_report_sale_vat" model="account.report.line">
                 <field name="name">Taxable Sales - VAT</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_sale_vat_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ET_TAXABLE_SALES_VAT_OUT_OF_SCOPE_SALES.balance + ET_TAXABLE_SALES_VAT_EXEMPT.balance + ET_TAXABLE_SALES_VAT_RATED_0.balance + ET_TAXABLE_ET_SALES_VAT_RATED_15.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ET_TAXABLE_SALES_VAT_OUT_OF_SCOPE_SALES.balance + ET_TAXABLE_SALES_VAT_EXEMPT.balance + ET_TAXABLE_SALES_VAT_RATED_0.balance + ET_TAXABLE_ET_SALES_VAT_RATED_15.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_sale_vat_out_scope" model="account.report.line">
                         <field name="name">Taxable Sales VAT Out of Scope (Sales)</field>
@@ -161,13 +143,7 @@
             </record>
             <record id="account_tax_report_sale_withholding" model="account.report.line">
                 <field name="name">Taxable Sales - Withholding</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_sale_withholding_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ET_TAXABLE_2_WITHHOLDING_ON_SALES.balance + ET_TAXABLE_35_WITHHOLDING_ON_SALES.balance + ET_TAXABLE_VAT_WITHHOLDING_ON_SALES.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ET_TAXABLE_2_WITHHOLDING_ON_SALES.balance + ET_TAXABLE_35_WITHHOLDING_ON_SALES.balance + ET_TAXABLE_VAT_WITHHOLDING_ON_SALES.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_sale_withholding_2" model="account.report.line">
                         <field name="name">Taxable 2% Withholding on Sales</field>
@@ -206,24 +182,12 @@
             </record>
             <record id="account_tax_report_net_vat" model="account.report.line">
                 <field name="name">Net VAT to be Paid/Reclaimed</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_net_vat_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ET_PURCHASE_VAT.balance + ET_SALES_VAT.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ET_PURCHASE_VAT.balance + ET_SALES_VAT.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_purch_vat" model="account.report.line">
                         <field name="name">Purchase VAT</field>
                         <field name="code">ET_PURCHASE_VAT</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_purch_vat_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">ET_PURCHASE_VAT_RATED_15.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">ET_PURCHASE_VAT_RATED_15.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_purch_vat_rated_15" model="account.report.line">
                                 <field name="name">Purchase VAT Rated 15%</field>
@@ -241,13 +205,7 @@
                     <record id="account_tax_report_net_sale_vat" model="account.report.line">
                         <field name="name">Sales VAT</field>
                         <field name="code">ET_SALES_VAT</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_net_sale_vat_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">ET_SALES_VAT_RATED_15.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">ET_SALES_VAT_RATED_15.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_net_sale_vat_15" model="account.report.line">
                                 <field name="name">Sales VAT Rated 15%</field>
@@ -266,13 +224,7 @@
             </record>
             <record id="account_tax_report_net_purch_witholding" model="account.report.line">
                 <field name="name">Withholding on Purchases</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_net_purch_witholding_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ET_2_WITHHOLDING_ON_PURCHASES.balance + ET_35_WITHHOLDING_ON_PURCHASES.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ET_2_WITHHOLDING_ON_PURCHASES.balance + ET_35_WITHHOLDING_ON_PURCHASES.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_net_purch_witholding_2" model="account.report.line">
                         <field name="name">2% Withholding on Purchases</field>
@@ -300,13 +252,7 @@
             </record>
             <record id="account_tax_report_net_sale_witholding" model="account.report.line">
                 <field name="name">Withholding on Sales</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_net_sale_witholding_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ET_2_WITHHELD_ON_SALES.balance + ET_35_WITHHELD_ON_SALES.balance + ET_VAT_WITHHELD_ON_SALES.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ET_2_WITHHELD_ON_SALES.balance + ET_35_WITHHELD_ON_SALES.balance + ET_VAT_WITHHELD_ON_SALES.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_net_sale_witheld_2" model="account.report.line">
                         <field name="name">2% Withheld on Sales</field>

--- a/addons/l10n_fi/data/account_tax_report_line.xml
+++ b/addons/l10n_fi/data/account_tax_report_line.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="tax_report_sales_title" model="account.report.line">
                 <field name="name">Vero kotimaan myynneistä verokannoittain</field>
-                <field name="expression_ids">
-                    <record id="tax_report_sales_title_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">sale_24.balance + sale_14.balance + sale_10.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">sale_24.balance + sale_14.balance + sale_10.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_sales_24" model="account.report.line">
                         <field name="name">24 %:n vero</field>
@@ -125,13 +119,7 @@
             </record>
             <record id="tax_report_tax_payable" model="account.report.line">
                 <field name="name">Maksettava vero / Palautukseen oikeuttava vero (-)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_tax_payable_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">sale_24.balance + sale_14.balance + sale_10.balance + goods_eu.balance + service_eu.balance + goods_no_eu.balance + construct.balance - deductible.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">sale_24.balance + sale_14.balance + sale_10.balance + goods_eu.balance + service_eu.balance + goods_no_eu.balance + construct.balance - deductible.balance</field>
             </record>
             <record id="tax_report_base_turnover_0_vat" model="account.report.line">
                 <field name="name">0-verokannan alainen liikevaihto</field>

--- a/addons/l10n_fr/data/tax_report_data.xml
+++ b/addons/l10n_fr/data/tax_report_data.xml
@@ -378,13 +378,7 @@
                             <record id="tax_report_16" model="account.report.line">
                                 <field name="name">16 - Total de la TVA brute due</field>
                                 <field name="code">box_16</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_16_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">box_08_taxe.balance + box_09_taxe.balance + box_9B_taxe.balance + box_10_taxe.balance + box_11_taxe.balance + box_13_taxe.balance + box_14_taxe.balance + box_15.balance + box_5B.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">box_08_taxe.balance + box_09_taxe.balance + box_9B_taxe.balance + box_10_taxe.balance + box_11_taxe.balance + box_13_taxe.balance + box_14_taxe.balance + box_15.balance + box_5B.balance</field>
                             </record>
                             <record id="tax_report_7C" model="account.report.line">
                                 <field name="name">7C - Dont TVA sur importations bénéficiant du dispositif d'autoliquidation</field>
@@ -504,13 +498,7 @@
                             <record id="tax_report_23" model="account.report.line">
                                 <field name="name">23 - Total TVA déductible</field>
                                 <field name="code">box_23</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_23_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">box_19.balance + box_20.balance + box_21.balance + box_22.balance + box_2C.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">box_19.balance + box_20.balance + box_21.balance + box_22.balance + box_2C.balance</field>
                             </record>
                             <record id="tax_report_24" model="account.report.line">
                                 <field name="name">24 - Dont TVA déductible sur importations</field>
@@ -618,13 +606,7 @@
                     <record id="tax_report_32" model="account.report.line">
                         <field name="name">32 - Total à payer</field>
                         <field name="code">box_32</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_32_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">box_28.balance + box_29.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">box_28.balance + box_29.balance</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_gr/data/account_tax_report_data.xml
+++ b/addons/l10n_gr/data/account_tax_report_data.xml
@@ -27,13 +27,7 @@
                 <field name="children_ids">
                     <record id="account_tax_report_line_307" model="account.report.line">
                         <field name="name">307 Σύνολο φορολ. Εκροών</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_307_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">GRTAX_303.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">GRTAX_303.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_303" model="account.report.line">
                                 <field name="name">303 Πωλήσεις 19-23%f</field>
@@ -53,13 +47,7 @@
             <record id="account_tax_report_line_358" model="account.report.line">
                 <field name="name">358 Σύνολο φορολ. Εισροών</field>
                 <field name="code">GRTAX_358</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_358_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">GRTAX_353.balance + GRTAX_357.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">GRTAX_353.balance + GRTAX_357.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_353" model="account.report.line">
                         <field name="name">353 Αγορές ΦΠΑ 19-23%</field>
@@ -98,13 +86,7 @@
                 <field name="children_ids">
                     <record id="account_tax_report_line_337" model="account.report.line">
                         <field name="name">337 ΦΠΑ Πωλήσεων</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_337_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">GRTAX_333.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">GRTAX_333.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_333" model="account.report.line">
                                 <field name="name">333 ΦΠΑ 19-23%</field>
@@ -121,23 +103,11 @@
                     </record>
                     <record id="account_tax_report_line_420" model="account.report.line">
                         <field name="name">420 ΦΠΑ Αγορών</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_420_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">GRTAX_373.balance+GRTAX_377.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">GRTAX_373.balance+GRTAX_377.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_378" model="account.report.line">
                                 <field name="name">378 Σύνολο Φορ. Αγορών</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_378_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">GRTAX_373.balance+GRTAX_377.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">GRTAX_373.balance+GRTAX_377.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_373" model="account.report.line">
                                         <field name="name">373 ΦΠΑ Αγορών 19-23%</field>

--- a/addons/l10n_hr/data/account_tax_report_data.xml
+++ b/addons/l10n_hr/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="account_tax_report_line_ostali_porezi" model="account.report.line">
                 <field name="name">Ostali porezi, carine, trošarine i sl.</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_ostali_porezi_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">POREZ_NA_POTROSNJU.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">POREZ_NA_POTROSNJU.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_porez" model="account.report.line">
                         <field name="name">Porez na potrošnju</field>
@@ -39,54 +33,24 @@
             </record>
             <record id="account_tax_report_line_pdv" model="account.report.line">
                 <field name="name">PDV</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_pdv_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">(((koje.balance + (izvozne.balance + isporuke.balance + tuzemne.balance + ostale.balance) + isporuke_po.balance) + (izdani_10.balance + izdani_25.balance)) + (pretporez_10.balance + (0.7 * pretporez_25_70.balance + 0.3 * pretporez_25_30.balance) + placeni_uvozu.balance + placeni_usluge_10.balance + placeni_usluge_25.balance + pretporez_0.balance)) + (((izdani_racuni.balance + izdani_racuni_25.balance) + (pretporez_10_tax.balance + pretporez_25_tax.balance + placeni_uvozu_tax.balance + placeni_usluge_10_tax.balance + placeni_usluge_25_ta.balance))) + ((nepriznati_pretporez_25_other.balance + (0.3 * nepriznati_pretporez_25_30.balance) + (0.7 * nepriznati_pretporez_25_70.balance)) + pretporez_koji.balance + (nepriznati_pretporez_25_tax.balance) + (pretporez_koji_neplaceni.balance + pretporez_koji_neplaceni_25.balance + pretporez_koji_neplaceni_usluge_25.balance))</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">(((koje.balance + (izvozne.balance + isporuke.balance + tuzemne.balance + ostale.balance) + isporuke_po.balance) + (izdani_10.balance + izdani_25.balance)) + (pretporez_10.balance + (0.7 * pretporez_25_70.balance + 0.3 * pretporez_25_30.balance) + placeni_uvozu.balance + placeni_usluge_10.balance + placeni_usluge_25.balance + pretporez_0.balance)) + (((izdani_racuni.balance + izdani_racuni_25.balance) + (pretporez_10_tax.balance + pretporez_25_tax.balance + placeni_uvozu_tax.balance + placeni_usluge_10_tax.balance + placeni_usluge_25_ta.balance))) + ((nepriznati_pretporez_25_other.balance + (0.3 * nepriznati_pretporez_25_30.balance) + (0.7 * nepriznati_pretporez_25_70.balance)) + pretporez_koji.balance + (nepriznati_pretporez_25_tax.balance) + (pretporez_koji_neplaceni.balance + pretporez_koji_neplaceni_25.balance + pretporez_koji_neplaceni_usluge_25.balance))</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_obrazac_pdv" model="account.report.line">
                         <field name="name">OBRAZAC PDV</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_obrazac_pdv_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">(((koje.balance + (izvozne.balance + isporuke.balance + tuzemne.balance + ostale.balance) + isporuke_po.balance) + (izdani_10.balance + izdani_25.balance)) + (pretporez_10.balance + (0.7 * pretporez_25_70.balance + 0.3 * pretporez_25_30.balance) + placeni_uvozu.balance + placeni_usluge_10.balance + placeni_usluge_25.balance + pretporez_0.balance)) + (((izdani_racuni.balance + izdani_racuni_25.balance) + (pretporez_10_tax.balance + pretporez_25_tax.balance + placeni_uvozu_tax.balance + placeni_usluge_10_tax.balance + placeni_usluge_25_ta.balance)))</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">(((koje.balance + (izvozne.balance + isporuke.balance + tuzemne.balance + ostale.balance) + isporuke_po.balance) + (izdani_10.balance + izdani_25.balance)) + (pretporez_10.balance + (0.7 * pretporez_25_70.balance + 0.3 * pretporez_25_30.balance) + placeni_uvozu.balance + placeni_usluge_10.balance + placeni_usluge_25.balance + pretporez_0.balance)) + (((izdani_racuni.balance + izdani_racuni_25.balance) + (pretporez_10_tax.balance + pretporez_25_tax.balance + placeni_uvozu_tax.balance + placeni_usluge_10_tax.balance + placeni_usluge_25_ta.balance)))</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_osnovica" model="account.report.line">
                                 <field name="name">O S N O V I C A</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_osnovica_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">((koje.balance + (izvozne.balance + isporuke.balance + tuzemne.balance + ostale.balance) + isporuke_po.balance) + (izdani_10.balance + izdani_25.balance)) + (pretporez_10.balance + (0.7 * pretporez_25_70.balance + 0.3 * pretporez_25_30.balance) + placeni_uvozu.balance + placeni_usluge_10.balance + placeni_usluge_25.balance + pretporez_0.balance)</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">((koje.balance + (izvozne.balance + isporuke.balance + tuzemne.balance + ostale.balance) + isporuke_po.balance) + (izdani_10.balance + izdani_25.balance)) + (pretporez_10.balance + (0.7 * pretporez_25_70.balance + 0.3 * pretporez_25_30.balance) + placeni_uvozu.balance + placeni_usluge_10.balance + placeni_usluge_25.balance + pretporez_0.balance)</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_obracun" model="account.report.line">
                                         <field name="name">Obračun isporuka (I+II)</field>
-                                        <field name="expression_ids">
-                                            <record id="account_tax_report_line_obracun_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">OBRACUN_I_ISPORUKE_NE_PODLIJEZU__OSLOBODENE.balance + OBRACUN_II_OPOREZIVE_ISPORUKE.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">OBRACUN_I_ISPORUKE_NE_PODLIJEZU__OSLOBODENE.balance + OBRACUN_II_OPOREZIVE_ISPORUKE.balance</field>
                                         <field name="children_ids">
                                             <record id="account_tax_report_line_obracun_isporuke" model="account.report.line">
                                                 <field name="name">I. Isporuke ne podliježu / oslobođene</field>
                                                 <field name="code">OBRACUN_I_ISPORUKE_NE_PODLIJEZU__OSLOBODENE</field>
-                                                <field name="expression_ids">
-                                                    <record id="account_tax_report_line_obracun_isporuke_formula" model="account.report.expression">
-                                                        <field name="label">balance</field>
-                                                        <field name="engine">aggregation</field>
-                                                        <field name="formula">koje.balance + I2_OSLOBODENE_UKUPNO.balance + isporuke_po.balance</field>
-                                                    </record>
-                                                </field>
+                                                <field name="aggregation_formula">koje.balance + I2_OSLOBODENE_UKUPNO.balance + isporuke_po.balance</field>
                                                 <field name="children_ids">
                                                     <record id="account_tax_report_line_koje" model="account.report.line">
                                                         <field name="name">I.1. Koje ne podliježu oporezivanju</field>
@@ -102,13 +66,7 @@
                                                     <record id="account_tax_report_line_oslobodene" model="account.report.line">
                                                         <field name="name">I.2. Oslobođene ukupno</field>
                                                         <field name="code">I2_OSLOBODENE_UKUPNO</field>
-                                                        <field name="expression_ids">
-                                                            <record id="account_tax_report_line_oslobodene_formula" model="account.report.expression">
-                                                                <field name="label">balance</field>
-                                                                <field name="engine">aggregation</field>
-                                                                <field name="formula">izvozne.balance + isporuke.balance + tuzemne.balance + ostale.balance</field>
-                                                            </record>
-                                                        </field>
+                                                        <field name="aggregation_formula">izvozne.balance + isporuke.balance + tuzemne.balance + ostale.balance</field>
                                                         <field name="children_ids">
                                                             <record id="account_tax_report_line_izvozne" model="account.report.line">
                                                                 <field name="name">I.2.1. Izvozne</field>
@@ -172,13 +130,7 @@
                                             <record id="account_tax_report_line_oporezive" model="account.report.line">
                                                 <field name="name">II. Oporezive isporuke</field>
                                                 <field name="code">OBRACUN_II_OPOREZIVE_ISPORUKE</field>
-                                                <field name="expression_ids">
-                                                    <record id="account_tax_report_line_oporezive_formula" model="account.report.expression">
-                                                        <field name="label">balance</field>
-                                                        <field name="engine">aggregation</field>
-                                                        <field name="formula">izdani_10.balance + OBRACUN_II2_IZDANI_RACUNI_PO_STOPI_22_I_23.balance + izdani_25.balance + II4_NENAPLACENI_IZVOZ.balance + II5_OSLOBODENJE_IZVOZA__PUTNICKI_PROMET.balance</field>
-                                                    </record>
-                                                </field>
+                                                <field name="aggregation_formula">izdani_10.balance + OBRACUN_II2_IZDANI_RACUNI_PO_STOPI_22_I_23.balance + izdani_25.balance + II4_NENAPLACENI_IZVOZ.balance + II5_OSLOBODENJE_IZVOZA__PUTNICKI_PROMET.balance</field>
                                                 <field name="children_ids">
                                                     <record id="account_tax_report_line_izdani_10" model="account.report.line">
                                                         <field name="name">II.1 Izdani računi po stopi 10%</field>
@@ -244,13 +196,7 @@
                                     </record>
                                     <record id="account_tax_report_line_obracunani" model="account.report.line">
                                         <field name="name">III. OBRAČUNANI PRETPOREZ</field>
-                                        <field name="expression_ids">
-                                            <record id="account_tax_report_line_obracunani_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">pretporez_10.balance + (0.7 * pretporez_25_70.balance + 0.3 * pretporez_25_30.balance) + placeni_uvozu.balance + placeni_usluge_10.balance + placeni_usluge_25.balance + pretporez_0.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">pretporez_10.balance + (0.7 * pretporez_25_70.balance + 0.3 * pretporez_25_30.balance) + placeni_uvozu.balance + placeni_usluge_10.balance + placeni_usluge_25.balance + pretporez_0.balance</field>
                                         <field name="children_ids">
                                             <record id="account_tax_report_line_pretporez_10" model="account.report.line">
                                                 <field name="name">III.1. Pretporez 10%</field>
@@ -275,13 +221,7 @@
                                             </record>
                                             <record id="account_tax_report_line_pretporez_25" model="account.report.line">
                                                 <field name="name">III.3. Pretporez 25%</field>
-                                                <field name="expression_ids">
-                                                    <record id="account_tax_report_line_pretporez_25_formula" model="account.report.expression">
-                                                        <field name="label">balance</field>
-                                                        <field name="engine">aggregation</field>
-                                                        <field name="formula">0.3 * pretporez_25_30.balance + 0.7 * pretporez_25_70.balance</field>
-                                                    </record>
-                                                </field>
+                                                <field name="aggregation_formula">0.3 * pretporez_25_30.balance + 0.7 * pretporez_25_70.balance</field>
                                                 <field name="children_ids">
                                                     <record id="account_tax_report_line_pretporez_25_30" model="account.report.line">
                                                         <field name="name">III.3. Pretporez 25% (30%)</field>
@@ -367,24 +307,12 @@
                             </record>
                             <record id="account_tax_report_line_pdv_porez" model="account.report.line">
                                 <field name="name">PDV – POREZ – razlika za uplatu/preplata</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_pdv_porez_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VI_POREZNA_OBVEZA_U_RAZDOBLJU.balance + UPLACENO_U_RAZDOBLJU.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">VI_POREZNA_OBVEZA_U_RAZDOBLJU.balance + UPLACENO_U_RAZDOBLJU.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_porezna" model="account.report.line">
                                         <field name="name">VI. POREZNA OBVEZA U RAZDOBLJU</field>
                                         <field name="code">VI_POREZNA_OBVEZA_U_RAZDOBLJU</field>
-                                        <field name="expression_ids">
-                                            <record id="account_tax_report_line_porezna_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">POREZNA_I_ISPORUKE_NE_PODLIJEZU__OSLOBODENE.balance + POREZNA_II_OPOREZIVE_ISPORUKE.balance + III_OBRACUNANI_PRETPOREZ.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">POREZNA_I_ISPORUKE_NE_PODLIJEZU__OSLOBODENE.balance + POREZNA_II_OPOREZIVE_ISPORUKE.balance + III_OBRACUNANI_PRETPOREZ.balance</field>
                                         <field name="children_ids">
                                             <record id="account_tax_report_line_isporuke_ne" model="account.report.line">
                                                 <field name="name">I. Isporuke ne podliježu / oslobođene</field>
@@ -401,13 +329,7 @@
                                             <record id="account_tax_report_line_oporezive_isporuke" model="account.report.line">
                                                 <field name="name">II. Oporezive isporuke</field>
                                                 <field name="code">POREZNA_II_OPOREZIVE_ISPORUKE</field>
-                                                <field name="expression_ids">
-                                                    <record id="account_tax_report_line_oporezive_isporuke_formula" model="account.report.expression">
-                                                        <field name="label">balance</field>
-                                                        <field name="engine">aggregation</field>
-                                                        <field name="formula">izdani_racuni.balance + POREZNA_II2_IZDANI_RACUNI_PO_STOPI_22_I_23.balance + izdani_racuni_25.balance + II4_OSLOBODENJE_IZVOZA__PUTNICKI_PROMET.balance</field>
-                                                    </record>
-                                                </field>
+                                                <field name="aggregation_formula">izdani_racuni.balance + POREZNA_II2_IZDANI_RACUNI_PO_STOPI_22_I_23.balance + izdani_racuni_25.balance + II4_OSLOBODENJE_IZVOZA__PUTNICKI_PROMET.balance</field>
                                                 <field name="children_ids">
                                                     <record id="account_tax_report_line_izdani_racuni" model="account.report.line">
                                                         <field name="name">II.1 Izdani računi po stopi 10%</field>
@@ -460,13 +382,7 @@
                                             <record id="account_tax_report_line_obracunani_pretporez" model="account.report.line">
                                                 <field name="name">III. OBRAČUNANI PRETPOREZ</field>
                                                 <field name="code">III_OBRACUNANI_PRETPOREZ</field>
-                                                <field name="expression_ids">
-                                                    <record id="account_tax_report_line_obracunani_pretporez_formula" model="account.report.expression">
-                                                        <field name="label">balance</field>
-                                                        <field name="engine">aggregation</field>
-                                                        <field name="formula">pretporez_10_tax.balance + III2_PRETPOREZ_22_I_23.balance + pretporez_25_tax.balance + placeni_uvozu_tax.balance + placeni_usluge_10_tax.balance + III6_PLACENI_PP_NA_INO_USLUGE_22_I_23.balance + placeni_usluge_25_ta.balance + III8_ISPRAVCI_PRETPOREZA.balance</field>
-                                                    </record>
-                                                </field>
+                                                <field name="aggregation_formula">pretporez_10_tax.balance + III2_PRETPOREZ_22_I_23.balance + pretporez_25_tax.balance + placeni_uvozu_tax.balance + placeni_usluge_10_tax.balance + III6_PLACENI_PP_NA_INO_USLUGE_22_I_23.balance + placeni_usluge_25_ta.balance + III8_ISPRAVCI_PRETPOREZA.balance</field>
                                                 <field name="children_ids">
                                                     <record id="account_tax_report_line_pretporez_10_tax" model="account.report.line">
                                                         <field name="name">III.1. Pretporez 10%</field>
@@ -581,34 +497,16 @@
                     </record>
                     <record id="account_tax_report_line_pdv_ostalo" model="account.report.line">
                         <field name="name">PDV - OSTALO</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_pdv_ostalo_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">(nepriznati_pretporez_25_other.balance + (0.3 * nepriznati_pretporez_25_30.balance) + (0.7 * nepriznati_pretporez_25_70.balance)) + pretporez_koji.balance + (nepriznati_pretporez_25_tax.balance) + (pretporez_koji_neplaceni.balance + pretporez_koji_neplaceni_25.balance + pretporez_koji_neplaceni_usluge_25.balance)</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">(nepriznati_pretporez_25_other.balance + (0.3 * nepriznati_pretporez_25_30.balance) + (0.7 * nepriznati_pretporez_25_70.balance)) + pretporez_koji.balance + (nepriznati_pretporez_25_tax.balance) + (pretporez_koji_neplaceni.balance + pretporez_koji_neplaceni_25.balance + pretporez_koji_neplaceni_usluge_25.balance)</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_ostali_podaci" model="account.report.line">
                                 <field name="name">Ostali podaci</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_ostali_podaci_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">1_ZA_ISPRAVAK_PRETPOREZA.balance + 2_OTUDENJESTJECANJE_GOSPODARSKE_CJELINE_ILI_POGONA.balance + 3_NABAVA_DOBARA_I_USLUGA_ZA_REPREZENTACIJU.balance + 4_NABAVA_OSOBNIH_VOZILA_I_DRUGIH_SREDSTAVA_ZA_OSOBNI_PRIJEVOZ.balance + 5_OSNOVICA_ZA_OBRACUN_VLASTITE_POTROSNJE_ZA_OSOBNA_VOZILA_NABAV.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">1_ZA_ISPRAVAK_PRETPOREZA.balance + 2_OTUDENJESTJECANJE_GOSPODARSKE_CJELINE_ILI_POGONA.balance + 3_NABAVA_DOBARA_I_USLUGA_ZA_REPREZENTACIJU.balance + 4_NABAVA_OSOBNIH_VOZILA_I_DRUGIH_SREDSTAVA_ZA_OSOBNI_PRIJEVOZ.balance + 5_OSNOVICA_ZA_OBRACUN_VLASTITE_POTROSNJE_ZA_OSOBNA_VOZILA_NABAV.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_ispravak" model="account.report.line">
                                         <field name="name">1. ZA ISPRAVAK PRETPOREZA</field>
                                         <field name="code">1_ZA_ISPRAVAK_PRETPOREZA</field>
-                                        <field name="expression_ids">
-                                            <record id="account_tax_report_line_ispravak_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">11_NABAVA_NEKRETNINA.balance + 12_PRODAJA_NEKRETNINA.balance + 13_NABAVA_OSOBNIH_VOZILA.balance + 14_PRODAJA_OSOBNIH_VOZILA.balance + 15_NABAVA_DUGOTRAJNE_IMOVINE.balance + 16_PRODAJA_DUGOTRAJNE_IMOVINE.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">11_NABAVA_NEKRETNINA.balance + 12_PRODAJA_NEKRETNINA.balance + 13_NABAVA_OSOBNIH_VOZILA.balance + 14_PRODAJA_OSOBNIH_VOZILA.balance + 15_NABAVA_DUGOTRAJNE_IMOVINE.balance + 16_PRODAJA_DUGOTRAJNE_IMOVINE.balance</field>
                                         <field name="children_ids">
                                             <record id="account_tax_report_line_nabava" model="account.report.line">
                                                 <field name="name">1.1. NABAVA NEKRETNINA</field>
@@ -736,23 +634,11 @@
                             </record>
                             <record id="account_tax_report_line_nepriznati_pretporez" model="account.report.line">
                                 <field name="name">NEPRIZNATI PRETPOREZ</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_nepriznati_pretporez_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">0.3 * nepriznati_pretporez_25_30.balance + 0.7 * nepriznati_pretporez_25_70.balance + nepriznati_pretporez_25_other.balance + pretporez_koji.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">0.3 * nepriznati_pretporez_25_30.balance + 0.7 * nepriznati_pretporez_25_70.balance + nepriznati_pretporez_25_other.balance + pretporez_koji.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_nepriznati_pretporez_osnovica_3070" model="account.report.line">
                                         <field name="name">NEPRIZNATI PRETPOREZ (osnovica 30 ili 70%)</field>
-                                        <field name="expression_ids">
-                                            <record id="account_tax_report_line_nepriznati_pretporez_osnovica_3070_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">0.3 * nepriznati_pretporez_25_30.balance + 0.7 * nepriznati_pretporez_25_70.balance + nepriznati_pretporez_25_other.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">0.3 * nepriznati_pretporez_25_30.balance + 0.7 * nepriznati_pretporez_25_70.balance + nepriznati_pretporez_25_other.balance</field>
                                         <field name="children_ids">
                                             <record id="account_tax_report_line_nepriznati_pretporez_10" model="account.report.line">
                                                 <field name="name">Nepriznati pretporez 10% (o)</field>
@@ -778,13 +664,7 @@
                                             </record>
                                             <record id="account_tax_report_line_nepriznati_pretporez_25" model="account.report.line">
                                                 <field name="name">Nepriznati pretporez 25% (o)</field>
-                                                <field name="expression_ids">
-                                                    <record id="account_tax_report_line_nepriznati_pretporez_25_formula" model="account.report.expression">
-                                                        <field name="label">balance</field>
-                                                        <field name="engine">aggregation</field>
-                                                        <field name="formula">0.3 * nepriznati_pretporez_25_30.balance + 0.7 * nepriznati_pretporez_25_70.balance + nepriznati_pretporez_25_other.balance</field>
-                                                    </record>
-                                                </field>
+                                                <field name="aggregation_formula">0.3 * nepriznati_pretporez_25_30.balance + 0.7 * nepriznati_pretporez_25_70.balance + nepriznati_pretporez_25_other.balance</field>
                                                 <field name="children_ids">
                                                     <record id="account_tax_report_line_nepriznati_pretporez_25_30" model="account.report.line">
                                                         <field name="name">Nepriznati pretporez 25% (o) (30%)</field>
@@ -836,24 +716,12 @@
                                     </record>
                                     <record id="account_tax_report_line_nepriznati_pretporez_porez" model="account.report.line">
                                         <field name="name">NEPRIZNATI PRETPOREZ (porez)</field>
-                                        <field name="expression_ids">
-                                            <record id="account_tax_report_line_nepriznati_pretporez_porez_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">NEPRIZNATI_PRETPOREZ_30_ILI_70.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">NEPRIZNATI_PRETPOREZ_30_ILI_70.balance</field>
                                         <field name="children_ids">
                                             <record id="account_tax_report_line_nepriznati_pretporez_3070" model="account.report.line">
                                                 <field name="name">NEPRIZNATI PRETPOREZ (30 ili 70%)</field>
                                                 <field name="code">NEPRIZNATI_PRETPOREZ_30_ILI_70</field>
-                                                <field name="expression_ids">
-                                                    <record id="account_tax_report_line_nepriznati_pretporez_3070_formula" model="account.report.expression">
-                                                        <field name="label">balance</field>
-                                                        <field name="engine">aggregation</field>
-                                                        <field name="formula">NEPRIZNATI_PRETPOREZ_10_P.balance + NEPRIZNATI_PRETPOREZ_22_I_23_P.balance + nepriznati_pretporez_25_tax.balance</field>
-                                                    </record>
-                                                </field>
+                                                <field name="aggregation_formula">NEPRIZNATI_PRETPOREZ_10_P.balance + NEPRIZNATI_PRETPOREZ_22_I_23_P.balance + nepriznati_pretporez_25_tax.balance</field>
                                                 <field name="children_ids">
                                                     <record id="account_tax_report_line_nepriznati_pretporez_10_tax" model="account.report.line">
                                                         <field name="name">Nepriznati pretporez 10% (p)</field>
@@ -896,13 +764,7 @@
                                     </record>
                                     <record id="account_tax_report_line_pretporez_koji_ukupno" model="account.report.line">
                                         <field name="name">Pretporez koji još nije priznan (ukupno)</field>
-                                        <field name="expression_ids">
-                                            <record id="account_tax_report_line_pretporez_koji_ukupno_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">pretporez_koji_neplaceni.balance + pretporez_koji_neplaceni_25.balance + pretporez_koji_neplaceni_usluge_25.balance + PRETPOREZ_KOJI_JOS_NIJE_PRIZNAN_NEPLACENE_INO_USLUGE_10.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">pretporez_koji_neplaceni.balance + pretporez_koji_neplaceni_25.balance + pretporez_koji_neplaceni_usluge_25.balance + PRETPOREZ_KOJI_JOS_NIJE_PRIZNAN_NEPLACENE_INO_USLUGE_10.balance</field>
                                         <field name="children_ids">
                                             <record id="account_tax_report_line_pretporez_koji_neplaceni" model="account.report.line">
                                                 <field name="name">Pretporez koji još nije priznan (neplaćeni R2)</field>

--- a/addons/l10n_hu/data/account_tax_report_data.xml
+++ b/addons/l10n_hu/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="tax_report_alap" model="account.report.line">
                 <field name="name">ÁFA alap</field>
-                <field name="expression_ids">
-                    <record id="tax_report_alap_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ADOALAP__FIZETENDO_AFA_EXPORT.balance + ADOALAP__FIZETENDO_AFA_EU.balance + ADOALAP__FIZETENDO_AFA_TARGYI_ADOMENTES.balance + ADOALAP__FIZETENDO_AFA_ALANYI_ADOMENTES.balance + ADOALAP__FIZETENDO_AFA_KORON_KIVULI.balance + ADOALAP__FIZETENDO_AFA_5.balance + ADOALAP__FIZETENDO_AFA_18.balance + ADOALAP__FIZETENDO_AFA_27.balance + ADOALAP__VISSZAIGENYELHETO_AFA_EU.balance + ADOALAP__IMPORT_AFA.balance + ADOALAP__FORDITOTT_AFA.balance + ADOALAP__VISSZAIGENYELHETO_AFA_ALANYI_ADOMENTES.balance + ADOALAP__VISSZAIGENYELHETO_AFA_TARGYI_ADOMENTES.balance + ADOALAP__VISSZAIGENYELHETO_AFA_KORON_KIVULI.balance + ADOALAP__VISSZAIGENYELHETO_AFA_5.balance + ADOALAP__VISSZAIGENYELHETO_AFA_18.balance + ADOALAP__VISSZAIGENYELHETO_AFA_27.balance + ADOALAP__VISSZAIGENYELHETO_KOMPENZACIOS_FELAR.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ADOALAP__FIZETENDO_AFA_EXPORT.balance + ADOALAP__FIZETENDO_AFA_EU.balance + ADOALAP__FIZETENDO_AFA_TARGYI_ADOMENTES.balance + ADOALAP__FIZETENDO_AFA_ALANYI_ADOMENTES.balance + ADOALAP__FIZETENDO_AFA_KORON_KIVULI.balance + ADOALAP__FIZETENDO_AFA_5.balance + ADOALAP__FIZETENDO_AFA_18.balance + ADOALAP__FIZETENDO_AFA_27.balance + ADOALAP__VISSZAIGENYELHETO_AFA_EU.balance + ADOALAP__IMPORT_AFA.balance + ADOALAP__FORDITOTT_AFA.balance + ADOALAP__VISSZAIGENYELHETO_AFA_ALANYI_ADOMENTES.balance + ADOALAP__VISSZAIGENYELHETO_AFA_TARGYI_ADOMENTES.balance + ADOALAP__VISSZAIGENYELHETO_AFA_KORON_KIVULI.balance + ADOALAP__VISSZAIGENYELHETO_AFA_5.balance + ADOALAP__VISSZAIGENYELHETO_AFA_18.balance + ADOALAP__VISSZAIGENYELHETO_AFA_27.balance + ADOALAP__VISSZAIGENYELHETO_KOMPENZACIOS_FELAR.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_alap_fiz_export" model="account.report.line">
                         <field name="name">Adóalap - Fizetendő ÁFA Export</field>
@@ -225,13 +219,7 @@
             </record>
             <record id="tax_report_fizetndo" model="account.report.line">
                 <field name="name">ÁFA fizetndő / visszaigényelhető</field>
-                <field name="expression_ids">
-                    <record id="tax_report_fizetndo_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">FIZETENDO_AFA_5.balance + FIZETENDO_AFA_18.balance + FIZETENDO_AFA_27.balance + VISSZAIGENYELHETO_AFA_5.balance + VISSZAIGENYELHETO_AFA_18.balance + VISSZAIGENYELHETO_AFA_27.balance + VISSZAIGENYELHETO_KOMPENZACIOS_FELAR.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">FIZETENDO_AFA_5.balance + FIZETENDO_AFA_18.balance + FIZETENDO_AFA_27.balance + VISSZAIGENYELHETO_AFA_5.balance + VISSZAIGENYELHETO_AFA_18.balance + VISSZAIGENYELHETO_AFA_27.balance + VISSZAIGENYELHETO_KOMPENZACIOS_FELAR.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_fizetndo_5" model="account.report.line">
                         <field name="name">Fizetendő ÁFA 5%</field>

--- a/addons/l10n_il/data/account_tax_report_data.xml
+++ b/addons/l10n_il/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="account_tax_report_line_out_base_title" model="account.report.line">
                 <field name="name">VAT SALES (BASE)</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_out_base_title_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ILTAX_OUT_BASE.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ILTAX_OUT_BASE.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_out_base" model="account.report.line">
                         <field name="name">VAT SALES (BASE)</field>
@@ -39,13 +33,7 @@
             <record id="account_tax_report_line_vat_sales_tax" model="account.report.line">
                 <field name="name">VAT SALES (TAX)</field>
                 <field name="code">ILTAX_OUT_BALANCE</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_vat_sales_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ILTAX_OUT_BALANCE_00.balance+ILTAX_OUT_BALANCE_PA.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ILTAX_OUT_BALANCE_00.balance+ILTAX_OUT_BALANCE_PA.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_out_balance" model="account.report.line">
                         <field name="name">VAT Sales</field>
@@ -73,13 +61,7 @@
             </record>
             <record id="account_tax_report_line_out_base_exempt_title" model="account.report.line">
                 <field name="name">VAT Exempt Sales (BASE)</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_out_base_exempt_title_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ILTAX_OUT_BASE_exempt.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ILTAX_OUT_BASE_exempt.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_out_base_exempt" model="account.report.line">
                         <field name="name">VAT Exempt Sales (BASE)</field>
@@ -97,13 +79,7 @@
             <record id="account_tax_report_line_in_balance" model="account.report.line">
                 <field name="name">VAT INPUTS (TAX)</field>
                 <field name="code">ILTAX_IN_BALANCE</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_in_balance_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ILTAX_IN_BALANCE_17.balance+ILTAX_IN_BALANCE_2_3.balance+ILTAX_IN_BALANCE_1_4.balance+ILTAX_IN_BALANCE_PA.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ILTAX_IN_BALANCE_17.balance+ILTAX_IN_BALANCE_2_3.balance+ILTAX_IN_BALANCE_1_4.balance+ILTAX_IN_BALANCE_PA.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_in_balance_17" model="account.report.line">
                         <field name="name">VAT Inputs 17%</field>
@@ -153,13 +129,7 @@
             </record>
             <record id="account_tax_report_line_vat_in_fa_title" model="account.report.line">
                 <field name="name">VAT INPUTS (fixed assets)</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_vat_in_fa_title_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ILTAX_VAT_IN_FA.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ILTAX_VAT_IN_FA.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_vat_in_fa" model="account.report.line">
                         <field name="name">VAT INPUTS (fixed assets)</field>
@@ -177,13 +147,7 @@
             <record id="account_tax_report_line_vat_due" model="account.report.line">
                 <field name="name">VAT DUE</field>
                 <field name="code">ILTAX_VAT_DUE</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_vat_due_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">(ILTAX_OUT_BALANCE_00.balance + ILTAX_OUT_BALANCE_PA.balance) - (ILTAX_IN_BALANCE_17.balance + ILTAX_IN_BALANCE_2_3.balance + ILTAX_IN_BALANCE_1_4.balance + ILTAX_IN_BALANCE_PA.balance) - ILTAX_VAT_IN_FA.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">(ILTAX_OUT_BALANCE_00.balance + ILTAX_OUT_BALANCE_PA.balance) - (ILTAX_IN_BALANCE_17.balance + ILTAX_IN_BALANCE_2_3.balance + ILTAX_IN_BALANCE_1_4.balance + ILTAX_IN_BALANCE_PA.balance) - ILTAX_VAT_IN_FA.balance</field>
             </record>
         </field>
     </record>

--- a/addons/l10n_it/data/account_tax_report_data.xml
+++ b/addons/l10n_it/data/account_tax_report_data.xml
@@ -494,13 +494,7 @@
                     <record id="tax_report_line_vj19" model="account.report.line">
                         <field name="name">VJ19 - Totale quadro VJ</field>
                         <field name="code">VJ19</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_vj1_balance" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">VJ1.balance + VJ2.balance + VJ3.balance + VJ4.balance + VJ5.balance + VJ6.balance + VJ7.balance + VJ8.balance + VJ9.balance + VJ10.balance + VJ11.balance + VJ12.balance + VJ13.balance + VJ14.balance + VJ15.balance + VJ16.balance + VJ17.balance + VJ18.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">VJ1.balance + VJ2.balance + VJ3.balance + VJ4.balance + VJ5.balance + VJ6.balance + VJ7.balance + VJ8.balance + VJ9.balance + VJ10.balance + VJ11.balance + VJ12.balance + VJ13.balance + VJ14.balance + VJ15.balance + VJ16.balance + VJ17.balance + VJ18.balance</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_jp/data/account_tax_report_data.xml
+++ b/addons/l10n_jp/data/account_tax_report_data.xml
@@ -15,24 +15,12 @@
         <field name="line_ids">
             <record id="tax_report_to_pay" model="account.report.line">
                 <field name="name">支払対象税額</field>
-                <field name="expression_ids">
-                    <record id="tax_report_to_pay_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">JIA_SHOU_SHUI_E_.balance + JIA_FU_SHUI_E_.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">JIA_SHOU_SHUI_E_.balance + JIA_FU_SHUI_E_.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_to_pay_temp_tx" model="account.report.line">
                         <field name="name">仮受税額</field>
                         <field name="code">JIA_SHOU_SHUI_E_</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_to_pay_temp_tx_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">JIA_SHOU_XIAO_FEI_SHUI_8.balance + JIA_SHOU_XIAO_FEI_SHUI_10.balance + MIAN_SHUI_.balance + BU_KE_SHUI__JIA_SHOU_SHUI_E_.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">JIA_SHOU_XIAO_FEI_SHUI_8.balance + JIA_SHOU_XIAO_FEI_SHUI_10.balance + MIAN_SHUI_.balance + BU_KE_SHUI__JIA_SHOU_SHUI_E_.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_to_pay_temp_tx_output_8" model="account.report.line">
                                 <field name="name">仮受消費税(8%)</field>
@@ -83,13 +71,7 @@
                     <record id="tax_report_to_pay_temp_pmt" model="account.report.line">
                         <field name="name">仮払税額</field>
                         <field name="code">JIA_FU_SHUI_E_</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_to_pay_temp_pmt_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">JIA_FU_XIAO_FEI_SHUI_8.balance + JIA_FU_XIAO_FEI_SHUI_10.balance + SHU_RU_.balance + BU_KE_SHUI__JIA_FU_SHUI_E_.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">JIA_FU_XIAO_FEI_SHUI_8.balance + JIA_FU_XIAO_FEI_SHUI_10.balance + SHU_RU_.balance + BU_KE_SHUI__JIA_FU_SHUI_E_.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_to_pay_temp_pmt_susp_cons_8" model="account.report.line">
                                 <field name="name">仮払消費税(8%)</field>
@@ -141,24 +123,12 @@
             </record>
             <record id="tax_report_comp_basis" model="account.report.line">
                 <field name="name">税計算基準額</field>
-                <field name="expression_ids">
-                    <record id="tax_report_comp_basis_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">FAN_MAI_JI_ZHUN_E_.balance + GOU_MAI_JI_ZHUN_E_.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">FAN_MAI_JI_ZHUN_E_.balance + GOU_MAI_JI_ZHUN_E_.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_comp_basis_sales" model="account.report.line">
                         <field name="name">販売基準額</field>
                         <field name="code">FAN_MAI_JI_ZHUN_E_</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_comp_basis_sales_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">KE_SHUI_DUI_XIANG_MAI_SHANG_8.balance + KE_SHUI_DUI_XIANG_MAI_SHANG_10.balance + MIAN_SHUI_MAI_SHANG_.balance + BU_KE_SHUI_MAI_SHANG_.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">KE_SHUI_DUI_XIANG_MAI_SHANG_8.balance + KE_SHUI_DUI_XIANG_MAI_SHANG_10.balance + MIAN_SHUI_MAI_SHANG_.balance + BU_KE_SHUI_MAI_SHANG_.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_comp_basis_sales_taxable_8" model="account.report.line">
                                 <field name="name">課税対象売上(8%)</field>
@@ -209,13 +179,7 @@
                     <record id="tax_report_comp_basis_purchases" model="account.report.line">
                         <field name="name">購買基準額</field>
                         <field name="code">GOU_MAI_JI_ZHUN_E_</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_comp_basis_purchases_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">KE_SHUI_DUI_XIANG_SHI_RU_8.balance + KE_SHUI_DUI_XIANG_SHI_RU_10.balance + SHU_RU_SHI_RU_.balance + BU_KE_SHUI_SHI_RU_.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">KE_SHUI_DUI_XIANG_SHI_RU_8.balance + KE_SHUI_DUI_XIANG_SHI_RU_10.balance + SHU_RU_SHI_RU_.balance + BU_KE_SHUI_SHI_RU_.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_comp_basis_purchases_taxable_8" model="account.report.line">
                                 <field name="name">課税対象仕入(8%)</field>

--- a/addons/l10n_lu/data/account_tax_report_line.xml
+++ b/addons/l10n_lu/data/account_tax_report_line.xml
@@ -19,13 +19,7 @@
                     <record id="account_tax_report_line_2b_intra_community_acqui_of_goods_base" model="account.report.line">
                         <field name="name">051 - Intra-Community acquisitions of goods – base</field>
                         <field name="code">LUTAX_051</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_2b_intra_community_acqui_of_goods_base_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_049.balance + LUTAX_194.balance + LUTAX_711.balance + LUTAX_713.balance + LUTAX_715.balance + LUTAX_719.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_049.balance + LUTAX_194.balance + LUTAX_711.balance + LUTAX_713.balance + LUTAX_715.balance + LUTAX_719.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_2b_base_3" model="account.report.line">
                                 <field name="name">049 - base 3%</field>
@@ -98,13 +92,7 @@
                     <record id="account_tax_report_line_2d_importation_of_goods_base" model="account.report.line">
                         <field name="name">065 - Importation of goods – base</field>
                         <field name="code">LUTAX_065</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_2d_importation_of_goods_base_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_196.balance + LUTAX_721.balance + LUTAX_723.balance + LUTAX_725.balance + LUTAX_731.balance + LUTAX_733.balance + LUTAX_735.balance + LUTAX_059.balance + LUTAX_063.balance + LUTAX_195.balance + LUTAX_729.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_196.balance + LUTAX_721.balance + LUTAX_723.balance + LUTAX_725.balance + LUTAX_731.balance + LUTAX_733.balance + LUTAX_735.balance + LUTAX_059.balance + LUTAX_063.balance + LUTAX_195.balance + LUTAX_729.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_2d_2_base_exempt" model="account.report.line">
                                 <field name="name">196 - for non-business purposes: base exempt</field>
@@ -243,24 +231,12 @@
                     <record id="account_tax_report_line_2e_supply_of_service_for_customer" model="account.report.line">
                         <field name="name">409 - Supply of services for which the customer is liable for the payment of VAT – base</field>
                         <field name="code">LUTAX_409</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_2e_supply_of_service_for_customer_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_436.balance + LUTAX_435.balance + LUTAX_463.balance + LUTAX_765.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_436.balance + LUTAX_435.balance + LUTAX_463.balance + LUTAX_765.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_2e_1_base" model="account.report.line">
                                 <field name="name">436 - base</field>
                                 <field name="code">LUTAX_436</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_2e_1_base_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">LUTAX_431.balance + LUTAX_741.balance + LUTAX_743.balance + LUTAX_745.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">LUTAX_431.balance + LUTAX_741.balance + LUTAX_743.balance + LUTAX_745.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_2e_1_a_base_3" model="account.report.line">
                                         <field name="name">431 - not exempt within the territory: base 3%</field>
@@ -322,13 +298,7 @@
                             <record id="account_tax_report_line_2e_2_base" model="account.report.line">
                                 <field name="name">463 - base</field>
                                 <field name="code">LUTAX_463</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_2e_2_base_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">LUTAX_441.balance + LUTAX_445.balance + LUTAX_751.balance + LUTAX_753.balance + LUTAX_755.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">LUTAX_441.balance + LUTAX_445.balance + LUTAX_751.balance + LUTAX_753.balance + LUTAX_755.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_2e_2_base_3" model="account.report.line">
                                         <field name="name">441 - not established or residing within the Community: base 3%</field>
@@ -390,13 +360,7 @@
                             <record id="account_tax_report_line_2e_3_base" model="account.report.line">
                                 <field name="name">765 - base</field>
                                 <field name="code">LUTAX_765</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_2e_3_base_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">LUTAX_761.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">LUTAX_761.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_2e_3_base_17" model="account.report.line">
                                         <field name="name">761 - suppliers established within the territory: base 17%</field>
@@ -416,13 +380,7 @@
                     <record id="account_tax_report_line_2a_breakdown_taxable_turnover_base" model="account.report.line">
                         <field name="name">037 - Breakdown of taxable turnover – base</field>
                         <field name="code">LUTAX_037</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_2a_breakdown_taxable_turnover_base_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_031.balance + LUTAX_033.balance + LUTAX_701.balance + LUTAX_703.balance + LUTAX_705.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_031.balance + LUTAX_033.balance + LUTAX_701.balance + LUTAX_703.balance + LUTAX_705.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_2a_base_3" model="account.report.line">
                                 <field name="name">031 - base 3%</field>
@@ -484,13 +442,7 @@
                     <record id="account_tax_report_line_2f_supply_goods_base" model="account.report.line">
                         <field name="name">767 - Supply of goods for which the purchaser is liable for the payment of VAT - base</field>
                         <field name="code">LUTAX_767</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_2f_supply_goods_base_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_763.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_763.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_2f_supply_goods_base_8" model="account.report.line">
                                 <field name="name">763 - base 8%</field>
@@ -508,13 +460,7 @@
                     <record id="account_tax_report_line_2f_supply_goods_tax" model="account.report.line">
                         <field name="name">768 - Supply of goods for which the purchaser is liable for the payment of VAT - tax</field>
                         <field name="code">LUTAX_768</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_2f_supply_goods_tax_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_764.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_764.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_2f_supply_goods_tax_8" model="account.report.line">
                                 <field name="name">764 - tax 8%</field>
@@ -543,24 +489,12 @@
                     <record id="account_tax_report_line_2h_total_tax_due" model="account.report.line">
                         <field name="name">076 - Total tax due</field>
                         <field name="code">LUTAX_076</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_2h_total_tax_due_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_103.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_103.balance</field>
                     </record>
                     <record id="account_tax_report_line_2a_breakdown_taxable_turnover_tax" model="account.report.line">
                         <field name="name">046 - Breakdown of taxable turnover – tax</field>
                         <field name="code">LUTAX_046</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_2a_breakdown_taxable_turnover_tax_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_040.balance + LUTAX_702.balance + LUTAX_704.balance + LUTAX_706.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_040.balance + LUTAX_702.balance + LUTAX_704.balance + LUTAX_706.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_2a_tax_3" model="account.report.line">
                                 <field name="name">040 - tax 3%</field>
@@ -611,13 +545,7 @@
                     <record id="account_tax_report_line_2b_intra_community_acquisitions_goods_tax" model="account.report.line">
                         <field name="name">056 - Intra-Community acquisitions of goods – tax</field>
                         <field name="code">LUTAX_056</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_2b_intra_community_acquisitions_goods_tax_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_054.balance + LUTAX_712.balance + LUTAX_714.balance + LUTAX_716.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_054.balance + LUTAX_712.balance + LUTAX_714.balance + LUTAX_716.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_2b_tax_3" model="account.report.line">
                                 <field name="name">054 - tax 3%</field>
@@ -668,13 +596,7 @@
                     <record id="account_tax_report_line_2d_importation_of_goods_tax" model="account.report.line">
                         <field name="name">407 - Importation of goods – tax</field>
                         <field name="code">LUTAX_407</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_2d_importation_of_goods_tax_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_724.balance + LUTAX_726.balance + LUTAX_732.balance + LUTAX_734.balance + LUTAX_736.balance + LUTAX_068.balance + LUTAX_073.balance + LUTAX_722.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_724.balance + LUTAX_726.balance + LUTAX_732.balance + LUTAX_734.balance + LUTAX_736.balance + LUTAX_068.balance + LUTAX_073.balance + LUTAX_722.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_2d_1_tax_14" model="account.report.line">
                                 <field name="name">724 - for business purposes: tax 14%</field>
@@ -769,24 +691,12 @@
                     <record id="account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax" model="account.report.line">
                         <field name="name">410 - Supply of services for which the customer is liable for the payment of VAT – tax</field>
                         <field name="code">LUTAX_410</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_462.balance + LUTAX_464.balance + LUTAX_766.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_462.balance + LUTAX_464.balance + LUTAX_766.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_2e_1_a_tax" model="account.report.line">
                                 <field name="name">462 - tax</field>
                                 <field name="code">LUTAX_462</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_2e_1_a_tax_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">LUTAX_432.balance + LUTAX_742.balance + LUTAX_744.balance + LUTAX_746.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">LUTAX_432.balance + LUTAX_742.balance + LUTAX_744.balance + LUTAX_746.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_2e_1_a_tax_3" model="account.report.line">
                                         <field name="name">432 - not exempt within the territory: tax 3%</field>
@@ -837,13 +747,7 @@
                             <record id="account_tax_report_line_2e_2_tax" model="account.report.line">
                                 <field name="name">464 - tax</field>
                                 <field name="code">LUTAX_464</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_2e_2_tax_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">LUTAX_442.balance + LUTAX_752.balance + LUTAX_754.balance + LUTAX_756.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">LUTAX_442.balance + LUTAX_752.balance + LUTAX_754.balance + LUTAX_756.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_2e_2_tax_3" model="account.report.line">
                                         <field name="name">442 - not established or residing within the Community: tax 3%</field>
@@ -894,13 +798,7 @@
                             <record id="account_tax_report_line_2e_3_tax" model="account.report.line">
                                 <field name="name">766 - tax</field>
                                 <field name="code">LUTAX_766</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_2e_3_tax_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">LUTAX_762.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">LUTAX_762.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_2e_3_tax_17" model="account.report.line">
                                         <field name="name">762 - suppliers established within the territory: tax 17%</field>
@@ -925,24 +823,12 @@
                     <record id="account_tax_report_line_1a_overall_turnover" model="account.report.line">
                         <field name="name">012 - Overall turnover</field>
                         <field name="code">LUTAX_012</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_1a_overall_turnover_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_454.balance + LUTAX_455.balance + LUTAX_456.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_454.balance + LUTAX_455.balance + LUTAX_456.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_1a_total_sale" model="account.report.line">
                                 <field name="name">454 - Total Sales / Receipts</field>
                                 <field name="code">LUTAX_454</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1a_total_sale_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">LUTAX_471.balance + LUTAX_472.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">LUTAX_471.balance + LUTAX_472.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_1a_telecom_service" model="account.report.line">
                                         <field name="name">471 - Telecommunications services, radio and television broadcasting services...</field>
@@ -958,13 +844,7 @@
                                     <record id="account_tax_report_line_1a_other_sales" model="account.report.line">
                                         <field name="name">472 - Other sales / receipts</field>
                                         <field name="code">LUTAX_472</field>
-                                        <field name="expression_ids">
-                                            <record id="account_tax_report_line_1a_other_sales_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">LUTAX_021.balance + LUTAX_037.balance - LUTAX_456.balance - LUTAX_455.balance - LUTAX_471.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">LUTAX_021.balance + LUTAX_037.balance - LUTAX_456.balance - LUTAX_455.balance - LUTAX_471.balance</field>
                                     </record>
                                 </field>
                             </record>
@@ -995,13 +875,7 @@
                     <record id="account_tax_report_line_1b_exemptions_deductible_amounts" model="account.report.line">
                         <field name="name">021 - Exemptions and deductible amounts</field>
                         <field name="code">LUTAX_021</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_1b_exemptions_deductible_amounts_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_014.balance + LUTAX_457.balance + LUTAX_015.balance + LUTAX_016.balance + LUTAX_017.balance + LUTAX_018.balance + LUTAX_423.balance + LUTAX_424.balance + LUTAX_226.balance + LUTAX_019.balance + LUTAX_419.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_014.balance + LUTAX_457.balance + LUTAX_015.balance + LUTAX_016.balance + LUTAX_017.balance + LUTAX_018.balance + LUTAX_423.balance + LUTAX_424.balance + LUTAX_226.balance + LUTAX_019.balance + LUTAX_419.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_1b_2_export" model="account.report.line">
                                 <field name="name">014 - Exports</field>
@@ -1129,13 +1003,7 @@
                     <record id="account_tax_report_line_1c_taxable_turnover" model="account.report.line">
                         <field name="name">022 - Taxable turnover</field>
                         <field name="code">LUTAX_022</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_1c_taxable_turnover_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_037.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_037.balance</field>
                     </record>
                 </field>
             </record>
@@ -1145,35 +1013,17 @@
                     <record id="account_tax_report_line_4c_exceeding_amount" model="account.report.line">
                         <field name="name">105 - Exceeding amount</field>
                         <field name="code">LUTAX_105</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_4c_exceeding_amount_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_103.balance - LUTAX_102.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_103.balance - LUTAX_102.balance</field>
                     </record>
                     <record id="account_tax_report_line_4a_total_tax_due" model="account.report.line">
                         <field name="name">103 - Total tax due</field>
                         <field name="code">LUTAX_103</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_4a_total_tax_due_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_702.balance+LUTAX_704.balance+LUTAX_706.balance+LUTAX_040.balance+LUTAX_712.balance+LUTAX_714.balance+LUTAX_716.balance+LUTAX_054.balance+LUTAX_722.balance+LUTAX_724.balance+LUTAX_726.balance+LUTAX_068.balance+LUTAX_732.balance+LUTAX_734.balance+LUTAX_736.balance+LUTAX_073.balance+LUTAX_742.balance+LUTAX_744.balance+LUTAX_746.balance+LUTAX_432.balance+LUTAX_752.balance+LUTAX_754.balance+LUTAX_756.balance+LUTAX_442.balance+LUTAX_762.balance+LUTAX_764.balance+LUTAX_227.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_702.balance+LUTAX_704.balance+LUTAX_706.balance+LUTAX_040.balance+LUTAX_712.balance+LUTAX_714.balance+LUTAX_716.balance+LUTAX_054.balance+LUTAX_722.balance+LUTAX_724.balance+LUTAX_726.balance+LUTAX_068.balance+LUTAX_732.balance+LUTAX_734.balance+LUTAX_736.balance+LUTAX_073.balance+LUTAX_742.balance+LUTAX_744.balance+LUTAX_746.balance+LUTAX_432.balance+LUTAX_752.balance+LUTAX_754.balance+LUTAX_756.balance+LUTAX_442.balance+LUTAX_762.balance+LUTAX_764.balance+LUTAX_227.balance</field>
                     </record>
                     <record id="account_tax_report_line_4a_total_input_tax_deductible" model="account.report.line">
                         <field name="name">104 - Total input tax deductible</field>
                         <field name="code">LUTAX_104</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_4a_total_input_tax_deductible_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_102.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_102.balance</field>
                     </record>
                 </field>
             </record>
@@ -1183,13 +1033,7 @@
                     <record id="account_tax_report_line_3a_total_input_tax" model="account.report.line">
                         <field name="name">093 - Total input tax</field>
                         <field name="code">LUTAX_093</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_3a_total_input_tax_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_090.balance + LUTAX_092.balance + LUTAX_228.balance + LUTAX_458.balance + LUTAX_459.balance + LUTAX_460.balance + LUTAX_461.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_090.balance + LUTAX_092.balance + LUTAX_228.balance + LUTAX_458.balance + LUTAX_459.balance + LUTAX_460.balance + LUTAX_461.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_3a_4_due_respect_application_goods" model="account.report.line">
                                 <field name="name">090 - Due in respect of the application of goods for business purposes</field>
@@ -1273,13 +1117,7 @@
                     <record id="account_tax_report_line_3b_total_input_tax_nd" model="account.report.line">
                         <field name="name">097 - Total input tax non-deductible</field>
                         <field name="code">LUTAX_097</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_3b_total_input_tax_nd_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_094.balance + LUTAX_095.balance + LUTAX_096.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_094.balance + LUTAX_095.balance + LUTAX_096.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_3b1_rel_trans" model="account.report.line">
                                 <field name="name">094 - relating to transactions which are exempt pursuant to articles 44 and 56quater</field>
@@ -1319,13 +1157,7 @@
                     <record id="account_tax_report_line_3c_total_input_tax_deductible" model="account.report.line">
                         <field name="name">102 - Total input tax deductible</field>
                         <field name="code">LUTAX_102</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_3c_total_input_tax_deductible_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">LUTAX_458.balance+LUTAX_459.balance+LUTAX_460.balance+LUTAX_090.balance+LUTAX_461.balance+LUTAX_092.balance+LUTAX_228.balance+LUTAX_094.balance+LUTAX_095.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">LUTAX_458.balance+LUTAX_459.balance+LUTAX_460.balance+LUTAX_090.balance+LUTAX_461.balance+LUTAX_092.balance+LUTAX_228.balance+LUTAX_094.balance+LUTAX_095.balance</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_ma/data/account_tax_report_data.xml
+++ b/addons/l10n_ma/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="tax_report_ventilation_chiffre_affaires_imposable" model="account.report.line">
                 <field name="name">Ventilation du chiffre d’affaires imposable</field>
-                <field name="expression_ids">
-                    <record id="tax_report_ventilation_chiffre_affaires_imposable_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">MATAXB_1.balance + MATAXB_2.balance + MATAXB_3.balance + MATAXB_4.balance + MATAXB_5.balance + MATAXB_6.balance + MATAXB_7.balance + MATAXB_8.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">MATAXB_1.balance + MATAXB_2.balance + MATAXB_3.balance + MATAXB_4.balance + MATAXB_5.balance + MATAXB_6.balance + MATAXB_7.balance + MATAXB_8.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_taux_normal_20" model="account.report.line">
                         <field name="name">TAUX NORMAL DE 20% (Base HT)</field>
@@ -115,24 +109,12 @@
             </record>
             <record id="tax_report_ventilation_des_deductions" model="account.report.line">
                 <field name="name">Ventilation des déductions</field>
-                <field name="expression_ids">
-                    <record id="tax_report_ventilation_des_deductions_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">1ACHATS_NON_IMMOBILISES_BASE_HT.balance + 1ACHATS_NON_IMMOBILISES_TVA_DEDUCTIBLE.balance + IMMOBILISATIONS_BASE_HT.balance + IMMOBILISATIONS_TVA_DEDUCTIBLE.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">1ACHATS_NON_IMMOBILISES_BASE_HT.balance + 1ACHATS_NON_IMMOBILISES_TVA_DEDUCTIBLE.balance + IMMOBILISATIONS_BASE_HT.balance + IMMOBILISATIONS_TVA_DEDUCTIBLE.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_achats_non_immobilises_ht" model="account.report.line">
                         <field name="name">1-ACHATS NON IMMOBILISES (Base HT)</field>
                         <field name="code">1ACHATS_NON_IMMOBILISES_BASE_HT</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_achats_non_immobilises_ht_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">TRAVAUX_A_FACONS_HT.balance + SOUSTRAITANCE_TRAVAUX_IMMOBILIERS_HT.balance + BIENS_MATERIELS_BASE_HT.balance + PRESTATIONS_DE_SERVICES_BASE_HT.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">TRAVAUX_A_FACONS_HT.balance + SOUSTRAITANCE_TRAVAUX_IMMOBILIERS_HT.balance + BIENS_MATERIELS_BASE_HT.balance + PRESTATIONS_DE_SERVICES_BASE_HT.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_travaux_facons_ht" model="account.report.line">
                                 <field name="name">Travaux à façons (HT)</field>
@@ -161,13 +143,7 @@
                             <record id="tax_report_biens_materiels_ht" model="account.report.line">
                                 <field name="name">Biens matériels (Base HT)</field>
                                 <field name="code">BIENS_MATERIELS_BASE_HT</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_biens_materiels_ht_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">ACHATS_A_LIMPORTATION_20_HT.balance + ACHATS_A_LINTERIEUR_20_HT.balance + ACHATS_A_LIMPORTATION_14_HT.balance + ACHATS_A_LINTERIEUR_14_HT.balance + ACHATS_A_LIMPORTATION_10_HT.balance + ACHATS_A_LINTERIEUR_10_HT.balance + ACHAT_A_LIMPORTATION_7_HT.balance + ACHAT_A_LINTERIEUR_7_HT.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">ACHATS_A_LIMPORTATION_20_HT.balance + ACHATS_A_LINTERIEUR_20_HT.balance + ACHATS_A_LIMPORTATION_14_HT.balance + ACHATS_A_LINTERIEUR_14_HT.balance + ACHATS_A_LIMPORTATION_10_HT.balance + ACHATS_A_LINTERIEUR_10_HT.balance + ACHAT_A_LIMPORTATION_7_HT.balance + ACHAT_A_LINTERIEUR_7_HT.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_achats_importation_ht_20" model="account.report.line">
                                         <field name="name">Achats à l'importation (20%) (HT)</field>
@@ -276,13 +252,7 @@
                     <record id="tax_report_achats_immobilises_deductible_tva" model="account.report.line">
                         <field name="name">1-ACHATS NON IMMOBILISES (TVA déductible)</field>
                         <field name="code">1ACHATS_NON_IMMOBILISES_TVA_DEDUCTIBLE</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_achats_immobilises_deductible_tva_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">TRAVAUX_A_FACONS_TVA_DEDUCTIBLE.balance + SOUSTRAITANCE_TRAVAUX_IMMOBILIERS_TVA_DEDUCTIBLE.balance + BIENS_MATERIELS_TVA_DEDUCTIBLE.balance + PRESTATIONS_DE_SERVICES_TVA_DEDUCTIBLE.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">TRAVAUX_A_FACONS_TVA_DEDUCTIBLE.balance + SOUSTRAITANCE_TRAVAUX_IMMOBILIERS_TVA_DEDUCTIBLE.balance + BIENS_MATERIELS_TVA_DEDUCTIBLE.balance + PRESTATIONS_DE_SERVICES_TVA_DEDUCTIBLE.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_travaux_facons_tva" model="account.report.line">
                                 <field name="name">Travaux à façons (TVA déductible)</field>
@@ -311,13 +281,7 @@
                             <record id="tax_report_biens_materiels_tva" model="account.report.line">
                                 <field name="name">Biens matériels (TVA déductible)</field>
                                 <field name="code">BIENS_MATERIELS_TVA_DEDUCTIBLE</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_biens_materiels_tva_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">ACHATS_A_LIMPORTATION_20_TVA.balance + ACHATS_A_LINTERIEUR_20_TVA.balance + ACHATS_A_LIMPORTATION_14_TVA.balance + ACHATS_A_LINTERIEUR_14_TVA.balance + ACHATS_A_LIMPORTATION_10_TVA.balance + ACHATS_A_LINTERIEUR_10_TVA.balance + ACHAT_A_LIMPORTATION_7_TVA.balance + ACHAT_A_LINTERIEUR_7_TVA.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">ACHATS_A_LIMPORTATION_20_TVA.balance + ACHATS_A_LINTERIEUR_20_TVA.balance + ACHATS_A_LIMPORTATION_14_TVA.balance + ACHATS_A_LINTERIEUR_14_TVA.balance + ACHATS_A_LIMPORTATION_10_TVA.balance + ACHATS_A_LINTERIEUR_10_TVA.balance + ACHAT_A_LIMPORTATION_7_TVA.balance + ACHAT_A_LINTERIEUR_7_TVA.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_achats_importation_tva_20" model="account.report.line">
                                         <field name="name">Achats à l'importation (20%) (TVA)</field>

--- a/addons/l10n_nl/data/account_tax_report_data.xml
+++ b/addons/l10n_nl/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="tax_report_rub_1" model="account.report.line">
                 <field name="name">Rubriek 1: Prestaties binnenland</field>
-                <field name="expression_ids">
-                    <record id="tax_report_rub_1_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">1A_OMZET.balance + 1B_OMZET.balance + 1C_OMZET.balance + 1D_OMZET.balance + 1E_OMZET.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">1A_OMZET.balance + 1B_OMZET.balance + 1C_OMZET.balance + 1D_OMZET.balance + 1E_OMZET.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_1a" model="account.report.line">
                         <field name="name">1a. Leveringen/diensten belast met hoog tarief (omzet)</field>
@@ -82,13 +76,7 @@
             </record>
             <record id="tax_report_rub_2" model="account.report.line">
                 <field name="name">Rubriek 2: Verleggingsregelingen binnenland (omzet)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_rub_2_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">2A_OMZET.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">2A_OMZET.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_2a" model="account.report.line">
                         <field name="name">2a. Leveringen/diensten waarbij de heffing van omzetbelasting naar u is verlegd (omzet)</field>
@@ -105,13 +93,7 @@
             </record>
             <record id="tax_report_rub_3" model="account.report.line">
                 <field name="name">Rubriek 3: Prestaties naar of in het buitenland (omzet)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_rub_3_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">3A_OMZET.balance + 3B_OMZET.balance + 3C_OMZET.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">3A_OMZET.balance + 3B_OMZET.balance + 3C_OMZET.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_3a" model="account.report.line">
                         <field name="name">3a. Leveringen naar landen buiten de EU (uitvoer) (omzet)</field>
@@ -150,13 +132,7 @@
             </record>
             <record id="tax_report_rub_4" model="account.report.line">
                 <field name="name">Rubriek 4: Prestaties vanuit het buitenland aan u verricht (omzet)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_rub_4_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">4A_OMZET.balance + 4B_OMZET.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">4A_OMZET.balance + 4B_OMZET.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_4a" model="account.report.line">
                         <field name="name">4a. Leveringen/diensten uit landen buiten de EU (invoer) (omzet)</field>
@@ -185,13 +161,7 @@
             <record id="tax_report_rub_btw_1" model="account.report.line">
                 <field name="name">Rubriek 1: Prestaties binnenland (BTW)</field>
                 <field name="code">NLTAX_B1</field>
-                <field name="expression_ids">
-                    <record id="tax_report_rub_btw_1_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">1A_BTW.balance + 1B_BTW.balance + 1C_BTW.balance + 1D_BTW.balance + 1E_BTW.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">1A_BTW.balance + 1B_BTW.balance + 1C_BTW.balance + 1D_BTW.balance + 1E_BTW.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_btw_1a" model="account.report.line">
                         <field name="name">1a. Leveringen/diensten belast met 21% (BTW)</field>
@@ -252,13 +222,7 @@
             </record>
             <record id="tax_report_rub_btw_2" model="account.report.line">
                 <field name="name">Rubriek 2: Verleggingsregelingen binnenland (BTW)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_rub_btw_2_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NLTAX_B2.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NLTAX_B2.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_btw_2a" model="account.report.line">
                         <field name="name">2a. Leveringen/diensten waarbij de heffing van Heffing van omzetbelasting naar u is verlegd (BTW)</field>
@@ -275,13 +239,7 @@
             </record>
             <record id="tax_report_rub_btw_4" model="account.report.line">
                 <field name="name">Rubriek 4: Prestaties vanuit het buitenland aan u verricht (BTW)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_rub_btw_4_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NLTAX_B4a.balance + NLTAX_B4b.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NLTAX_B4a.balance + NLTAX_B4b.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_btw_4a" model="account.report.line">
                         <field name="name">4a. Leveringen/diensten uit landen buiten de EU (BTW)</field>
@@ -309,23 +267,11 @@
             </record>
             <record id="tax_report_rub_btw_5" model="account.report.line">
                 <field name="name">Rubriek 5: Voorbelasting, kleineondernemersregeling en totaal (BTW)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_rub_btw_5_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NLTAX_B5b.balance + NLTAX_B5d.balance + NLTAX_B5e.balance + NLTAX_B5f.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NLTAX_B5b.balance + NLTAX_B5d.balance + NLTAX_B5e.balance + NLTAX_B5f.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_btw_5a" model="account.report.line">
                         <field name="name">5a. Verschuldigde omzetbelasting (rubrieken 1a t/m 4b) (BTW)</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_rub_btw_5a_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">NLTAX_B1.balance + NLTAX_B2.balance + NLTAX_B4a.balance + NLTAX_B4b.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">NLTAX_B1.balance + NLTAX_B2.balance + NLTAX_B4a.balance + NLTAX_B4b.balance</field>
                     </record>
                     <record id="tax_report_rub_btw_5b" model="account.report.line">
                         <field name="name">5b. Voorbelasting (BTW)</field>
@@ -341,13 +287,7 @@
                     <record id="tax_report_rub_btw_5c" model="account.report.line">
                         <field name="name">5c. Subtotaal (rubriek 5a min 5b) (BTW)</field>
                         <field name="code"/>
-                        <field name="expression_ids">
-                            <record id="tax_report_rub_btw_5c_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">NLTAX_B1.balance + NLTAX_B2.balance + NLTAX_B4a.balance + NLTAX_B4b.balance - NLTAX_B5b.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">NLTAX_B1.balance + NLTAX_B2.balance + NLTAX_B4a.balance + NLTAX_B4b.balance - NLTAX_B5b.balance</field>
                     </record>
                     <record id="tax_report_rub_btw_5d" model="account.report.line">
                         <field name="name">5d. Vermindering volgens de kleineondernemersregeling (BTW)</field>
@@ -385,13 +325,7 @@
                     <record id="tax_report_rub_btw_5g" model="account.report.line">
                         <field name="name">5g. Totaal te betalen/terug te vragen (BTW)</field>
                         <field name="code">NLTAX_B5g</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_rub_btw_5g_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">NLTAX_B1.balance + NLTAX_B2.balance + NLTAX_B4a.balance + NLTAX_B4b.balance - NLTAX_B5b.balance - NLTAX_B5d.balance - NLTAX_B5e.balance - NLTAX_B5f.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">NLTAX_B1.balance + NLTAX_B2.balance + NLTAX_B4a.balance + NLTAX_B4b.balance - NLTAX_B5b.balance - NLTAX_B5d.balance - NLTAX_B5e.balance - NLTAX_B5f.balance</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_no/data/account_tax_report_data.xml
+++ b/addons/l10n_no/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="account_tax_report_line_samlet_omsetning" model="account.report.line">
                 <field name="name">A. Samlet omsetning, uttak og innførsel</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_samlet_omsetning_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NOTAX_01.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NOTAX_01.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_post_1" model="account.report.line">
                         <field name="name">Post 1 Samlet omsetning og uttak utenfor merverdiavgiftsloven</field>
@@ -37,25 +31,13 @@
                     <record id="account_tax_report_line_post_2" model="account.report.line">
                         <field name="name">Post 2 Samlet omsetning og uttak innenfor merverdiavgiftloven og innførsel</field>
                         <field name="code">NOTAX_02</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_post_2_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">NOTAX_03.balance+NOTAX_04.balance+NOTAX_05.balance+NOTAX_06.balance+NOTAX_07.balance+NOTAX_08.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">NOTAX_03.balance+NOTAX_04.balance+NOTAX_05.balance+NOTAX_06.balance+NOTAX_07.balance+NOTAX_08.balance</field>
                     </record>
                 </field>
             </record>
             <record id="account_tax_report_line_innenlands_omsetning" model="account.report.line">
                 <field name="name">B. Innenlands omsetning og uttak</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_innenlands_omsetning_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NOTAX_03.balance + NOTAX_03_1.balance + NOTAX_04.balance + NOTAX_04_1.balance + NOTAX_05.balance + NOTAX_05_1.balance + NOTAX_06.balance + NOTAX_07.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NOTAX_03.balance + NOTAX_03_1.balance + NOTAX_04.balance + NOTAX_04_1.balance + NOTAX_05.balance + NOTAX_05_1.balance + NOTAX_06.balance + NOTAX_07.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_post_3" model="account.report.line">
                         <field name="name">Post 3 Innenlands omsetning og uttak, og beregnet avgift 25 %</field>
@@ -149,13 +131,7 @@
             </record>
             <record id="account_tax_report_line_utforsel" model="account.report.line">
                 <field name="name">C. Utførsel</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_utforsel_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NOTAX_08.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NOTAX_08.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_post_8" model="account.report.line">
                         <field name="name">Post 8 Utførsel av varer og tjenester fritatt for merverdiavgift</field>
@@ -172,13 +148,7 @@
             </record>
             <record id="account_tax_report_line_innforsel_av_varer" model="account.report.line">
                 <field name="name">D. Innførsel av varer</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_innforsel_av_varer_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NOTAX_09.balance + NOTAX_09_1.balance + NOTAX_10.balance + NOTAX_10_1.balance + NOTAX_11.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NOTAX_09.balance + NOTAX_09_1.balance + NOTAX_10.balance + NOTAX_10_1.balance + NOTAX_11.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_post_9" model="account.report.line">
                         <field name="name">Post 9 Innførsel av varer, og beregnet avgift 25 %</field>
@@ -239,13 +209,7 @@
             </record>
             <record id="account_tax_report_line_kjop_med_omvendt_avgiftsplikt" model="account.report.line">
                 <field name="name">E. Kjøp med omvendt avgiftsplikt</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_kjop_med_omvendt_avgiftsplikt_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NOTAX_12.balance + NOTAX_12_1.balance + NOTAX_13.balance + NOTAX_13_1.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NOTAX_12.balance + NOTAX_12_1.balance + NOTAX_13.balance + NOTAX_13_1.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_post_12" model="account.report.line">
                         <field name="name">Post 12 Tjenester kjøpt fra utlandet, og beregnet avgift 25 %</field>
@@ -295,13 +259,7 @@
             </record>
             <record id="account_tax_report_line_fradragsberettigen_innenlands" model="account.report.line">
                 <field name="name">F. Fradragsberettiget innenlands inngående avgift</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_fradragsberettigen_innenlands_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NOTAX_14.balance + NOTAX_15.balance + NOTAX_16.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NOTAX_14.balance + NOTAX_15.balance + NOTAX_16.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_post_14" model="account.report.line">
                         <field name="name">Post 14 Fradragsberettiget innenlands inngående avgift 25 %</field>
@@ -340,13 +298,7 @@
             </record>
             <record id="account_tax_report_line_fradragsberettiget_innforselsmerverdiavgift" model="account.report.line">
                 <field name="name">G. Fradragsberettiget innførselsmerverdiavgift</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_fradragsberettiget_innforselsmerverdiavgift_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NOTAX_17.balance + NOTAX_18.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NOTAX_17.balance + NOTAX_18.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_post_17" model="account.report.line">
                         <field name="name">Post 17 Fradragsberettiget innførselsmerverdiavgift 25 %</field>
@@ -386,13 +338,7 @@
                     <record id="account_tax_report_line_post_19" model="account.report.line">
                         <field name="name">Post 19 Avgift å betale</field>
                         <field name="code">NOTAX_19</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_post_19_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">NOTAX_03_1.balance+NOTAX_04_1.balance+NOTAX_05_1.balance+NOTAX_09_1.balance+NOTAX_10_1.balance+NOTAX_12_1.balance+NOTAX_13_1.balance-NOTAX_14.balance-NOTAX_15.balance-NOTAX_16.balance-NOTAX_17.balance-NOTAX_18.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">NOTAX_03_1.balance+NOTAX_04_1.balance+NOTAX_05_1.balance+NOTAX_09_1.balance+NOTAX_10_1.balance+NOTAX_12_1.balance+NOTAX_13_1.balance-NOTAX_14.balance-NOTAX_15.balance-NOTAX_16.balance-NOTAX_17.balance-NOTAX_18.balance</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_nz/data/account_tax_report_data.xml
+++ b/addons/l10n_nz/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="tax_report_sale_and_income" model="account.report.line">
                 <field name="name">Sales and Income</field>
-                <field name="expression_ids">
-                    <record id="tax_report_sale_and_income_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NZBOX5.balance + NZBOX6.balance + NZBOX9.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NZBOX5.balance + NZBOX6.balance + NZBOX9.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_box5" model="account.report.line">
                         <field name="name">[BOX 5] Total sales and income for the period(including GST and zero-rated Supplies)</field>
@@ -48,24 +42,12 @@
                     <record id="tax_report_box7" model="account.report.line">
                         <field name="name">[BOX 7] The amount in Box 6 is subracted from Box 5</field>
                         <field name="code">NZBOX7</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_box7_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">NZBOX5.balance - NZBOX6.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">NZBOX5.balance - NZBOX6.balance</field>
                     </record>
                     <record id="tax_report_box8" model="account.report.line">
                         <field name="name">[BOX 8] Multiply the amount in Box 7 by 3 and then divide by 23</field>
                         <field name="code">NZBOX8</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_box8_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">(NZBOX7.balance * 3).balance/23.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">(NZBOX7.balance * 3).balance/23.balance</field>
                     </record>
                     <record id="tax_report_box9" model="account.report.line">
                         <field name="name">[BOX 9] Enter any adjustments from your calculation sheet</field>
@@ -81,25 +63,13 @@
                     <record id="tax_report_box10" model="account.report.line">
                         <field name="name">[BOX 10] Total GST collected on sales and income</field>
                         <field name="code">NZBOX10</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_box10_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">NZBOX8.balance + NZBOX9.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">NZBOX8.balance + NZBOX9.balance</field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_purchases_and_expenses" model="account.report.line">
                 <field name="name">Purchases and Expenses</field>
-                <field name="expression_ids">
-                    <record id="tax_report_purchases_and_expenses_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NZBOX11.balance + NZBOX13.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NZBOX11.balance + NZBOX13.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_box11" model="account.report.line">
                         <field name="name">[BOX 11] Total purchases and expenses(including GST) for which tax invoicing requirements have been met</field>
@@ -115,13 +85,7 @@
                     <record id="tax_report_box12" model="account.report.line">
                         <field name="name">[BOX 12] Multiply BOX11 by 3 and then divide by 23</field>
                         <field name="code">NZBOX12</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_box12_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">(NZBOX11.balance * 3).balance/23.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">(NZBOX11.balance * 3).balance/23.balance</field>
                     </record>
                     <record id="tax_report_box13" model="account.report.line">
                         <field name="name">[BOX 13] Credit adjustments from your calculation sheet</field>
@@ -138,25 +102,13 @@
                     <record id="tax_report_box14" model="account.report.line">
                         <field name="name">[BOX 14] Total GST credit for purchases and expenses</field>
                         <field name="code">NZBOX14</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_box14_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">NZBOX12.balance + NZBOX13.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">NZBOX12.balance + NZBOX13.balance</field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_box15" model="account.report.line">
                 <field name="name">[BOX 15] Difference between BOX10 and BOX14</field>
-                <field name="expression_ids">
-                    <record id="tax_report_box15_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">NZBOX10.balance - NZBOX14.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">NZBOX10.balance - NZBOX14.balance</field>
             </record>
         </field>
     </record>

--- a/addons/l10n_pl/data/account_tax_report_data.xml
+++ b/addons/l10n_pl/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="account_tax_report_line_razem_c" model="account.report.line">
                 <field name="name">Podstawa - Razem C</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_razem_c_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">PLTAXC_01_10.balance + PLTAXC_02_11.balance + PLTAXC_03_13.balance + PLTAXC_04_15.balance + PLTAXC_05_17.balance + PLTAXC_06_19.balance + PLTAXC_07_21.balance + PLTAXC_08_22.balance + PLTAXC_09_23.balance + PLTAXC_10_25.balance + PLTAXC_11_27.balance + PLTAXC_12_31.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">PLTAXC_01_10.balance + PLTAXC_02_11.balance + PLTAXC_03_13.balance + PLTAXC_04_15.balance + PLTAXC_05_17.balance + PLTAXC_06_19.balance + PLTAXC_07_21.balance + PLTAXC_08_22.balance + PLTAXC_09_23.balance + PLTAXC_10_25.balance + PLTAXC_11_27.balance + PLTAXC_12_31.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_kraj_zwolnione" model="account.report.line">
                         <field name="name">Podstawa - Dostawa towarów/usług, kraj, zwolnione</field>
@@ -198,13 +192,7 @@
             </record>
             <record id="account_tax_report_line_razem_d" model="account.report.line">
                 <field name="name">Podstawa - Razem D</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_razem_d_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">PODSTAWA__NABYCIE_TOWAROW_I_USLUG_STRWALE.balance + PLTAXD_02_41a.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">PODSTAWA__NABYCIE_TOWAROW_I_USLUG_STRWALE.balance + PLTAXD_02_41a.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_uslug_s_trwale" model="account.report.line">
                         <field name="name">Podstawa - Nabycie towarów i usług ś.trwałe</field>
@@ -233,33 +221,15 @@
             </record>
             <record id="account_tax_report_line_do_przeniesienia" model="account.report.line">
                 <field name="name">Podatek - Do przeniesienia</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_do_przeniesienia_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">PLTAXC.balance - PLTAXD.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">PLTAXC.balance - PLTAXD.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_nad_naleznym" model="account.report.line">
                         <field name="name">Podatek - Nadwyżka naliczonego nad należnym</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_nad_naleznym_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">PLTAXC.balance - PLTAXD.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">PLTAXC.balance - PLTAXD.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_do_US" model="account.report.line">
                                 <field name="name">Podatek - Do wpłaty do US</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_do_US_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">PLTAXC.balance - PLTAXD.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">PLTAXC.balance - PLTAXD.balance</field>
                                 <field name="children_ids">
                                     <record id="account_tax_report_line_kasy_rejestrujace" model="account.report.line">
                                         <field name="name">Podatek - Wydatek na kasy rejestrujące</field>
@@ -286,13 +256,7 @@
                                     <record id="account_tax_report_line_podatek_razem_c" model="account.report.line">
                                         <field name="name">Podatek - Razem C</field>
                                         <field name="code">PLTAXC</field>
-                                        <field name="expression_ids">
-                                            <record id="account_tax_report_line_podatek_razem_c_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">PLTAXC_04_16.balance + PLTAXC_05_18.balance + PLTAXC_06_20.balance + PLTAXC_09_24.balance + PLTAXC_10_26.balance + PLTAXC_11_28.balance + PLTAXC_12_32.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">PLTAXC_04_16.balance + PLTAXC_05_18.balance + PLTAXC_06_20.balance + PLTAXC_09_24.balance + PLTAXC_10_26.balance + PLTAXC_11_28.balance + PLTAXC_12_32.balance</field>
                                         <field name="children_ids">
                                             <record id="account_tax_report_line_podatek_kraj_3_lub_5" model="account.report.line">
                                                 <field name="name">Podatek - Dostawa towarów/usług, kraj, 3% lub 5%</field>
@@ -411,13 +375,7 @@
                                     <record id="account_tax_report_line_podatek_razem_d" model="account.report.line">
                                         <field name="name">Podatek - Razem D</field>
                                         <field name="code">PLTAXD</field>
-                                        <field name="expression_ids">
-                                            <record id="account_tax_report_line_podatek_razem_d_formula" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">aggregation</field>
-                                                <field name="formula">PODATEK__NADWYZKA_Z_POPRZEDNIEJ_DEKLARACJI.balance + PODATEK__NALICZONY_ZE_SPISU_Z_NATURY_ART113.balance + PODATEK__NABYCIE_TOWAROW_I_USLUG_STRWALE.balance + PLTAXD_02_42.balance + PODATEK__KOREKTA_NALICZONEGO_OD_NABYCIA_STRWALYCH.balance + PODATEK__KOREKTA_NALICZONEGO_OD_POZOSTALYCH_NABYC.balance</field>
-                                            </record>
-                                        </field>
+                                        <field name="aggregation_formula">PODATEK__NADWYZKA_Z_POPRZEDNIEJ_DEKLARACJI.balance + PODATEK__NALICZONY_ZE_SPISU_Z_NATURY_ART113.balance + PODATEK__NABYCIE_TOWAROW_I_USLUG_STRWALE.balance + PLTAXD_02_42.balance + PODATEK__KOREKTA_NALICZONEGO_OD_NABYCIA_STRWALYCH.balance + PODATEK__KOREKTA_NALICZONEGO_OD_POZOSTALYCH_NABYC.balance</field>
                                         <field name="children_ids">
                                             <record id="account_tax_report_line_podatek_deklaracji" model="account.report.line">
                                                 <field name="name">Podatek - Nadwyżka z poprzedniej deklaracji</field>
@@ -509,13 +467,7 @@
                     </record>
                     <record id="account_tax_report_line_podatek_do_zwrotu" model="account.report.line">
                         <field name="name">Podatek - Do zwrotu</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_podatek_do_zwrotu_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">PODATEK__DO_ZWROTU_25_DNI.balance + PODATEK__DO_ZWROTU_60_DNI.balance + PODATEK__DO_ZWROTU_180_DNI.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">PODATEK__DO_ZWROTU_25_DNI.balance + PODATEK__DO_ZWROTU_60_DNI.balance + PODATEK__DO_ZWROTU_180_DNI.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_do_zwrotu_25_dni" model="account.report.line">
                                 <field name="name">Podatek - Do zwrotu 25 dni</field>

--- a/addons/l10n_pt/data/account_tax_report.xml
+++ b/addons/l10n_pt/data/account_tax_report.xml
@@ -21,13 +21,7 @@
                         <field name="children_ids">
                             <record id="tax_report_pt_base_vendas_faturas" model="account.report.line">
                                 <field name="name">Faturas/Notas de débito</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_pt_base_vendas_faturas_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">TAX_REPORT_PT_BASE_VENDAS_FATURAS_NORMAL.balance + TAX_REPORT_PT_BASE_VENDAS_FATURAS_INTERMEDIA.balance + TAX_REPORT_PT_BASE_VENDAS_FATURAS_REDUZIDA.balance + TAX_REPORT_PT_BASE_VENDAS_FATURAS_ISENTO.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">TAX_REPORT_PT_BASE_VENDAS_FATURAS_NORMAL.balance + TAX_REPORT_PT_BASE_VENDAS_FATURAS_INTERMEDIA.balance + TAX_REPORT_PT_BASE_VENDAS_FATURAS_REDUZIDA.balance + TAX_REPORT_PT_BASE_VENDAS_FATURAS_ISENTO.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_pt_base_vendas_faturas_normal" model="account.report.line">
                                         <field name="name">Normal</field>
@@ -77,13 +71,7 @@
                             </record>
                             <record id="tax_report_pt_base_vendas_notas_credito" model="account.report.line">
                                 <field name="name">Notas de crédito</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_pt_base_vendas_notas_credito_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">TAX_REPORT_PT_BASE_VENDAS_NOTAS_CREDITO_NORMAL.balance + TAX_REPORT_PT_BASE_VENDAS_NOTAS_CREDITO_INTERMEDIA.balance + TAX_REPORT_PT_BASE_VENDAS_NOTAS_CREDITO_REDUZIDA.balance + TAX_REPORT_PT_BASE_VENDAS_NOTAS_CREDITO_ISENTO.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">TAX_REPORT_PT_BASE_VENDAS_NOTAS_CREDITO_NORMAL.balance + TAX_REPORT_PT_BASE_VENDAS_NOTAS_CREDITO_INTERMEDIA.balance + TAX_REPORT_PT_BASE_VENDAS_NOTAS_CREDITO_REDUZIDA.balance + TAX_REPORT_PT_BASE_VENDAS_NOTAS_CREDITO_ISENTO.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_pt_base_vendas_notas_credito_normal" model="account.report.line">
                                         <field name="name">Normal</field>
@@ -138,13 +126,7 @@
                         <field name="children_ids">
                             <record id="tax_report_pt_base_despesas_faturas" model="account.report.line">
                                 <field name="name">Faturas</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_pt_base_despesas_faturas_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">TAX_REPORT_PT_BASE_DESPESAS_FATURAS_NORMAL.balance + TAX_REPORT_PT_BASE_DESPESAS_FATURAS_INTERMEDIA.balance + TAX_REPORT_PT_BASE_DESPESAS_FATURAS_REDUZIDA.balance + TAX_REPORT_PT_BASE_DESPESAS_FATURAS_ISENTO.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">TAX_REPORT_PT_BASE_DESPESAS_FATURAS_NORMAL.balance + TAX_REPORT_PT_BASE_DESPESAS_FATURAS_INTERMEDIA.balance + TAX_REPORT_PT_BASE_DESPESAS_FATURAS_REDUZIDA.balance + TAX_REPORT_PT_BASE_DESPESAS_FATURAS_ISENTO.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_pt_base_despesas_faturas_normal" model="account.report.line">
                                         <field name="name">Normal</field>
@@ -194,13 +176,7 @@
                             </record>
                             <record id="tax_report_pt_base_despesas_notas_credito" model="account.report.line">
                                 <field name="name">Notas de crédito</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_pt_base_despesas_notas_credito_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">TAX_REPORT_PT_BASE_DESPESAS_NOTAS_CREDITO_NORMAL.balance + TAX_REPORT_PT_BASE_DESPESAS_NOTAS_CREDITO_INTERMEDIA.balance + TAX_REPORT_PT_BASE_DESPESAS_NOTAS_CREDITO_REDUZIDA.balance + TAX_REPORT_PT_BASE_DESPESAS_NOTAS_CREDITO_ISENTO.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">TAX_REPORT_PT_BASE_DESPESAS_NOTAS_CREDITO_NORMAL.balance + TAX_REPORT_PT_BASE_DESPESAS_NOTAS_CREDITO_INTERMEDIA.balance + TAX_REPORT_PT_BASE_DESPESAS_NOTAS_CREDITO_REDUZIDA.balance + TAX_REPORT_PT_BASE_DESPESAS_NOTAS_CREDITO_ISENTO.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_pt_base_despesas_notas_credito_normal" model="account.report.line">
                                         <field name="name">Normal</field>
@@ -261,13 +237,7 @@
                             <record id="tax_report_pt_tax_vendas_faturas" model="account.report.line">
                                 <field name="name">Faturas/Notas de débito (Total IVA liquidado)</field>
                                 <field name="code">tax_report_pt_tax_vendas_faturas</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_pt_tax_vendas_faturas_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">TAX_REPORT_PT_TAX_VENDAS_FATURAS_NORMAL.balance + TAX_REPORT_PT_TAX_VENDAS_FATURAS_INTERMEDIA.balance + TAX_REPORT_PT_TAX_VENDAS_FATURAS_REDUZIDA.balance + TAX_REPORT_PT_TAX_VENDAS_FATURAS_ISENTO.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">TAX_REPORT_PT_TAX_VENDAS_FATURAS_NORMAL.balance + TAX_REPORT_PT_TAX_VENDAS_FATURAS_INTERMEDIA.balance + TAX_REPORT_PT_TAX_VENDAS_FATURAS_REDUZIDA.balance + TAX_REPORT_PT_TAX_VENDAS_FATURAS_ISENTO.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_pt_tax_vendas_faturas_normal" model="account.report.line">
                                         <field name="name">Normal</field>
@@ -318,13 +288,7 @@
                             <record id="tax_report_pt_tax_vendas_notas_credito" model="account.report.line">
                                 <field name="name">Notas de crédito (Total IVA regularizado a favor da empresa)</field>
                                 <field name="code">tax_report_pt_tax_vendas_notas_credito</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_pt_tax_vendas_notas_credito_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">TAX_REPORT_PT_TAX_VENDAS_NOTAS_CREDITO_NORMAL.balance + TAX_REPORT_PT_TAX_VENDAS_NOTAS_CREDITO_INTERMEDIA.balance + TAX_REPORT_PT_TAX_VENDAS_NOTAS_CREDITO_REDUZIDA.balance + TAX_REPORT_PT_TAX_VENDAS_NOTAS_CREDITO_ISENTO.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">TAX_REPORT_PT_TAX_VENDAS_NOTAS_CREDITO_NORMAL.balance + TAX_REPORT_PT_TAX_VENDAS_NOTAS_CREDITO_INTERMEDIA.balance + TAX_REPORT_PT_TAX_VENDAS_NOTAS_CREDITO_REDUZIDA.balance + TAX_REPORT_PT_TAX_VENDAS_NOTAS_CREDITO_ISENTO.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_pt_tax_vendas_notas_credito_normal" model="account.report.line">
                                         <field name="name">Normal</field>
@@ -380,13 +344,7 @@
                             <record id="tax_report_pt_tax_despesas_faturas" model="account.report.line">
                                 <field name="name">Faturas (Total IVA dedutível)</field>
                                 <field name="code">tax_report_pt_tax_despesas_faturas</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_pt_tax_despesas_faturas_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">TAX_REPORT_PT_TAX_DESPESAS_FATURAS_NORMAL.balance + TAX_REPORT_PT_TAX_DESPESAS_FATURAS_INTERMEDIA.balance + TAX_REPORT_PT_TAX_DESPESAS_FATURAS_REDUZIDA.balance + TAX_REPORT_PT_TAX_DESPESAS_FATURAS_ISENTO.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">TAX_REPORT_PT_TAX_DESPESAS_FATURAS_NORMAL.balance + TAX_REPORT_PT_TAX_DESPESAS_FATURAS_INTERMEDIA.balance + TAX_REPORT_PT_TAX_DESPESAS_FATURAS_REDUZIDA.balance + TAX_REPORT_PT_TAX_DESPESAS_FATURAS_ISENTO.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_pt_tax_despesas_faturas_normal" model="account.report.line">
                                         <field name="name">Normal</field>
@@ -437,13 +395,7 @@
                             <record id="tax_report_pt_tax_despesas_notas_credito" model="account.report.line">
                                 <field name="name">Notas de crédito (Total IVA regularizado a favor do Estado)</field>
                                 <field name="code">tax_report_pt_tax_despesas_notas_credito</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_pt_tax_despesas_notas_credito_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">TAX_REPORT_PT_TAX_DESPESAS_NOTAS_CREDITO_NORMAL.balance + TAX_REPORT_PT_TAX_DESPESAS_NOTAS_CREDITO_INTERMEDIA.balance + TAX_REPORT_PT_TAX_DESPESAS_NOTAS_CREDITO_REDUZIDA.balance + TAX_REPORT_PT_TAX_DESPESAS_NOTAS_CREDITO_ISENTO.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">TAX_REPORT_PT_TAX_DESPESAS_NOTAS_CREDITO_NORMAL.balance + TAX_REPORT_PT_TAX_DESPESAS_NOTAS_CREDITO_INTERMEDIA.balance + TAX_REPORT_PT_TAX_DESPESAS_NOTAS_CREDITO_REDUZIDA.balance + TAX_REPORT_PT_TAX_DESPESAS_NOTAS_CREDITO_ISENTO.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_pt_tax_despesas_notas_credito_normal" model="account.report.line">
                                         <field name="name">Normal</field>

--- a/addons/l10n_ro/data/account_tax_report_data.xml
+++ b/addons/l10n_ro/data/account_tax_report_data.xml
@@ -16,13 +16,7 @@
             <record id="account_tax_report_ro_baza_intracom_eu" model="account.report.line">
                 <field name="name">Baza COMERŢ INTRACOMUNITAR ŞI ÎN AFARA UE</field>
                 <field name="code">tax_ro_baza_intracom_eu</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_baza_intracom_eu_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_baza_rd1.balance + tax_ro_baza_rd2.balance + tax_ro_baza_rd3.balance + tax_ro_baza_rd4.balance + tax_ro_baza_rd5.balance + tax_ro_baza_rd6.balance + tax_ro_baza_rd7.balance + tax_ro_baza_rd8.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_baza_rd1.balance + tax_ro_baza_rd2.balance + tax_ro_baza_rd3.balance + tax_ro_baza_rd4.balance + tax_ro_baza_rd5.balance + tax_ro_baza_rd6.balance + tax_ro_baza_rd7.balance + tax_ro_baza_rd8.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_baza_rd1" model="account.report.line">
                         <field name="name">1 - BAZA - Livrări intracomunitare de bunuri, scutite conform art. 294 alin.(2) lit.a) şid) din Codul fiscal</field>
@@ -156,13 +150,7 @@
             <record id="account_tax_report_ro_tva_intracom_eu" model="account.report.line">
                 <field name="name">TVA COMERŢ INTRACOMUNITAR ŞI ÎN AFARA UE</field>
                 <field name="code">tax_ro_tva_intracom_eu</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_intracom_eu_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_tva_rd5.balance + tax_ro_tva_rd6.balance + tax_ro_tva_rd7.balance + tax_ro_tva_rd8.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_tva_rd5.balance + tax_ro_tva_rd6.balance + tax_ro_tva_rd7.balance + tax_ro_tva_rd8.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_tva_rd5" model="account.report.line">
                         <field name="name">5 - TVA - Achizitii intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA (taxare inversă), din care:</field>
@@ -239,13 +227,7 @@
             <record id="account_tax_report_ro_baza_livrari" model="account.report.line">
                 <field name="name">BAZA LIVRĂRI DE BUNURI/ PRESTĂRI DE SERVICII ÎN INTERIORUL ŢĂRII ŞI EXPORTURI</field>
                 <field name="code">tax_ro_baza_livrari</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_baza_livrari_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_baza_rd9.balance + tax_ro_baza_rd10.balance + tax_ro_baza_rd11.balance + tax_ro_baza_rd12.balance + tax_ro_baza_rd13.balance + tax_ro_baza_rd14.balance + tax_ro_baza_rd15.balance + tax_ro_baza_rd16.balance + tax_ro_baza_rd17.balance + tax_ro_baza_rd18.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_baza_rd9.balance + tax_ro_baza_rd10.balance + tax_ro_baza_rd11.balance + tax_ro_baza_rd12.balance + tax_ro_baza_rd13.balance + tax_ro_baza_rd14.balance + tax_ro_baza_rd15.balance + tax_ro_baza_rd16.balance + tax_ro_baza_rd17.balance + tax_ro_baza_rd18.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_baza_rd9" model="account.report.line">
                         <field name="name">9 - BAZA - Livrări de bunuri şi prestări de servicii taxabile cu cota 19%</field>
@@ -272,13 +254,7 @@
                             <record id="account_tax_report_ro_baza_rd92" model="account.report.line">
                                 <field name="name">9.2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 19%</field>
                                 <field name="code">tax_ro_baza_rd92</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_ro_baza_rd92_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">0.5 * tax_ro_baza_rd242.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">0.5 * tax_ro_baza_rd242.balance</field>
                             </record>
                         </field>
                     </record>
@@ -307,13 +283,7 @@
                             <record id="account_tax_report_ro_baza_rd102" model="account.report.line">
                                 <field name="name">10_2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 9%</field>
                                 <field name="code">tax_ro_baza_rd102</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_ro_baza_rd102_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">0.5 * tax_ro_baza_rd252.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">0.5 * tax_ro_baza_rd252.balance</field>
                             </record>
                         </field>
                     </record>
@@ -342,13 +312,7 @@
                             <record id="account_tax_report_ro_baza_rd112" model="account.report.line">
                                 <field name="name">11.2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 5%</field>
                                 <field name="code">tax_ro_baza_rd112</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_ro_baza_rd112_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">0.5 * tax_ro_baza_rd262.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">0.5 * tax_ro_baza_rd262.balance</field>
                             </record>
                         </field>
                     </record>
@@ -469,13 +433,7 @@
             <record id="account_tax_report_ro_tva_livrari" model="account.report.line">
                 <field name="name">TVA LIVRĂRI DE BUNURI/ PRESTĂRI DE SERVICII ÎN INTERIORUL ŢĂRII ŞI EXPORTURI</field>
                 <field name="code">tax_ro_tva_livrari</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_livrari_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_tva_rd9.balance + tax_ro_tva_rd10.balance + tax_ro_tva_rd11.balance + tax_ro_tva_rd12.balance + tax_ro_tva_rd16.balance + tax_ro_tva_rd17.balance + tax_ro_tva_rd18.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_tva_rd9.balance + tax_ro_tva_rd10.balance + tax_ro_tva_rd11.balance + tax_ro_tva_rd12.balance + tax_ro_tva_rd16.balance + tax_ro_tva_rd17.balance + tax_ro_tva_rd18.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_tva_rd9" model="account.report.line">
                         <field name="name">9 - TVA - Livrări de bunuri şi prestări de servicii taxabile cu cota 19%</field>
@@ -666,35 +624,17 @@
             <record id="account_tax_report_ro_baza_col" model="account.report.line">
                 <field name="name">Baza Total Taxa COLECTATĂ</field>
                 <field name="code">total_tax_ro_baza_col</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_baza_col_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_baza_intracom_eu.balance + tax_ro_baza_livrari.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_baza_intracom_eu.balance + tax_ro_baza_livrari.balance</field>
             </record>
             <record id="account_tax_report_ro_tva_col" model="account.report.line">
                 <field name="name">TVA Total Taxa COLECTATĂ</field>
                 <field name="code">total_tax_ro_tva_col</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_col_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_tva_intracom_eu.balance + tax_ro_tva_livrari.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_tva_intracom_eu.balance + tax_ro_tva_livrari.balance</field>
             </record>
             <record id="account_tax_report_ro_baza_intracom_eu_achiz" model="account.report.line">
                 <field name="name">BAZA ACHIZIŢII INTRACOMUNITARE DE BUNURI ŞI ALTE ACHIZIŢII DE BUNURI ŞI SERVICII IMPOZABILE ÎN ROMÂNIA</field>
                 <field name="code">tax_ro_baza_intracom_eu_a</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_baza_intracom_eu_achiz_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_baza_rd20.balance + tax_ro_baza_rd21.balance + tax_ro_baza_rd22.balance + tax_ro_baza_rd23.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_baza_rd20.balance + tax_ro_baza_rd21.balance + tax_ro_baza_rd22.balance + tax_ro_baza_rd23.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_baza_rd20" model="account.report.line">
                         <field name="name">20 - BAZA - Achiziţii intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA (taxare inversă) (rd.18=rd.5), din care:</field>
@@ -771,13 +711,7 @@
             <record id="account_tax_report_ro_tva_intracom_eu_achiz" model="account.report.line">
                 <field name="name">TVA ACHIZIŢII INTRACOMUNITARE DE BUNURI ŞI ALTE ACHIZIŢII DE BUNURI ŞI SERVICII IMPOZABILE ÎN ROMÂNIA</field>
                 <field name="code">tax_ro_tva_intracom_eu_a</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_intracom_eu_achiz_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_tva_rd20.balance + tax_ro_tva_rd21.balance + tax_ro_tva_rd22.balance + tax_ro_tva_rd23.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_tva_rd20.balance + tax_ro_tva_rd21.balance + tax_ro_tva_rd22.balance + tax_ro_tva_rd23.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_tva_rd20" model="account.report.line">
                         <field name="name">20 - TVA - Achiziţii intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA (taxare inversă) (rd.18=rd.5), din care:</field>
@@ -854,24 +788,12 @@
             <record id="account_tax_report_ro_baza_achiz" model="account.report.line">
                 <field name="name">BAZA ACHIZIŢII DE BUNURI/ SERVICII ÎN INTERIORUL ŢĂRII ŞI IMPORTURI, ACHIZIŢII INTRACOMUNITARE, SCUTITE SAU NEIMPOZABILE</field>
                 <field name="code">tax_ro_baza_achiz</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_baza_achiz_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_baza_rd24.balance + tax_ro_baza_rd25.balance + tax_ro_baza_rd26.balance + tax_ro_baza_rd27.balance + tax_ro_baza_rd30.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_baza_rd24.balance + tax_ro_baza_rd25.balance + tax_ro_baza_rd26.balance + tax_ro_baza_rd27.balance + tax_ro_baza_rd30.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_baza_rd24" model="account.report.line">
                         <field name="name">24 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
                         <field name="code">tax_ro_baza_rd24</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_ro_baza_rd24_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">tax_ro_baza_rd241.balance + 0.5 * tax_ro_baza_rd242.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">tax_ro_baza_rd241.balance + 0.5 * tax_ro_baza_rd242.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_baza_rd241" model="account.report.line">
                                 <field name="name">24.1 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
@@ -900,13 +822,7 @@
                     <record id="account_tax_report_ro_baza_rd25" model="account.report.line">
                         <field name="name">25 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%</field>
                         <field name="code">tax_ro_baza_rd25</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_ro_baza_rd25_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">tax_ro_baza_rd251.balance + 0.5 * tax_ro_baza_rd252.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">tax_ro_baza_rd251.balance + 0.5 * tax_ro_baza_rd252.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_baza_rd251" model="account.report.line">
                                 <field name="name">25.1 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%</field>
@@ -935,13 +851,7 @@
                     <record id="account_tax_report_ro_baza_rd26" model="account.report.line">
                         <field name="name">26 - BAZA - Achiziţii de bunuri taxabile cu cota de 5%</field>
                         <field name="code">tax_ro_baza_rd26</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_ro_baza_rd26_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">tax_ro_baza_rd261.balance + 0.5 * tax_ro_baza_rd262.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">tax_ro_baza_rd261.balance + 0.5 * tax_ro_baza_rd262.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_baza_rd261" model="account.report.line">
                                 <field name="name">26.1 - BAZA - Achiziţii de bunuri taxabile cu cota de 5%</field>
@@ -1042,24 +952,12 @@
             <record id="account_tax_report_ro_tva_achiz" model="account.report.line">
                 <field name="name">TVA ACHIZIŢII DE BUNURI/ SERVICII ÎN INTERIORUL ŢĂRII ŞI IMPORTURI, ACHIZIŢII INTRACOMUNITARE, SCUTITE SAU NEIMPOZABILE</field>
                 <field name="code">tax_ro_tva_achiz</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_achiz_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_tva_rd24.balance + tax_ro_tva_rd25.balance + tax_ro_tva_rd26.balance + tax_ro_tva_rd27.balance + tax_ro_tva_rd28.balance + tax_ro_tva_rd29.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_tva_rd24.balance + tax_ro_tva_rd25.balance + tax_ro_tva_rd26.balance + tax_ro_tva_rd27.balance + tax_ro_tva_rd28.balance + tax_ro_tva_rd29.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_tva_rd24" model="account.report.line">
                         <field name="name">24 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
                         <field name="code">tax_ro_tva_rd24</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_ro_tva_rd24_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">tax_ro_tva_rd241.balance + tax_ro_tva_rd242.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">tax_ro_tva_rd241.balance + tax_ro_tva_rd242.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_tva_rd241" model="account.report.line">
                                 <field name="name">24.1 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
@@ -1123,13 +1021,7 @@
                     <record id="account_tax_report_ro_tva_rd26" model="account.report.line">
                         <field name="name">26 - TVA - Achiziţii de bunuri taxabile cu cota de 5%</field>
                         <field name="code">tax_ro_tva_rd26</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_ro_tva_rd26_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">tax_ro_tva_rd261.balance + tax_ro_tva_rd262.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">tax_ro_tva_rd261.balance + tax_ro_tva_rd262.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_tva_rd261" model="account.report.line">
                                 <field name="name">26.1 - TVA - Achiziţii de bunuri taxabile cu cota de 5%</field>
@@ -1228,35 +1120,17 @@
             <record id="account_tax_report_ro_baza_total_rd31" model="account.report.line">
                 <field name="name">31 - BAZA - TOTAL TAXĂ DEDUCTIBILĂ ( sumă de la rd.20 până la rd.29, cu excepţia celor de la rd.20.1,22.1, 27.1, 27.2, 27.3)</field>
                 <field name="code">tax_ro_baza_total_rd31</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_baza_total_rd31_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_baza_intracom_eu_a.balance + tax_ro_baza_achiz.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_baza_intracom_eu_a.balance + tax_ro_baza_achiz.balance</field>
             </record>
             <record id="account_tax_report_ro_tva_total_rd31" model="account.report.line">
                 <field name="name">31 - TVA - TOTAL TAXĂ DEDUCTIBILĂ ( sumă de la rd.20 până la rd.29, cu excepţia celor de la rd.20.1,22.1, 27.1, 27.2, 27.3)</field>
                 <field name="code">tax_ro_tva_total_rd31</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_total_rd31_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance</field>
             </record>
             <record id="account_tax_report_ro_tva_rd32" model="account.report.line">
                 <field name="name">32 - TVA - SUB-TOTAL TAXĂ DEDUSĂ CONFORM ART. 297 ŞI ART. 298 SAU ART. 300 ŞI ART. 298 (rd.30&lt;=rd.29)</field>
                 <field name="code">tax_ro_tva_rd32</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_rd32_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance</field>
             </record>
             <record id="account_tax_report_ro_tva_rd33" model="account.report.line">
                 <field name="name">33 - TVA - TVA efectiv restituită cumpărătorilor straini, inclusiv comisionul unităţilor autorizate</field>
@@ -1305,13 +1179,7 @@
             <record id="account_tax_report_ro_tva_rd36" model="account.report.line">
                 <field name="name">36 - TVA - TOTAL TAXA DEDUSA (rd.32+rd.33+rd.34+rd.35)</field>
                 <field name="code">tax_ro_tva_rd36</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_ro_tva_rd36_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance + tax_ro_tva_rd33.balance + tax_ro_tva_rd34.balance + tax_ro_tva_rd35.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance + tax_ro_tva_rd33.balance + tax_ro_tva_rd34.balance + tax_ro_tva_rd35.balance</field>
             </record>
             <record id="account_tax_report_ro_tva_rd40" model="account.report.line">
                 <field name="name">40 - TVA - Diferenţe de TVA de plată stabilite de organele de inspecţie fiscală prin decizie comunicată şi neachitate până la data depunerii decontului de TVA </field>

--- a/addons/l10n_sa/data/account_tax_report_data.xml
+++ b/addons/l10n_sa/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="tax_report_line_vat_all_sales_base" model="account.report.line">
                 <field name="name">VAT on Sales and all other Outputs (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_vat_all_sales_base_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">SA_STD_SALE_B.balance + SA_SPCL_SALE_B.balance + SA_ZERO_SALE_B.balance + SA_EXP_SALE_B.balance + SA_EXM_SALE_B.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">SA_STD_SALE_B.balance + SA_SPCL_SALE_B.balance + SA_ZERO_SALE_B.balance + SA_EXP_SALE_B.balance + SA_EXM_SALE_B.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_standard_rated_15_base" model="account.report.line">
                         <field name="name">1. Standard Rated 15% (Base)</field>
@@ -80,25 +74,13 @@
                     </record>
                     <record id="tax_report_line_net_sales_base" model="account.report.line">
                         <field name="name">6. Net Sales (Base)</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_net_sales_base_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">SA_STD_SALE_B.balance + SA_SPCL_SALE_B.balance + SA_ZERO_SALE_B.balance + SA_EXP_SALE_B.balance + SA_EXM_SALE_B.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">SA_STD_SALE_B.balance + SA_SPCL_SALE_B.balance + SA_ZERO_SALE_B.balance + SA_EXP_SALE_B.balance + SA_EXM_SALE_B.balance</field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_line_vat_all_sales_tax" model="account.report.line">
                 <field name="name">VAT on Sales and all other Outputs (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_vat_all_sales_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">SA_STD_SALE_T.balance + SA_SPCL_SALE_T.balance + SA_ZERO_SALE_T.balance + SA_EXP_SALE_T.balance + SA_EXM_SALE_T.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">SA_STD_SALE_T.balance + SA_SPCL_SALE_T.balance + SA_ZERO_SALE_T.balance + SA_EXP_SALE_T.balance + SA_EXM_SALE_T.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_standard_rated_15_tax" model="account.report.line">
                         <field name="name">1. Standard Rated 15% (Tax)</field>
@@ -157,25 +139,13 @@
                     </record>
                     <record id="tax_report_line_net_sales_tax" model="account.report.line">
                         <field name="name">6. Net Sales (Tax)</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_net_sales_tax_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">SA_STD_SALE_T.balance + SA_SPCL_SALE_T.balance + SA_ZERO_SALE_T.balance + SA_EXP_SALE_T.balance + SA_EXM_SALE_T.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">SA_STD_SALE_T.balance + SA_SPCL_SALE_T.balance + SA_ZERO_SALE_T.balance + SA_EXP_SALE_T.balance + SA_EXM_SALE_T.balance</field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_line_vat_all_expenses_base" model="account.report.line">
                 <field name="name">VAT on Expenses and all other Inputs (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_vat_all_expenses_base_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">SA_STD_PUR_B.balance + SA_CUST_PUR_B.balance + SA_RCM_PUR_B.balance + SA_ZER_PUR_B.balance + SA_EXM_PUR_B.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">SA_STD_PUR_B.balance + SA_CUST_PUR_B.balance + SA_RCM_PUR_B.balance + SA_ZER_PUR_B.balance + SA_EXM_PUR_B.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_standard_rated_15_purchases_base" model="account.report.line">
                         <field name="name">7. Standard rated 15% Purchases (Base)</field>
@@ -234,25 +204,13 @@
                     </record>
                     <record id="tax_report_line_net_purchases_base" model="account.report.line">
                         <field name="name">12. Net Purchases (Base)</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_net_purchases_base_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">SA_STD_PUR_B.balance + SA_CUST_PUR_B.balance + SA_RCM_PUR_B.balance + SA_ZER_PUR_B.balance + SA_EXM_PUR_B.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">SA_STD_PUR_B.balance + SA_CUST_PUR_B.balance + SA_RCM_PUR_B.balance + SA_ZER_PUR_B.balance + SA_EXM_PUR_B.balance</field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_line_vat_all_expenses_tax" model="account.report.line">
                 <field name="name">VAT on Expenses and all other Inputs (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_vat_all_expenses_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">SA_STD_PUR_T.balance + SA_CUST_PUR_T.balance + SA_RCM_PUR_T.balance + SA_ZER_PUR_T.balance + SA_EXM_PUR_T.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">SA_STD_PUR_T.balance + SA_CUST_PUR_T.balance + SA_RCM_PUR_T.balance + SA_ZER_PUR_T.balance + SA_EXM_PUR_T.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_standard_rated_15_purchases_tax" model="account.report.line">
                         <field name="name">7. Standard rated 15% Purchases (Tax)</field>
@@ -311,13 +269,7 @@
                     </record>
                     <record id="tax_report_line_net_purchases_tax" model="account.report.line">
                         <field name="name">12. Net Purchases (Tax)</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_net_purchases_tax_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">SA_STD_PUR_T.balance + SA_CUST_PUR_T.balance + SA_RCM_PUR_T.balance + SA_ZER_PUR_T.balance + SA_EXM_PUR_T.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">SA_STD_PUR_T.balance + SA_CUST_PUR_T.balance + SA_RCM_PUR_T.balance + SA_ZER_PUR_T.balance + SA_EXM_PUR_T.balance</field>
                     </record>
                 </field>
             </record>
@@ -334,33 +286,15 @@
                 <field name="children_ids">
                     <record id="tax_report_line_total_value_of_due_tax_for_the_period" model="account.report.line">
                         <field name="name">Total value of due tax for the period</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_total_value_of_due_tax_for_the_period_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">SA_STD_SALE_T.balance + SA_SPCL_SALE_T.balance + SA_ZERO_SALE_T.balance + SA_EXP_SALE_T.balance + SA_EXM_SALE_T.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">SA_STD_SALE_T.balance + SA_SPCL_SALE_T.balance + SA_ZERO_SALE_T.balance + SA_EXP_SALE_T.balance + SA_EXM_SALE_T.balance</field>
                     </record>
                     <record id="tax_report_line_total_value_of_recoverable_tax_for_the_period" model="account.report.line">
                         <field name="name">Total value of recoverable tax for the period</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_total_value_of_recoverable_tax_for_the_period_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">SA_STD_PUR_T.balance + SA_CUST_PUR_T.balance + SA_RCM_PUR_T.balance + SA_ZER_PUR_T.balance + SA_EXM_PUR_T.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">SA_STD_PUR_T.balance + SA_CUST_PUR_T.balance + SA_RCM_PUR_T.balance + SA_ZER_PUR_T.balance + SA_EXM_PUR_T.balance</field>
                     </record>
                     <record id="tax_report_line_net_vat_due_or_reclaimed_for_the_period" model="account.report.line">
                         <field name="name">Net VAT due (or reclaimed) for the period</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_net_vat_due_or_reclaimed_for_the_period_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">SA_STD_SALE_T.balance + SA_SPCL_SALE_T.balance + SA_ZERO_SALE_T.balance + SA_EXP_SALE_T.balance + SA_EXM_SALE_T.balance - (SA_STD_PUR_T.balance + SA_CUST_PUR_T.balance + SA_RCM_PUR_T.balance + SA_ZER_PUR_T.balance + SA_EXM_PUR_T.balance)</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">SA_STD_SALE_T.balance + SA_SPCL_SALE_T.balance + SA_ZERO_SALE_T.balance + SA_EXP_SALE_T.balance + SA_EXM_SALE_T.balance - (SA_STD_PUR_T.balance + SA_CUST_PUR_T.balance + SA_RCM_PUR_T.balance + SA_ZER_PUR_T.balance + SA_EXM_PUR_T.balance)</field>
                     </record>
                 </field>
             </record>
@@ -381,13 +315,7 @@
         <field name="line_ids">
             <record id="tax_report_line_withholding_tax_on_purchased_services_base" model="account.report.line">
                 <field name="name">Withholding Tax on Purchased Services (Base)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_withholding_tax_on_purchased_services_base_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">SA_RENTB.balance + SA_AIRB.balance + SA_SEAB.balance + SA_TELEB.balance + SA_DIVB.balance + SA_CONB.balance + SA_ROLB.balance + SA_INSB.balance + SA_ROYB.balance + SA_MAIB.balance + SA_BRAB.balance + SA_OTHB.balance + SA_MAGB.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">SA_RENTB.balance + SA_AIRB.balance + SA_SEAB.balance + SA_TELEB.balance + SA_DIVB.balance + SA_CONB.balance + SA_ROLB.balance + SA_INSB.balance + SA_ROYB.balance + SA_MAIB.balance + SA_BRAB.balance + SA_OTHB.balance + SA_MAGB.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_withholding_tax_5_rental_base" model="account.report.line">
                         <field name="name">Withholding Tax 5% (Rental) (Base)</field>
@@ -534,25 +462,13 @@
                     </record>
                     <record id="tax_report_line_withholding_tax_total_base" model="account.report.line">
                         <field name="name">Withholding Tax Total (Base)</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_withholding_tax_total_base_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">SA_RENTB.balance+SA_AIRB.balance+SA_SEAB.balance+SA_TELEB.balance+SA_DIVB.balance+SA_CONB.balance+SA_ROLB.balance+SA_INSB.balance+SA_ROYB.balance+SA_MAIB.balance+SA_BRAB.balance+SA_OTHB.balance+SA_MAGB.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">SA_RENTB.balance+SA_AIRB.balance+SA_SEAB.balance+SA_TELEB.balance+SA_DIVB.balance+SA_CONB.balance+SA_ROLB.balance+SA_INSB.balance+SA_ROYB.balance+SA_MAIB.balance+SA_BRAB.balance+SA_OTHB.balance+SA_MAGB.balance</field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_line_withholding_tax_on_purchased_services_tax" model="account.report.line">
                 <field name="name">Withholding Tax on Purchased Services (Tax)</field>
-                <field name="expression_ids">
-                    <record id="tax_report_line_withholding_tax_on_purchased_services_tax_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">SA_RENTT.balance + SA_AIRT.balance + SA_SEAT.balance + SA_TELET.balance + SA_DIVT.balance + SA_CONT.balance + SA_ROLT.balance + SA_INST.balance + SA_ROYT.balance + SA_MAIT.balance + SA_BRAT.balance + SA_OTHT.balance + SA_MAGT.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">SA_RENTT.balance + SA_AIRT.balance + SA_SEAT.balance + SA_TELET.balance + SA_DIVT.balance + SA_CONT.balance + SA_ROLT.balance + SA_INST.balance + SA_ROYT.balance + SA_MAIT.balance + SA_BRAT.balance + SA_OTHT.balance + SA_MAGT.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_withholding_tax_5_rental_tax" model="account.report.line">
                         <field name="name">Withholding Tax 5% (Rental) (Tax)</field>
@@ -699,13 +615,7 @@
                     </record>
                     <record id="tax_report_line_withholding_tax_total_tax" model="account.report.line">
                         <field name="name">Withholding Tax Total (Tax)</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_withholding_tax_total_tax_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">SA_RENTT.balance+SA_AIRT.balance+SA_SEAT.balance+SA_TELET.balance+SA_DIVT.balance+SA_CONT.balance+SA_ROLT.balance+SA_INST.balance+SA_ROYT.balance+SA_MAIT.balance+SA_BRAT.balance+SA_OTHT.balance+SA_MAGT.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">SA_RENTT.balance+SA_AIRT.balance+SA_SEAT.balance+SA_TELET.balance+SA_DIVT.balance+SA_CONT.balance+SA_ROLT.balance+SA_INST.balance+SA_ROYT.balance+SA_MAIT.balance+SA_BRAT.balance+SA_OTHT.balance+SA_MAGT.balance</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_se/data/account_tax_report_data.xml
+++ b/addons/l10n_se/data/account_tax_report_data.xml
@@ -16,13 +16,7 @@
             <record id="tax_report_title_sales" model="account.report.line">
                 <field name="name">Block A – Momspliktig försäljning eller uttag exklusive moms</field>
                 <field name="code">se_a</field>
-                <field name="expression_ids">
-                    <record id="tax_report_title_sales_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">se_05.balance + se_06.balance + se_07.balance + se_08.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">se_05.balance + se_06.balance + se_07.balance + se_08.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_05" model="account.report.line">
                         <field name="name">Fält 05 – Momspliktig försäljning som inte ingår i fält 06, 07 eller 08</field>
@@ -73,13 +67,7 @@
             <record id="tax_report_title_output_vat_sales" model="account.report.line">
                 <field name="name">Block B – Utgående moms på försäljning eller uttag i fält 05–08</field>
                 <field name="code">se_b</field>
-                <field name="expression_ids">
-                    <record id="tax_report_title_output_vat_sales_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">se_10.balance + se_11.balance + se_12.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">se_10.balance + se_11.balance + se_12.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_10" model="account.report.line">
                         <field name="name">Fält 10 – Utgående moms 25 %</field>
@@ -119,13 +107,7 @@
             <record id="tax_report_title_purchases" model="account.report.line">
                 <field name="name">Block C – Momspliktiga inköp vid omvänd skattskyldighet</field>
                 <field name="code">se_c</field>
-                <field name="expression_ids">
-                    <record id="tax_report_title_purchases_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">se_20.balance + se_21.balance + se_22.balance + se_23.balance + se_24.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">se_20.balance + se_21.balance + se_22.balance + se_23.balance + se_24.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_20" model="account.report.line">
                         <field name="name">Fält 20 – Inköp av varor från annat EU-land</field>
@@ -187,13 +169,7 @@
             <record id="tax_report_title_output_vat_purchases" model="account.report.line">
                 <field name="name">Block D – Utgående moms på inköp i fält 20–24</field>
                 <field name="code">se_d</field>
-                <field name="expression_ids">
-                    <record id="tax_report_title_output_vat_purchases_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">se_30.balance + se_31.balance + se_32.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">se_30.balance + se_31.balance + se_32.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_30" model="account.report.line">
                         <field name="name">Fält 30 – Utgående moms 25 %</field>
@@ -233,13 +209,7 @@
             <record id="tax_report_title_imports" model="account.report.line">
                 <field name="name">Block H - moms vid import</field>
                 <field name="code">se_h</field>
-                <field name="expression_ids">
-                    <record id="tax_report_title_imports_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">se_50.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">se_50.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_50" model="account.report.line">
                         <field name="name">Fält 50 - Beskattningsunderlag vid import</field>
@@ -257,13 +227,7 @@
             <record id="tax_report_title_output_vat_imports" model="account.report.line">
                 <field name="name">Block I - Utgående moms på import i fält 50</field>
                 <field name="code">se_i</field>
-                <field name="expression_ids">
-                    <record id="tax_report_title_output_vat_imports_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">se_60.balance + se_61.balance + se_62.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">se_60.balance + se_61.balance + se_62.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_60" model="account.report.line">
                         <field name="name">Fält 60 – Utgående moms 25 %</field>
@@ -303,13 +267,7 @@
             <record id="tax_report_title_exempt_sales" model="account.report.line">
                 <field name="name">Block E – Försäljning m.m. som är undantagen från moms</field>
                 <field name="code">se_e</field>
-                <field name="expression_ids">
-                    <record id="tax_report_title_exempt_sales_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">se_35.balance + se_36.balance + se_37.balance + se_38.balance + se_39.balance + se_40.balance + se_41.balance + se_42.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">se_35.balance + se_36.balance + se_37.balance + se_38.balance + se_39.balance + se_40.balance + se_41.balance + se_42.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_35" model="account.report.line">
                         <field name="name">Fält 35 – Försäljning av varor till ett annat EU-land</field>
@@ -404,13 +362,7 @@
             <record id="tax_report_title_input_vat" model="account.report.line">
                 <field name="name">Block F – Ingående moms</field>
                 <field name="code">se_f</field>
-                <field name="expression_ids">
-                    <record id="tax_report_title_input_vat_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">se_48.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">se_48.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_48" model="account.report.line">
                         <field name="name">Fält 48 – Ingående moms att dra av</field>
@@ -428,24 +380,12 @@
             <record id="tax_report_title_vat_debt_credit" model="account.report.line">
                 <field name="name">Block G – Moms att betala eller få tillbaka</field>
                 <field name="code">se_g</field>
-                <field name="expression_ids">
-                    <record id="tax_report_title_vat_debt_credit_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">se_b.balance+se_i.balance+se_d.balance+se_f.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">se_b.balance+se_i.balance+se_d.balance+se_f.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_line_49" model="account.report.line">
                         <field name="name">Fält 49 – Moms att betala eller få tillbaka</field>
                         <field name="code">se_49</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_line_49_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">se_b.balance+se_i.balance+se_d.balance+se_f.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">se_b.balance+se_i.balance+se_d.balance+se_f.balance</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_sg/data/account_tax_report_data.xml
+++ b/addons/l10n_sg/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="account_tax_report_line_supplies" model="account.report.line">
                 <field name="name">Supplies</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_supplies_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">BOX1.balance + BOX2.balance + BOX3.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">BOX1.balance + BOX2.balance + BOX3.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_std_rated_supplies" model="account.report.line">
                         <field name="name">Box 1 - Total value of standard-rated supplies</field>
@@ -58,25 +52,13 @@
                     </record>
                     <record id="account_tax_report_line_total_supplies" model="account.report.line">
                         <field name="name">Box 4 - Total value of (1) + (2) + (3)</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_total_supplies_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">BOX1.balance + BOX2.balance + BOX3.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">BOX1.balance + BOX2.balance + BOX3.balance</field>
                     </record>
                 </field>
             </record>
             <record id="account_tax_report_line_purchases" model="account.report.line">
                 <field name="name">Purchases</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_purchases_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">BOX_5.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">BOX_5.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_total_taxable_purchases" model="account.report.line">
                         <field name="name">Box 5 - Total value of taxable purchases</field>
@@ -93,13 +75,7 @@
             </record>
             <record id="account_tax_report_line_taxes" model="account.report.line">
                 <field name="name">Taxes</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_taxes_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">BOX6.balance + BOX7.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">BOX6.balance + BOX7.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_output_tax_due" model="account.report.line">
                         <field name="name">Box 6 - Output tax due</field>
@@ -125,25 +101,13 @@
                     </record>
                     <record id="account_tax_report_line_total_gst_paid_iras" model="account.report.line">
                         <field name="name">Box 8 - Equals : Net GST to be paid to IRAS</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_total_gst_paid_iras_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">BOX6.balance - BOX7.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">BOX6.balance - BOX7.balance</field>
                     </record>
                 </field>
             </record>
             <record id="account_tax_report_line_applicable" model="account.report.line">
                 <field name="name">Applicable to Taxable Persons under Major Exported Scheme / Approved 3rd Party Logistics Company / Other Approved Schemes Only</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_applicable_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">BOX_9.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">BOX_9.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_applicable_goods_imported_value" model="account.report.line">
                         <field name="name">Box 9 - Total value of goods imported under this scheme</field>
@@ -160,13 +124,7 @@
             </record>
             <record id="account_tax_report_line_revenues" model="account.report.line">
                 <field name="name">Revenue</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_revenues_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">BOX_13.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">BOX_13.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_revenues_accounting_period" model="account.report.line">
                         <field name="name">Box 13 - Revenue for the accounting period</field>

--- a/addons/l10n_si/data/account_tax_report_data.xml
+++ b/addons/l10n_si/data/account_tax_report_data.xml
@@ -15,35 +15,17 @@
         <field name="line_ids">
             <record id="tax_report_zo_dvd" model="account.report.line">
                 <field name="name">Znesek osnov za DDV</field>
-                <field name="expression_ids">
-                    <record id="tax_report_zo_dvd_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ZO_NEODBITNI_DDV.balance + ZO_ODBITNI_DDV.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ZO_NEODBITNI_DDV.balance + ZO_ODBITNI_DDV.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_zo_dvd_neo" model="account.report.line">
                         <field name="name">Neodbitni DDV</field>
                         <field name="code">ZO_NEODBITNI_DDV</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_zo_dvd_neo_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">ZO_NEODBITNI_VSTOPNI_DDV.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">ZO_NEODBITNI_VSTOPNI_DDV.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_zo_dvd_neo_sdtopni" model="account.report.line">
                                 <field name="name">Vstopni DDV</field>
                                 <field name="code">ZO_NEODBITNI_VSTOPNI_DDV</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_zo_dvd_neo_sdtopni_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">NABAVE_PO_OSNOVNI_STOPNJI_DDV_NEODBITNI.balance + NABAVE_PO_ZNIZANI_STOPNJI_DDV_NEODBITNI.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">NABAVE_PO_OSNOVNI_STOPNJI_DDV_NEODBITNI.balance + NABAVE_PO_ZNIZANI_STOPNJI_DDV_NEODBITNI.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_zo_dvd_neo_sdtopni_osno" model="account.report.line">
                                         <field name="name">Nabave po osnovni stopnji DDV</field>
@@ -74,24 +56,12 @@
                     <record id="tax_report_zo_dvd_odb" model="account.report.line">
                         <field name="name">Odbitni DDV</field>
                         <field name="code">ZO_ODBITNI_DDV</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_zo_dvd_odb_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">ZO_IZSTOPNI_DDV.balance + ODBITNI_VSTOPNI_DDV.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">ZO_IZSTOPNI_DDV.balance + ODBITNI_VSTOPNI_DDV.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_zo_dvd_odb_izstopni" model="account.report.line">
                                 <field name="name">Izstopni DDV</field>
                                 <field name="code">ZO_IZSTOPNI_DDV</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_zo_dvd_odb_izstopni_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">PRODAJA_OPROSCENA_DDV.balance + PRODAJA_PO_OSNOVNI_STOPNJI_DDV.balance + PRODAJA_PO_ZNIZANI_STOPNJI_DDV.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">PRODAJA_OPROSCENA_DDV.balance + PRODAJA_PO_OSNOVNI_STOPNJI_DDV.balance + PRODAJA_PO_ZNIZANI_STOPNJI_DDV.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_zo_dvd_odb_izstopni_opr" model="account.report.line">
                                         <field name="name">Prodaja oproščena DDV</field>
@@ -131,13 +101,7 @@
                             <record id="tax_report_zo_dvd_odb_vstopni" model="account.report.line">
                                 <field name="name">Vstopni DDV</field>
                                 <field name="code">ODBITNI_VSTOPNI_DDV</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_zo_dvd_odb_vstopni_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">NABAVE_OPROSCENE_DDV.balance + NABAVE_PO_OSNOVNI_STOPNJI_DDV_VSTOPNI.balance + NABAVE_PO_ZNIZANI_STOPNJI_DDV_VSTOPNI.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">NABAVE_OPROSCENE_DDV.balance + NABAVE_PO_OSNOVNI_STOPNJI_DDV_VSTOPNI.balance + NABAVE_PO_ZNIZANI_STOPNJI_DDV_VSTOPNI.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_zo_dvd_odb_vstopni_opr" model="account.report.line">
                                         <field name="name">Nabave oproščene DDV</field>
@@ -180,35 +144,17 @@
             </record>
             <record id="tax_report_zn_dvd" model="account.report.line">
                 <field name="name">Znesek DDV</field>
-                <field name="expression_ids">
-                    <record id="tax_report_zn_dvd_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">ZN_NEODBITNI_DDV.balance + ZN_ODBITNI_DDV.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">ZN_NEODBITNI_DDV.balance + ZN_ODBITNI_DDV.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_zn_dvd_neo" model="account.report.line">
                         <field name="name">Neodbitni DDV</field>
                         <field name="code">ZN_NEODBITNI_DDV</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_zn_dvd_neo_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">ZN_NEODBITNI_VSTOPNI_DDV.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">ZN_NEODBITNI_VSTOPNI_DDV.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_zn_dvd_neo_vstopni" model="account.report.line">
                                 <field name="name">Vstopni DDV</field>
                                 <field name="code">ZN_NEODBITNI_VSTOPNI_DDV</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_zn_dvd_neo_vstopni_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">NEODBITNI_DDV__OSNOVNA_STOPNJA.balance + NEODBITNI_DDV__ZNIZANA_STOPNJA.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">NEODBITNI_DDV__OSNOVNA_STOPNJA.balance + NEODBITNI_DDV__ZNIZANA_STOPNJA.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_zn_dvd_neo_vstopni_osnnovna" model="account.report.line">
                                         <field name="name">Neodbitni DDV – osnovna stopnja</field>
@@ -239,24 +185,12 @@
                     <record id="tax_report_zn_dvd_odb" model="account.report.line">
                         <field name="name">Odbitni DDV</field>
                         <field name="code">ZN_ODBITNI_DDV</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_zn_dvd_odb_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">ZN_IZSTOPNI_DDV.balance + VSTOPNI_DDV.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">ZN_IZSTOPNI_DDV.balance + VSTOPNI_DDV.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_zn_dvd_odb_izstopni" model="account.report.line">
                                 <field name="name">Izstopni DDV</field>
                                 <field name="code">ZN_IZSTOPNI_DDV</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_zn_dvd_odb_izstopni_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">IZSTOPNI_DDV__OSNOVNA_STOPNJA.balance + IZSTOPNI_DDV__ZNIZANA_STOPNJA.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">IZSTOPNI_DDV__OSNOVNA_STOPNJA.balance + IZSTOPNI_DDV__ZNIZANA_STOPNJA.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_zn_dvd_odb_izstopni_osn" model="account.report.line">
                                         <field name="name">Izstopni DDV - osnovna stopnja</field>
@@ -285,13 +219,7 @@
                             <record id="tax_report_zn_dvd_odb_vstopni" model="account.report.line">
                                 <field name="name">Vstopni DDV</field>
                                 <field name="code">VSTOPNI_DDV</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_zn_dvd_odb_vstopni_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VSTOPNI_DDV__OSNOVNA_STOPNJA.balance + VSTOPNI_DDV__ZNIZANA_STOPNJA.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">VSTOPNI_DDV__OSNOVNA_STOPNJA.balance + VSTOPNI_DDV__ZNIZANA_STOPNJA.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_zn_dvd_odb_vstopni_osn" model="account.report.line">
                                         <field name="name">Vstopni DDV - osnovna stopnja</field>

--- a/addons/l10n_th/data/account_tax_report_data.xml
+++ b/addons/l10n_th/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="tax_report_out_tax_title" model="account.report.line">
                 <field name="name">Output Tax</field>
-                <field name="expression_ids">
-                    <record id="tax_report_out_tax_title_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">OUTPUTTAX_SALEAMOUNT.balance + OUTPUTTAX_SALE_ZERO.balance + OUTPUTTAX_EXEMPTED.balance + OUTPUTTAX_TAX.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">OUTPUTTAX_SALEAMOUNT.balance + OUTPUTTAX_SALE_ZERO.balance + OUTPUTTAX_EXEMPTED.balance + OUTPUTTAX_TAX.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_out_tax_sale" model="account.report.line">
                         <field name="name">1. Sales amount</field>
@@ -58,13 +52,7 @@
                     </record>
                     <record id="tax_report_out_tax_taxable_sales_amount" model="account.report.line">
                         <field name="name">4. Taxable sales amount(1. -2. -3.)</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_out_tax_taxable_sales_amount_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">OUTPUTTAX_SALEAMOUNT.balance-(OUTPUTTAX_SALE_ZERO.balance+OUTPUTTAX_EXEMPTED.balance)</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">OUTPUTTAX_SALEAMOUNT.balance-(OUTPUTTAX_SALE_ZERO.balance+OUTPUTTAX_EXEMPTED.balance)</field>
                     </record>
                     <record id="tax_report_out_tax" model="account.report.line">
                         <field name="name">5. Output tax</field>
@@ -82,13 +70,7 @@
             <record id="tax_report_input_tax_title" model="account.report.line">
                 <field name="name">Input Tax</field>
                 <field name="code">INPUTTAX</field>
-                <field name="expression_ids">
-                    <record id="tax_report_input_tax_title_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">6_PURCHASE_AMOUNT_THAT_IS_ENTITLED_TO_DEDUCTION_OF_INPUT_TAX_FROM_OUTPUT_TAX_IN_TAX_COMPUTATION.balance + INPUTTAX_TAX.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">6_PURCHASE_AMOUNT_THAT_IS_ENTITLED_TO_DEDUCTION_OF_INPUT_TAX_FROM_OUTPUT_TAX_IN_TAX_COMPUTATION.balance + INPUTTAX_TAX.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_input_tax_purchase_from_out_tax" model="account.report.line">
                         <field name="name">6. Purchase amount that is entitled to deduction of input tax from output tax in tax computation</field>
@@ -116,33 +98,15 @@
             </record>
             <record id="tax_report_vat" model="account.report.line">
                 <field name="name">Value Added Tax</field>
-                <field name="expression_ids">
-                    <record id="tax_report_vat_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">10_EXCESS_TAX_PAYMENT_CARRIED_FORWARD_FROM_LAST_PERIOD.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">10_EXCESS_TAX_PAYMENT_CARRIED_FORWARD_FROM_LAST_PERIOD.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_vat_payable" model="account.report.line">
                         <field name="name">8. Tax payable (5. minus 7. (if 5. is greater than 7.))</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_vat_payable_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">OUTPUTTAX_TAX.balance - INPUTTAX_TAX if (OUTPUTTAX_TAX &gt; INPUTTAX_TAX) else 0.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">OUTPUTTAX_TAX.balance - INPUTTAX_TAX if (OUTPUTTAX_TAX &gt; INPUTTAX_TAX) else 0.balance</field>
                     </record>
                     <record id="tax_report_vat_excess" model="account.report.line">
                         <field name="name">9. Excess tax payable (7. minus 5. (if 5. is less than 7.))</field>
-                        <field name="expression_ids">
-                            <record id="tax_report_vat_excess_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">INPUTTAX_TAX.balance - OUTPUTTAX_TAX if (INPUTTAX_TAX &gt; OUTPUTTAX_TAX) else 0.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">INPUTTAX_TAX.balance - OUTPUTTAX_TAX if (INPUTTAX_TAX &gt; OUTPUTTAX_TAX) else 0.balance</field>
                     </record>
                     <record id="tax_report_vat_payment_last_period" model="account.report.line">
                         <field name="name">10. Excess tax payment carried forward from last period</field>
@@ -160,13 +124,7 @@
             </record>
             <record id="tax_report_net_vat" model="account.report.line">
                 <field name="name">Net Tax</field>
-                <field name="expression_ids">
-                    <record id="tax_report_net_vat_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">11_NET_TAX_PAYABLE_IF_8_IS_GREATER_THAN_10.balance + 12_NET_EXCESS_TAX_PAYABLE_IF_10_IS_GREATER_THAN_8_OR_9_PLUS_10.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">11_NET_TAX_PAYABLE_IF_8_IS_GREATER_THAN_10.balance + 12_NET_EXCESS_TAX_PAYABLE_IF_10_IS_GREATER_THAN_8_OR_9_PLUS_10.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_net_vat_payable" model="account.report.line">
                         <field name="name">11. Net tax payable (if 8. is greater than 10.)</field>

--- a/addons/l10n_uk/data/account_tax_report_data.xml
+++ b/addons/l10n_uk/data/account_tax_report_data.xml
@@ -15,13 +15,7 @@
         <field name="line_ids">
             <record id="account_tax_report_line_vat_cal" model="account.report.line">
                 <field name="name">VAT calculations</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_vat_cal_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">UKTAX_1.balance + UKTAX_2.balance + UKTAX_4.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">UKTAX_1.balance + UKTAX_2.balance + UKTAX_4.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_vat_box1" model="account.report.line">
                         <field name="name">[BOX 1] VAT due on sales and other outputs</field>
@@ -47,13 +41,7 @@
                     </record>
                     <record id="account_tax_report_line_vat_box3" model="account.report.line">
                         <field name="name">[BOX 3] Total VAT due (box 1 + box 2)</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_vat_box3_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">UKTAX_1.balance + UKTAX_2.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">UKTAX_1.balance + UKTAX_2.balance</field>
                     </record>
                     <record id="account_tax_report_line_vat_box4" model="account.report.line">
                         <field name="name">[BOX 4] VAT reclaimed on purchases and other inputs (including acquisitions from EC)</field>
@@ -68,25 +56,13 @@
                     </record>
                     <record id="account_tax_report_line_vat_box5" model="account.report.line">
                         <field name="name">[BOX 5] VAT to pay/reclaim</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_vat_box5_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">UKTAX_1.balance + UKTAX_2.balance - UKTAX_4.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">UKTAX_1.balance + UKTAX_2.balance - UKTAX_4.balance</field>
                     </record>
                 </field>
             </record>
             <record id="account_tax_report_line_exd_vat" model="account.report.line">
                 <field name="name">Sales and Purchases Excluding VAT</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_exd_vat_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">UKTAX_6.balance + UKTAX_7.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">UKTAX_6.balance + UKTAX_7.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_exd_vat_box6" model="account.report.line">
                         <field name="name">[BOX 6] Total value of sales and other outputs excluding VAT (including EC supplies)</field>
@@ -114,13 +90,7 @@
             </record>
             <record id="account_tax_report_line_ec_exd_vat" model="account.report.line">
                 <field name="name">EC Sales and Purchases excluding VAT</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_ec_exd_vat_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">UKTAX_8.balance + UKTAX_9.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">UKTAX_8.balance + UKTAX_9.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_exd_vat_box8" model="account.report.line">
                         <field name="name">[BOX 8] Total value of EC sales excluding VAT</field>

--- a/addons/l10n_uy/data/account_tax_report_data.xml
+++ b/addons/l10n_uy/data/account_tax_report_data.xml
@@ -15,24 +15,12 @@
         <field name="line_ids">
             <record id="account_tax_report_base_impb" model="account.report.line">
                 <field name="name">Base Imponible</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_base_impb_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">BASE_IMPONIBLE_COMPRAS.balance + BASE_IMPONIBLE_VENTAS.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">BASE_IMPONIBLE_COMPRAS.balance + BASE_IMPONIBLE_VENTAS.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_base_impb_cmprs" model="account.report.line">
                         <field name="name">Base Imponible Compras</field>
                         <field name="code">BASE_IMPONIBLE_COMPRAS</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_base_impb_cmprs_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">UYTAX_010101.balance + UYTAX_020101.balance + UYTAX_030101.balance + UYTAX_040101.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">UYTAX_010101.balance + UYTAX_020101.balance + UYTAX_030101.balance + UYTAX_040101.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_base_impb_cmprs_22" model="account.report.line">
                                 <field name="name">Base Compras 22%</field>
@@ -83,13 +71,7 @@
                     <record id="account_tax_report_base_impb_vnts" model="account.report.line">
                         <field name="name">Base Imponible Ventas</field>
                         <field name="code">BASE_IMPONIBLE_VENTAS</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_base_impb_vnts_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">UYTAX_010201.balance + UYTAX_020201.balance + UYTAX_030201.balance + UYTAX_040201.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">UYTAX_010201.balance + UYTAX_020201.balance + UYTAX_030201.balance + UYTAX_040201.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_base_impb_vnts_22" model="account.report.line">
                                 <field name="name">Base Ventas 22%</field>
@@ -141,24 +123,12 @@
             </record>
             <record id="account_tax_report_sldo_iva" model="account.report.line">
                 <field name="name">Saldo de IVA</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_sldo_iva_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">IVA_COMPRAS__PAGADO.balance + UYTAX_040102.balance + IVA_VENTAS__PERCIBIDO.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">IVA_COMPRAS__PAGADO.balance + UYTAX_040102.balance + IVA_VENTAS__PERCIBIDO.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_iva_cmprs_pagdo" model="account.report.line">
                         <field name="name">IVA Compras - pagado</field>
                         <field name="code">IVA_COMPRAS__PAGADO</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_iva_cmprs_pagdo_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">UYTAX_010102.balance + UYTAX_020102.balance + COMPRAS_EXENTO_IVA.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">UYTAX_010102.balance + UYTAX_020102.balance + COMPRAS_EXENTO_IVA.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_iva_cmprs_22" model="account.report.line">
                                 <field name="name">IVA Compras 22%</field>
@@ -210,13 +180,7 @@
                     <record id="account_tax_report_iva_vnts_prcbdo" model="account.report.line">
                         <field name="name">IVA Ventas - percibido</field>
                         <field name="code">IVA_VENTAS__PERCIBIDO</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_iva_vnts_prcbdo_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">UYTAX_010202.balance + UYTAX_020202.balance + VENTAS_EXENTO_IVA.balance + UYTAX_040202.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">UYTAX_010202.balance + UYTAX_020202.balance + VENTAS_EXENTO_IVA.balance + UYTAX_040202.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_iva_vnts_22" model="account.report.line">
                                 <field name="name">IVA Ventas 22%</field>

--- a/addons/l10n_vn/data/account_tax_report_data.xml
+++ b/addons/l10n_vn/data/account_tax_report_data.xml
@@ -15,24 +15,12 @@
         <field name="line_ids">
             <record id="account_tax_report_line_01_vn" model="account.report.line">
                 <field name="name">Purchase of Goods and Services</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_01_vn_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">VAT_ON_PURCHASE_OF_GOODS_AND_SERVICES.balance + UNTAXED_PURCHASE_OF_GOODS_AND_SERVICES.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">VAT_ON_PURCHASE_OF_GOODS_AND_SERVICES.balance + UNTAXED_PURCHASE_OF_GOODS_AND_SERVICES.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_01_01_vn" model="account.report.line">
                         <field name="name">VAT on purchase of goods and services</field>
                         <field name="code">VAT_ON_PURCHASE_OF_GOODS_AND_SERVICES</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_01_01_vn_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">VAT_ON_PURCHASE_OF_GOODS_AND_SERVICES_0.balance + VAT_ON_PURCHASE_OF_GOODS_AND_SERVICES_5.balance + VAT_ON_PURCHASE_OF_GOODS_AND_SERVICES_10.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">VAT_ON_PURCHASE_OF_GOODS_AND_SERVICES_0.balance + VAT_ON_PURCHASE_OF_GOODS_AND_SERVICES_5.balance + VAT_ON_PURCHASE_OF_GOODS_AND_SERVICES_10.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_01_01_01_vn" model="account.report.line">
                                 <field name="name">VAT on purchase of goods and services 0%</field>
@@ -72,13 +60,7 @@
                     <record id="account_tax_report_line_02_01_vn" model="account.report.line">
                         <field name="name">Untaxed Purchase of Goods and Services</field>
                         <field name="code">UNTAXED_PURCHASE_OF_GOODS_AND_SERVICES</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_02_01_vn_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">UNTAXED_PURCHASE_OF_GOODS_AND_SERVICES_TAXED_0.balance + UNTAXED_PURCHASE_OF_GOODS_AND_SERVICES_TAXED_5.balance + UNTAXED_PURCHASE_OF_GOODS_AND_SERVICES_TAXED_10.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">UNTAXED_PURCHASE_OF_GOODS_AND_SERVICES_TAXED_0.balance + UNTAXED_PURCHASE_OF_GOODS_AND_SERVICES_TAXED_5.balance + UNTAXED_PURCHASE_OF_GOODS_AND_SERVICES_TAXED_10.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_01_02_01_vn" model="account.report.line">
                                 <field name="name">Untaxed Purchase of Goods and Services taxed 0%</field>
@@ -119,24 +101,12 @@
             </record>
             <record id="account_tax_report_line_02_vn" model="account.report.line">
                 <field name="name">Sales of Goods and Services</field>
-                <field name="expression_ids">
-                    <record id="account_tax_report_line_02_vn_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">VAT_ON_SALES_OF_GOODS_AND_SERVICES.balance + UNTAXED_SALES_OF_GOODS_AND_SERVICES.balance</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">VAT_ON_SALES_OF_GOODS_AND_SERVICES.balance + UNTAXED_SALES_OF_GOODS_AND_SERVICES.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_01_02_vn" model="account.report.line">
                         <field name="name">VAT on sales of goods and services</field>
                         <field name="code">VAT_ON_SALES_OF_GOODS_AND_SERVICES</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_01_02_vn_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">VAT_ON_SALES_OF_GOODS_AND_SERVICES_0.balance + VAT_ON_SALES_OF_GOODS_AND_SERVICES_5.balance + VAT_ON_SALES_OF_GOODS_AND_SERVICES_10.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">VAT_ON_SALES_OF_GOODS_AND_SERVICES_0.balance + VAT_ON_SALES_OF_GOODS_AND_SERVICES_5.balance + VAT_ON_SALES_OF_GOODS_AND_SERVICES_10.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_01_01_02_vn" model="account.report.line">
                                 <field name="name">VAT on sales of goods and services 0%</field>
@@ -176,13 +146,7 @@
                     <record id="account_tax_report_line_02_02_vn" model="account.report.line">
                         <field name="name">Untaxed Sales of Goods and Services</field>
                         <field name="code">UNTAXED_SALES_OF_GOODS_AND_SERVICES</field>
-                        <field name="expression_ids">
-                            <record id="account_tax_report_line_02_02_vn_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">UNTAXED_SALES_OF_GOODS_AND_SERVICES_TAXED_0.balance + UNTAXED_SALES_OF_GOODS_AND_SERVICES_TAXED_5.balance + UNTAXED_SALES_OF_GOODS_AND_SERVICES_TAXED_10.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">UNTAXED_SALES_OF_GOODS_AND_SERVICES_TAXED_0.balance + UNTAXED_SALES_OF_GOODS_AND_SERVICES_TAXED_5.balance + UNTAXED_SALES_OF_GOODS_AND_SERVICES_TAXED_10.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_01_02_02_vn" model="account.report.line">
                                 <field name="name">Untaxed sales of goods and services taxed 0%</field>

--- a/addons/l10n_za/data/account_tax_report_data.xml
+++ b/addons/l10n_za/data/account_tax_report_data.xml
@@ -15,23 +15,11 @@
         <field name="line_ids">
             <record id="total_vat_payable" model="account.report.line">
                 <field name="name">[20] VAT PAYABLE/REFUNDABLE (Total A - Total B)</field>
-                <field name="expression_ids">
-                    <record id="total_vat_payable_formula" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">(VAT4.balance + VAT4A.balance + (SEC6.balance * 0.6 + SEC7.balance) + VAT11.balance + VAT12.balance) - (VAT14.balance + VAT14A.balance + VAT15.balance + VAT16.balance + VAT17.balance + VAT18.balance)</field>
-                    </record>
-                </field>
+                <field name="aggregation_formula">(VAT4.balance + VAT4A.balance + (SEC6.balance * 0.6 + SEC7.balance) + VAT11.balance + VAT12.balance) - (VAT14.balance + VAT14A.balance + VAT15.balance + VAT16.balance + VAT17.balance + VAT18.balance)</field>
                 <field name="children_ids">
                     <record id="total_output_tax" model="account.report.line">
                         <field name="name">[13] Total A: TOTAL OUTPUT TAX (4 + 4A + 9 + 11 + 12)</field>
-                        <field name="expression_ids">
-                            <record id="total_output_tax_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">VAT4.balance + VAT4A.balance + (SEC6.balance * 0.6 + SEC7.balance) + VAT11.balance + VAT12.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">VAT4.balance + VAT4A.balance + (SEC6.balance * 0.6 + SEC7.balance) + VAT11.balance + VAT12.balance</field>
                         <field name="children_ids">
                             <record id="standard_rate_exclude_capital_goods_service" model="account.report.line">
                                 <field name="name">[1] Standard Rate (Excluding Capital goods and/or services and accomodation)</field>
@@ -123,13 +111,7 @@
                             </record>
                             <record id="accomodation_exceeding_28_days_60_percent" model="account.report.line">
                                 <field name="name">[6] x 60%</field>
-                                <field name="expression_ids">
-                                    <record id="accomodation_exceeding_28_days_60_percent_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VAT5.balance * 0.6</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">VAT5.balance * 0.6</field>
                             </record>
                             <record id="accomodation_under_28_days" model="account.report.line">
                                 <field name="name">[7] Accomodation under 28 days</field>
@@ -144,23 +126,11 @@
                             </record>
                             <record id="accomodation_28_days" model="account.report.line">
                                 <field name="name">[8] Total (6 + 7)</field>
-                                <field name="expression_ids">
-                                    <record id="accomodation_28_days_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">(VAT5.balance * 0.6) + VAT7.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">(VAT5.balance * 0.6) + VAT7.balance</field>
                             </record>
                             <record id="vat_on_accomodation_28_days" model="account.report.line">
                                 <field name="name">[9] x 15 / (100 ??) </field>
-                                <field name="expression_ids">
-                                    <record id="vat_on_accomodation_28_days_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">SEC6.balance * 0.6 + SEC7.balance </field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">SEC6.balance * 0.6 + SEC7.balance </field>
                                 <field name="children_ids">
                                     <record id="vat_on_accomodation_exceeding_28_days" model="account.report.line">
                                         <field name="name">VAT on Accomodation exceeding 28 days</field>
@@ -188,13 +158,7 @@
                             </record>
                             <record id="vat_plus_base_of_second_hand_goods_export" model="account.report.line">
                                 <field name="name">[10] Change in use and export of second-hand goods</field>
-                                <field name="expression_ids">
-                                    <record id="vat_plus_base_of_second_hand_goods_export_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VAT10a.balance + VAT11.balance</field>
-                                    </record>
-                                </field>
+                                <field name="aggregation_formula">VAT10a.balance + VAT11.balance</field>
                                 <field name="children_ids">
                                     <record id="second_hand_goods_export" model="account.report.line">
                                         <field name="name">[10] Base Amount: Change in use and export of second-hand goods</field>
@@ -235,13 +199,7 @@
                     </record>
                     <record id="total_input_tax" model="account.report.line">
                         <field name="name">[19] Total B: TOTAL INPUT TAX (14 + 14A + 15 + 15A + 16 + 17 + 18)</field>
-                        <field name="expression_ids">
-                            <record id="total_input_tax_formula" model="account.report.expression">
-                                <field name="label">balance</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">VAT14.balance + VAT14A.balance + VAT15.balance + VAT15A.balance + VAT16.balance + VAT17.balance + VAT18.balance</field>
-                            </record>
-                        </field>
+                        <field name="aggregation_formula">VAT14.balance + VAT14A.balance + VAT15.balance + VAT15A.balance + VAT16.balance + VAT17.balance + VAT18.balance</field>
                         <field name="children_ids">
                             <record id="capital_goods_services_supplied" model="account.report.line">
                                 <field name="name">[14] Capital Goods and/or services supplied to you</field>


### PR DESCRIPTION
Most reports have one record in expression_ids added with standard options.
We can shorten many xml files by adding a way to create those expression ids using non-stored fields in one line.

Add 3 fields to account.report.line:
domain_formula - create an expression with domain engine.
account_codes_formula - create an expression with account_codes engine
aggregation_formula - create an expression with aggregation engine