### PR TITLE
[IMP] mail: rename test helpers (Messaging -> Test)

### DIFF
--- a/addons/mail/static/tests/activity/activity_menu_tests.js
+++ b/addons/mail/static/tests/activity/activity_menu_tests.js
@@ -2,7 +2,7 @@
 
 import { ActivityMenu } from "@mail/activity/activity_menu";
 import { click, getFixture, mount } from "@web/../tests/helpers/utils";
-import { makeMessagingEnv, MessagingServer } from "../helpers/helpers";
+import { makeTestEnv, TestServer } from "../helpers/helpers";
 
 let target;
 
@@ -14,8 +14,8 @@ QUnit.module("mail", (hooks) => {
     QUnit.module("activity menu");
 
     QUnit.test("activity menu: no activity", async (assert) => {
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
         await mount(ActivityMenu, target, { env });
         await click(document.querySelector("i[aria-label='Activities']").closest('.dropdown-toggle'));
         assert.containsOnce(target, ".o-mail-no-activity");

--- a/addons/mail/static/tests/chat/chat_window_tests.js
+++ b/addons/mail/static/tests/chat/chat_window_tests.js
@@ -2,7 +2,7 @@
 
 import { ChatWindow } from "@mail/chat/chat_window";
 import { click, getFixture, mount } from "@web/../tests/helpers/utils";
-import { makeMessagingEnv, MessagingServer } from "../helpers/helpers";
+import { makeTestEnv, TestServer } from "../helpers/helpers";
 
 let target;
 
@@ -14,9 +14,9 @@ QUnit.module("mail", (hooks) => {
     QUnit.module("chat window");
 
     QUnit.test("clicking on chat window header toggle its fold status", async (assert) => {
-        const server = new MessagingServer();
+        const server = new TestServer();
         server.addChannel(43, "abc");
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
         await mount(ChatWindow, target, { env, props: { threadId: 43 } });
 
         assert.containsOnce(target, ".o-mail-chat-window");

--- a/addons/mail/static/tests/composer/composer_tests.js
+++ b/addons/mail/static/tests/composer/composer_tests.js
@@ -1,8 +1,8 @@
 /** @odoo-module **/
 
 import { Composer } from "@mail/composer/composer";
-import { click, nextTick, getFixture, mount } from "@web/../tests/helpers/utils";
-import { makeMessagingEnv, MessagingServer } from "../helpers/helpers";
+import { getFixture, mount } from "@web/../tests/helpers/utils";
+import { makeTestEnv, TestServer } from "../helpers/helpers";
 
 let target;
 
@@ -14,9 +14,9 @@ QUnit.module("mail", (hooks) => {
     QUnit.module("composer");
 
     QUnit.test("composer display correct placeholder", async (assert) => {
-        const server = new MessagingServer();
+        const server = new TestServer();
         server.addChannel(1, "general", "General announcements...");
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
         await mount(Composer, target, { env, props: { threadId: 1, placeholder: "owl" } });
 
         assert.containsOnce(target, "textarea");

--- a/addons/mail/static/tests/discuss/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/discuss_tests.js
@@ -2,7 +2,7 @@
 
 import { Discuss } from "@mail/discuss/discuss";
 import { click, editInput, getFixture, mount, patchWithCleanup } from "@web/../tests/helpers/utils";
-import { makeMessagingEnv, MessagingServer } from "../helpers/helpers";
+import { makeTestEnv, TestServer } from "../helpers/helpers";
 import { browser } from "@web/core/browser/browser";
 
 let target;
@@ -19,8 +19,8 @@ QUnit.module("mail", (hooks) => {
     QUnit.module("discuss");
 
     QUnit.test("sanity check", async (assert) => {
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => {
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => {
             if (route.startsWith('/mail')) {
                 assert.step(route);
             }
@@ -38,9 +38,9 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("can open #general", async (assert) => {
-        const server = new MessagingServer();
+        const server = new TestServer();
         server.addChannel(1, "general", "General announcements...");
-        const env = makeMessagingEnv((route, params) => {
+        const env = makeTestEnv((route, params) => {
             if (route === "/mail/channel/messages") {
                 assert.strictEqual(route, "/mail/channel/messages");
                 assert.strictEqual(params.channel_id, 1);
@@ -62,9 +62,9 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("can post a message", async (assert) => {
-        const server = new MessagingServer();
+        const server = new TestServer();
         server.addChannel(1, "general", "General announcements...");
-        const env = makeMessagingEnv((route, params) => {
+        const env = makeTestEnv((route, params) => {
             if (route.startsWith('/mail')) {
                 assert.step(route);
             }
@@ -85,8 +85,8 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("can create a new channel", async (assert) => {
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => {
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => {
             if (
                 route.startsWith('/mail') ||
                 ["/web/dataset/call_kw/mail.channel/search_read", "/web/dataset/call_kw/mail.channel/channel_create"].includes(route)
@@ -112,9 +112,9 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("can join a chat conversation", async (assert) => {
-        const server = new MessagingServer();
+        const server = new TestServer();
         server.addPartner(43, "abc");
-        const env = makeMessagingEnv((route, params) => {
+        const env = makeTestEnv((route, params) => {
             if (
                 route.startsWith('/mail') ||
                 ["/web/dataset/call_kw/res.partner/im_search", "/web/dataset/call_kw/mail.channel/channel_get"].includes(route)
@@ -144,10 +144,10 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("focus is set on composer when switching channel", async (assert) => {
-        const server = new MessagingServer();
+        const server = new TestServer();
         server.addChannel(1, "general", "General announcements...");
         server.addChannel(2, "other", "info");
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
 
         await mount(Discuss, target, { env });
         assert.containsNone(target, ".o-mail-composer-textarea");

--- a/addons/mail/static/tests/discuss/sidebar_tests.js
+++ b/addons/mail/static/tests/discuss/sidebar_tests.js
@@ -3,7 +3,7 @@
 import { Sidebar } from "@mail/discuss/sidebar";
 import { click, getFixture, mount, patchWithCleanup } from "@web/../tests/helpers/utils";
 import { browser } from "@web/core/browser/browser";
-import { makeMessagingEnv, MessagingServer } from "../helpers/helpers";
+import { makeTestEnv, TestServer } from "../helpers/helpers";
 
 let target;
 
@@ -19,9 +19,9 @@ QUnit.module("mail", (hooks) => {
     QUnit.module("discuss sidebar");
 
     QUnit.test("toggling category button hide category items", async (assert) => {
-        const server = new MessagingServer();
+        const server = new TestServer();
         server.addChannel(43, "abc");
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
         await mount(Sidebar, target, { env });
 
         assert.containsOnce(target, "button.o-active:contains('Inbox')");
@@ -31,10 +31,10 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("toggling category button does not hide active category items", async (assert) => {
-        const server = new MessagingServer();
+        const server = new TestServer();
         server.addChannel(43, "abc");
         server.addChannel(46, "def");
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
         env.services["mail.messaging"].discuss.threadId = 43; // #abc is active
 
         await mount(Sidebar, target, { env });

--- a/addons/mail/static/tests/form/chatter_tests.js
+++ b/addons/mail/static/tests/form/chatter_tests.js
@@ -2,7 +2,7 @@
 
 import { Chatter } from "@mail/form/chatter";
 import { click, editInput, nextTick, getFixture, mount } from "@web/../tests/helpers/utils";
-import { makeMessagingEnv, MessagingServer } from "../helpers/helpers";
+import { makeTestEnv, TestServer } from "../helpers/helpers";
 import { Component, useState, xml } from "@odoo/owl";
 
 let target;
@@ -21,8 +21,8 @@ QUnit.module("mail", (hooks) => {
     QUnit.module("chatter");
 
     QUnit.test("simple chatter on a record", async (assert) => {
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => {
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => {
             if (route.startsWith('/mail')) {
                 assert.step(route);
             }
@@ -39,8 +39,8 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("simple chatter, with no record", async (assert) => {
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => {
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => {
             if (route.startsWith('/mail')) {
                 assert.step(route);
             }
@@ -60,8 +60,8 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("composer is closed when creating record", async (assert) => {
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
         const props = { resId: 43, resModel: "somemodel", displayName: "" };
         const parent = await mount(ChatterParent, target, { env, props });
         assert.containsNone(target, ".o-mail-composer");
@@ -75,8 +75,8 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("composer has proper placeholder when sending message", async (assert) => {
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
         await mount(Chatter, target, {
             env,
             props: { resId: 43, resModel: "somemodel", displayName: "" },
@@ -92,8 +92,8 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("composer has proper placeholder when logging note", async (assert) => {
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
         await mount(Chatter, target, {
             env,
             props: { resId: 43, resModel: "somemodel", displayName: "" },
@@ -109,8 +109,8 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("send/log buttons are properly styled", async (assert) => {
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
         await mount(Chatter, target, {
             env,
             props: { resId: 43, resModel: "somemodel", displayName: "" },
@@ -132,8 +132,8 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("composer is focused", async (assert) => {
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
         await mount(Chatter, target, {
             env,
             props: { resId: 43, resModel: "somemodel", displayName: "" },
@@ -161,8 +161,8 @@ QUnit.module("mail", (hooks) => {
     });
 
     QUnit.test("displayname is used when sending a message", async (assert) => {
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => server.rpc(route, params));
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => server.rpc(route, params));
         await mount(Chatter, target, {
             env,
             props: { resId: 43, resModel: "somemodel", displayName: "Gnargl" },
@@ -174,8 +174,8 @@ QUnit.module("mail", (hooks) => {
 
     QUnit.test("can post a message on a record thread", async (assert) => {
         assert.expect(10);
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => {
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => {
             if (route.startsWith('/mail')) {
                 assert.step(route);
             }
@@ -220,8 +220,8 @@ QUnit.module("mail", (hooks) => {
 
     QUnit.test("can post a note on a record thread", async (assert) => {
         assert.expect(10);
-        const server = new MessagingServer();
-        const env = makeMessagingEnv((route, params) => {
+        const server = new TestServer();
+        const env = makeTestEnv((route, params) => {
             if (route.startsWith('/mail')) {
                 assert.step(route);
             }

--- a/addons/mail/static/tests/helpers/helpers.js
+++ b/addons/mail/static/tests/helpers/helpers.js
@@ -6,9 +6,9 @@ import { ormService } from "@web/core/orm_service";
 import { EventBus } from "@odoo/owl";
 import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
 
-export { MessagingServer } from "./messaging_server";
+export { TestServer } from "./test_server";
 
-export function makeMessagingEnv(rpc) {
+export function makeTestEnv(rpc) {
     const user = {
         context: { uid: 2 },
         partnerId: 3,

--- a/addons/mail/static/tests/helpers/test_server.js
+++ b/addons/mail/static/tests/helpers/test_server.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-export class MessagingServer {
+export class TestServer {
     activities = [];
     channels = [];
     chats = [];


### PR DESCRIPTION
This rename so that it's not misleadingly limited to `MessagingService`.