### PR TITLE
[FIX] crm: fix test following 'always edit' mode

### DIFF
--- a/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
+++ b/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
@@ -44,12 +44,11 @@ odoo.define('crm.crm_email_and_phone_propagation', function (require) {
                 action.remove_text("", ".o_form_editable .o_field_widget[name=phone] input");
             },
         }, {
-            trigger: '.o_form_button_save',
+            trigger: '.o_back_button',
             // wait the the warning message to be visible
             extra_trigger: '.o_form_sheet_bg .fa-exclamation-triangle:not(.o_invisible_modifier)',
-            content: 'Save the lead',
+            content: 'Save the lead and exit to kanban',
             run: 'click',
         },
     ]);
-
 });


### PR DESCRIPTION
The save button is hidden, but we can achieve the last step (which is just there to confirm the extra_trigger's presence and doesn't actually cares about what happens when you save).

Instead of clicking on "Save", click on the breadcrumb.