### PR TITLE
[IMP] web: adapt `o_m2o_avatar_empty` for dark mode

### DIFF
--- a/addons/web/static/src/legacy/scss/fields.scss
+++ b/addons/web/static/src/legacy/scss/fields.scss
@@ -158,7 +158,8 @@
         }
         .o_m2o_avatar_empty {
             display: block;
-            background-color: #e9ecef;
+            background: $o-black;
+            opacity: .1;
         }
     }
 


### PR DESCRIPTION
This PR adapts the color of `o_m2o_avatar_empty` for dark mode.

task-2710677