### PR TITLE
[POC] don't add dependency to pytest nor upgrade pylint

### DIFF
--- a/odoo/addons/test_lint/tests/_odoo_checker_sql_injection.py
+++ b/odoo/addons/test_lint/tests/_odoo_checker_sql_injection.py
@@ -1,7 +1,8 @@
 import os
 
 import astroid
-from pylint.checkers import BaseChecker
+from pylint import checkers
+from pylint.checkers import BaseChecker, utils
 
 
 DFTL_CURSOR_EXPR = [
@@ -39,7 +40,7 @@ class OdooBaseChecker(BaseChecker):
         """
         :type node: NodeNG
         """
-        infered = checkers.utils.safe_infer(node)
+        infered = utils.safe_infer(node)
         # The package 'psycopg2' must be installed to infer
         # ignore sql.SQL().format or variable that can be infered as constant
         if infered and (infered.pytype().startswith('psycopg2') or  isinstance(infered, astroid.Const)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,9 +31,6 @@ pyopenssl==19.0.0
 PyPDF2==1.26.0
 pypiwin32 ; sys_platform == 'win32'
 pyserial==3.4
-pylint==2.14
-distutils
-pytest==7.1.3
 python-dateutil==2.7.3
 python-ldap==3.4.0 ; sys_platform != 'win32'  # min version = 3.2.0 (Focal with security backports)
 python-stdnum==1.13


### PR DESCRIPTION
The assert method could be improved as well as adding a setup to define the linter and spliting the test, but this is a way to make test independant from pytest and maybe a little more odoo style using standard assert and minimal tools.

We may also have a simple utility that return the messages and assert equal/false directly.