### PR TITLE
[IMP] webclient: badge border color

### DIFF
--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -125,7 +125,7 @@
                                                     <strong><span t-esc="record.name.value"/></strong>
                                                 </div>
                                                 <div class="text-odoo">
-                                                    <div t-if="record.is_new.raw_value" class="o_lunch_new_product me-1 py-1 border-0 fs-6 badge rounded-pill text-bg-success">
+                                                    <div t-if="record.is_new.raw_value" class="o_lunch_new_product me-1 py-1 fs-6 badge rounded-pill text-bg-success">
                                                         New
                                                     </div>
                                                     <field name="price" widget="monetary"/>

--- a/addons/mail/static/src/backend_components/activity_list_view/activity_list_view.xml
+++ b/addons/mail/static/src/backend_components/activity_list_view/activity_list_view.xml
@@ -9,7 +9,7 @@
                 <div class="d-flex bg-100 py-2 border-bottom">
                     <span class="text-danger fw-bold mx-3">Overdue</span>
                     <span class="flex-grow-1"/>
-                    <span class="badge rounded-pill text-bg-danger border-0 mx-3 align-self-center" t-esc="activityListView.overdueActivityListViewItems.length"/>
+                    <span class="badge rounded-pill text-bg-danger mx-3 align-self-center" t-esc="activityListView.overdueActivityListViewItems.length"/>
                 </div>
                 <t t-foreach="activityListView.overdueActivityListViewItems" t-as="activityListViewItem" t-key="activityListViewItem">
                     <ActivityListViewItem record="activityListViewItem"/>
@@ -19,7 +19,7 @@
                 <div class="d-flex bg-100 py-2 border-bottom">
                     <span class="text-warning fw-bold mx-3">Today</span>
                     <span class="flex-grow-1"/>
-                    <span class="badge rounded-pill text-bg-warning border-0 mx-3 align-self-center" t-esc="activityListView.todayActivityListViewItems.length"/>
+                    <span class="badge rounded-pill text-bg-warning mx-3 align-self-center" t-esc="activityListView.todayActivityListViewItems.length"/>
                 </div>
                 <t t-foreach="activityListView.todayActivityListViewItems" t-as="activityListViewItem" t-key="activityListViewItem">
                     <ActivityListViewItem record="activityListViewItem"/>
@@ -29,7 +29,7 @@
                 <div class="d-flex bg-100 py-2 border-bottom">
                     <span class="text-success fw-bold mx-3">Planned</span>
                     <span class="flex-grow-1"/>
-                    <span class="badge rounded-pill text-bg-success border-0 mx-3 align-self-center" t-esc="activityListView.plannedActivityListViewItems.length"/>
+                    <span class="badge rounded-pill text-bg-success mx-3 align-self-center" t-esc="activityListView.plannedActivityListViewItems.length"/>
                 </div>
                 <t t-foreach="activityListView.plannedActivityListViewItems" t-as="activityListViewItem" t-key="activityListViewItem">
                     <ActivityListViewItem record="activityListViewItem"/>

--- a/addons/mail/static/src/components/activity_box/activity_box.xml
+++ b/addons/mail/static/src/components/activity_box/activity_box.xml
@@ -13,17 +13,17 @@
                     <t t-if="!activityBoxView.isActivityListVisible">
                         <span class="o_ActivityBox_titleBadges ms-2">
                             <t t-if="activityBoxView.chatter.thread.overdueActivities.length > 0">
-                                <span class="o_ActivityBox_titleBadge me-1 badge border-0 text-bg-danger">
+                                <span class="o_ActivityBox_titleBadge me-1 badge text-bg-danger">
                                     <t t-esc="activityBoxView.chatter.thread.overdueActivities.length"/>
                                 </span>
                             </t>
                             <t t-if="activityBoxView.chatter.thread.todayActivities.length > 0">
-                                <span class="o_ActivityBox_titleBadge me-1 badge border-0 text-bg-warning">
+                                <span class="o_ActivityBox_titleBadge me-1 badge text-bg-warning">
                                     <t t-esc="activityBoxView.chatter.thread.todayActivities.length"/>
                                 </span>
                             </t>
                             <t t-if="activityBoxView.chatter.thread.futureActivities.length > 0">
-                                <span class="o_ActivityBox_titleBadge me-1 badge border-0 text-bg-success">
+                                <span class="o_ActivityBox_titleBadge me-1 badge text-bg-success">
                                     <t t-esc="activityBoxView.chatter.thread.futureActivities.length"/>
                                 </span>
                             </t>

--- a/addons/mail/static/src/components/discuss_sidebar_mailbox/discuss_sidebar_mailbox.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_mailbox/discuss_sidebar_mailbox.xml
@@ -15,7 +15,7 @@
             </div>
             <div t-attf-class="o_DiscussSidebarMailbox_item flex-grow-1 {{ discussSidebarMailboxView.mailbox.counter === 0 ? 'me-3': '' }}"/>
             <t t-if="discussSidebarMailboxView.mailbox.counter > 0">
-                <div t-attf-class="o_DiscussSidebarMailbox_counter o_DiscussSidebarMailbox_item badge rounded-pill {{ discussSidebarMailboxView.mailbox === messaging.starred ? 'bg-400 text-light' : 'text-bg-primary' }} ms-1 me-3 border-0">
+                <div t-attf-class="o_DiscussSidebarMailbox_counter o_DiscussSidebarMailbox_item badge rounded-pill {{ discussSidebarMailboxView.mailbox === messaging.starred ? 'bg-400 text-light' : 'text-bg-primary' }} ms-1 me-3">
                     <t t-esc="discussSidebarMailboxView.mailbox.counter"/>
                 </div>
             </t>

--- a/addons/mail/static/src/xml/web_kanban_activity.xml
+++ b/addons/mail/static/src/xml/web_kanban_activity.xml
@@ -36,7 +36,7 @@
 
                 <li role="menuitem" t-attf-class="list-group-item list-group-item list-group-item-light d-flex justify-content-between align-items-center o_activity_color_{{key}} {{!key_first ? 'mt-2' : ''}}">
                     <strong><t t-esc="widget.selection[key]"/></strong>
-                    <span t-attf-class="badge rounded-pill bg-{{contextual_class}} border-0 me-0"><t t-esc="logs.length"/></span>
+                    <span t-attf-class="badge rounded-pill bg-{{contextual_class}} me-0"><t t-esc="logs.length"/></span>
                 </li>
                 <t t-foreach="logs" t-as="log">
                     <t t-set="edit_class" t-value="'o_edit_activity'"/>

--- a/addons/web/static/src/views/graph/graph_renderer.xml
+++ b/addons/web/static/src/views/graph/graph_renderer.xml
@@ -12,7 +12,7 @@
                 <tbody>
                     <tr t-foreach="tooltipItems" t-as="tooltipItem" t-key="tooltipItem_index">
                         <td>
-                            <span class="o_square badge p-2 rounded-0 align-middle me-2 border-0" t-attf-style="background-color: {{ tooltipItem.boxColor }}"> </span>
+                            <span class="o_square badge p-2 rounded-0 align-middle me-2" t-attf-style="background-color: {{ tooltipItem.boxColor }}"> </span>
                             <span class="o_label text-truncate d-inline-block align-middle" t-attf-style="max-width: {{ maxWidth }}" t-esc="tooltipItem.label" />
                         </td>
                         <td class="o_value ps-2 text-end fw-bolder">

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_invite_users.xml
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_invite_users.xml
@@ -10,7 +10,7 @@
         <t t-if="state.invite.pending_users.length">
             <p class="o_form_label pt-3">Pending Invitations:</p>
             <span t-foreach="state.invite.pending_users" t-as="pending" t-key="pending[0]">
-                <a href="#" class="badge rounded-pill text-primary o_web_settings_user" t-on-click.prevent="(ev) => this.onClickUser(ev, pending)"> <t t-esc="pending[1]"/> </a>
+                <a href="#" class="badge rounded-pill text-primary border border-primary o_web_settings_user" t-on-click.prevent="(ev) => this.onClickUser(ev, pending)"> <t t-esc="pending[1]"/> </a>
             </span>
             <t t-if="state.invite.pending_users.length &lt; state.invite.pending_count">
                 <br/>

--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -332,7 +332,9 @@ b, strong {
 
 //== Badges
 .badge {
-  border: 1px solid $o-brand-primary;
+    &.text-bg-default, &.bg-light, &.text-bg-light, &.bg-default, &.text-primary{
+        outline: 1px solid $o-brand-primary;
+    }
 }
 
 //== Buttons

--- a/addons/website_blog/views/website_blog_posts_loop.xml
+++ b/addons/website_blog/views/website_blog_posts_loop.xml
@@ -211,7 +211,7 @@ according to the enabled options.
     <div t-if="len(blog_post.tag_ids)" class="o_wblog_post_short_tag_section d-flex align-items-center flex-wrap pt-2">
         <t t-foreach="blog_post.tag_ids" t-as="one_tag">
             <a t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, one_tag.id))}"
-               t-attf-class="badge mb-2 me-1 text-truncate #{one_tag.id in active_tag_ids and 'bg-primary text-light' or 'border text-primary'} post_link"
+               t-attf-class="badge mb-2 me-1 text-truncate #{one_tag.id in active_tag_ids and 'bg-primary text-light' or 'text-primary'} post_link"
                t-att-rel="len(active_tag_ids) and 'nofollow'"
                t-esc="one_tag.name"/>
         </t>

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -274,7 +274,7 @@ list of filtered posts (by date or tag).
         <div t-if="len(blogs) > 1">in <a t-attf-href="#{blog_url(blog=blog_post.blog_id)}"><b t-field="blog.name"/></a></div>
         <div t-if="len(blog_post.tag_ids) > 0">#
             <t t-foreach="blog_post.tag_ids" t-as="one_tag">
-                <a class="badge text-primary border me-1 post_link" t-attf-href="#{blog_url(tag=slug(one_tag), date_begin=False, date_end=False)}" t-esc="one_tag.name"/>
+                <a class="badge text-primary me-1 post_link" t-attf-href="#{blog_url(tag=slug(one_tag), date_begin=False, date_end=False)}" t-esc="one_tag.name"/>
             </t>
         </div>
     </div>


### PR DESCRIPTION
Prior to this commit, the border of the badge were in primary color on all badges that didn't had the "border-0" class.
Requires:
- https://github.com/odoo-dev/enterprise/pull/389
task-2710677


BEFORE<img width="885" alt="Screenshot 2022-10-03 at 15 24 20" src="https://user-images.githubusercontent.com/108661430/193588827-78e198f9-6453-4737-b4b2-41fda7a112c2.png">
AFTER<img width="885" alt="Screenshot 2022-10-03 at 15 24 35" src="https://user-images.githubusercontent.com/108661430/193588817-1247c7ab-b60b-48ca-9950-6330344339ca.png">

BEFORE<img width="885" alt="Screenshot 2022-10-03 at 15 24 00" src="https://user-images.githubusercontent.com/108661430/193588832-36ad6a1c-3984-4eb0-93b1-1cdf6bb1ab29.png">
AFTER<img width="885" alt="Screenshot 2022-10-03 at 15 23 32" src="https://user-images.githubusercontent.com/108661430/193588833-026a8c3b-3da3-44f5-bd44-a057369d3311.png">
