### PR TITLE
[FIX] website, web_editor, *: adaptations for dark mode

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -549,38 +549,6 @@
             > .nav.nav-tabs {
                 @include o-form-sheet-inner-left-padding;
                 border-bottom-color: $border-color;
-
-                > .nav-item {
-                    white-space: nowrap;
-
-                    > .nav-link {
-                        color: $body-color;
-                        border-color: $border-color;
-                        background-color: white;
-
-                        &:hover, &:focus, &:active {
-                            outline: none;
-                            color: $link-color;
-                        }
-
-                        &.active {
-                            border-bottom-color: white;
-
-                            &, &:hover, &:focus, &:active {
-                                color: $headings-color;
-                                border-top-color: $o-brand-odoo;
-                            }
-                        }
-
-                        &.disabled {
-                            color: $text-muted;
-                        }
-                    }
-
-                    + .nav-item {
-                        margin-left: -1px;
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
This PR fixes several issues in `[website]` and `[web_editor]` for dark mode.
It also : 
- Removes conflicting scss for `notebook`.
- Adapts colors for Ace Editor.

Requires:
- https://github.com/odoo-dev/enterprise/pull/373

task-2710677