### PR TITLE
[FIX] mail: make "mail" test pass

### DIFF
--- a/addons/mail/static/tests/discuss/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/discuss_tests.js
@@ -21,7 +21,9 @@ QUnit.module("mail", (hooks) => {
     QUnit.test("sanity check", async (assert) => {
         const server = new MessagingServer();
         const env = makeMessagingEnv((route, params) => {
-            assert.step(route);
+            if (route.startsWith('/mail')) {
+                assert.step(route);
+            }
             return server.rpc(route, params);
         });
 
@@ -63,7 +65,9 @@ QUnit.module("mail", (hooks) => {
         const server = new MessagingServer();
         server.addChannel(1, "general", "General announcements...");
         const env = makeMessagingEnv((route, params) => {
-            assert.step(route);
+            if (route.startsWith('/mail')) {
+                assert.step(route);
+            }
             return server.rpc(route, params);
         });
         env.services["mail.messaging"].setDiscussThread(1);
@@ -83,7 +87,12 @@ QUnit.module("mail", (hooks) => {
     QUnit.test("can create a new channel", async (assert) => {
         const server = new MessagingServer();
         const env = makeMessagingEnv((route, params) => {
-            assert.step(route);
+            if (
+                route.startsWith('/mail') ||
+                ["/web/dataset/call_kw/mail.channel/search_read", "/web/dataset/call_kw/mail.channel/channel_create"].includes(route)
+            ) {
+                assert.step(route);
+            }
             return server.rpc(route, params);
         });
         await mount(Discuss, target, { env });
@@ -106,7 +115,12 @@ QUnit.module("mail", (hooks) => {
         const server = new MessagingServer();
         server.addPartner(43, "abc");
         const env = makeMessagingEnv((route, params) => {
-            assert.step(route);
+            if (
+                route.startsWith('/mail') ||
+                ["/web/dataset/call_kw/res.partner/im_search", "/web/dataset/call_kw/mail.channel/channel_get"].includes(route)
+            ) {
+                assert.step(route);
+            }
             if (route === "/web/dataset/call_kw/mail.channel/channel_get") {
                 assert.equal(params.kwargs.partners_to[0], 43);
             }

--- a/addons/mail/static/tests/form/chatter_tests.js
+++ b/addons/mail/static/tests/form/chatter_tests.js
@@ -23,7 +23,9 @@ QUnit.module("mail", (hooks) => {
     QUnit.test("simple chatter on a record", async (assert) => {
         const server = new MessagingServer();
         const env = makeMessagingEnv((route, params) => {
-            assert.step(route);
+            if (route.startsWith('/mail')) {
+                assert.step(route);
+            }
             return server.rpc(route, params);
         });
         await mount(Chatter, target, {
@@ -39,7 +41,9 @@ QUnit.module("mail", (hooks) => {
     QUnit.test("simple chatter, with no record", async (assert) => {
         const server = new MessagingServer();
         const env = makeMessagingEnv((route, params) => {
-            assert.step(route);
+            if (route.startsWith('/mail')) {
+                assert.step(route);
+            }
             return server.rpc(route, params);
         });
         await mount(Chatter, target, {
@@ -164,7 +168,7 @@ QUnit.module("mail", (hooks) => {
             props: { resId: 43, resModel: "somemodel", displayName: "Gnargl" },
         });
         await click($(target).find("button:contains(Send message)")[0]);
-        const msg = $(target).find("span:contains(Gnargl)")[0];
+        const msg = $(target).find("small:contains(Gnargl)")[0];
         assert.ok(msg);
     });
 
@@ -172,7 +176,9 @@ QUnit.module("mail", (hooks) => {
         assert.expect(10);
         const server = new MessagingServer();
         const env = makeMessagingEnv((route, params) => {
-            assert.step(route);
+            if (route.startsWith('/mail')) {
+                assert.step(route);
+            }
             if (route === "/mail/message/post") {
                 const expected = {
                     post_data: {
@@ -216,7 +222,9 @@ QUnit.module("mail", (hooks) => {
         assert.expect(10);
         const server = new MessagingServer();
         const env = makeMessagingEnv((route, params) => {
-            assert.step(route);
+            if (route.startsWith('/mail')) {
+                assert.step(route);
+            }
             if (route === "/mail/message/post") {
                 const expected = {
                     post_data: {


### PR DESCRIPTION
Follow-up of recent commits that introduced activity service in tests, and also slight chatter dom change.