### PR TITLE
[IMP] rating: image background for dark mode

### DIFF
--- a/addons/rating/views/rating_rating_views.xml
+++ b/addons/rating/views/rating_rating_views.xml
@@ -93,7 +93,7 @@
                             <div class="oe_kanban_global_click d-flex align-items-center justify-content-center">
                                 <div class="row oe_kanban_details">
                                     <div class="col-4 my-auto">
-                                        <field name="rating_image" widget="image"/>
+                                        <field name="rating_image" widget="image" class="bg-view" />
                                     </div>
                                     <div class="col-8 ps-1">
                                         <strong>


### PR DESCRIPTION
Prior to this PR, the background of the rating images stayed white in dark mode