### PR TITLE
[IMP] mail: improve emoji picker style

### DIFF
--- a/addons/mail/static/src/new/composer/emoji_picker.scss
+++ b/addons/mail/static/src/new/composer/emoji_picker.scss
@@ -9,18 +9,11 @@
         width: 30px;
         font-size: 1.5rem;
         &:hover {
-            background-color: #e9ecef;
+            background-color: $gray-300;
         }
     }
 
-    .o-mail-emoji-picker-top {
-        border-bottom: 1px solid gray;
-        .o-emoji:hover {
-            background-color: white;
-        }
-    }
-
-    .o-mail-emoji-picker-search {
-        border-bottom: 1px solid gray;
+    .o-mail-emoji-picker-top .o-emoji:not(:hover):not(.o-isActive) {
+        filter: grayscale(1);
     }
 }

--- a/addons/mail/static/src/new/composer/emoji_picker.xml
+++ b/addons/mail/static/src/new/composer/emoji_picker.xml
@@ -2,17 +2,20 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.emoji_picker" owl="1">
-    <div class="o-mail-emoji-picker" t-on-click="onClick">
-        <div class="o-mail-emoji-picker-top d-flex align-items-center bg-200" t-on-click="selectCategory">
+    <div class="o-mail-emoji-picker bg-white" t-on-click="onClick">
+        <div class="o-mail-emoji-picker-top d-flex align-items-center border-bottom overflow-auto bg-100" t-on-click="selectCategory">
             <t t-foreach="categories" t-as="category" t-key="category.sortId">
-                <span class="o-emoji p-1 cursor-pointer" t-att-class="{'bg-white': category.sortId === state.categoryId}" t-att-title="category.name" t-att-data-id="category.sortId">
+                <span class="o-emoji text-center p-1 cursor-pointer" t-att-class="{'o-isActive bg-white': category.sortId === state.categoryId}" t-att-title="category.name" t-att-data-id="category.sortId">
                     <t t-esc="category.title"/>
                 </span>
             </t>
         </div>
-        <div class="o-mail-emoji-picker-search p-1 d-flex">
-            <input class="form-control border-0 flex-grow-1" t-ref="input" placeholder="Search an emoji" t-model="state.searchStr"/>
-            <i class="oi oi-search p-2 fs-5" title="Search..." role="img" aria-label="Search..."></i>
+        <div class="o-mail-emoji-picker-search p-1 d-flex flex-column">
+            <div class="d-flex">
+                <input class="form-control border-0 flex-grow-1" t-ref="input" placeholder="Search for an emoji" t-model="state.searchStr"/>
+                <i class="oi oi-search p-2 fs-5" title="Search..." role="img" aria-label="Search..."></i>
+            </div>
+            <hr class="mx-2 my-0 text-muted"/>
         </div>
         <div class="o-mail-emoji-picker-content overflow-auto d-flex flex-wrap align-content-start align-items-center" t-ref="emoji-grid" t-on-click="selectEmoji">
             <t t-set="current" t-value=""/>
@@ -20,11 +23,11 @@
                 <t t-if="!state.searchStr and current !== emoji.category">
                     <t t-set="current" t-value="emoji.category"/>
                     <t t-set="category" t-value="categories.find(c => c.name === current)"/>
-                    <div class="o-emoji-category w-100 fs-4 p-2" t-att-data-category="category.sortId">
+                    <div class="o-emoji-category w-100 fs-5 p-2" t-att-data-category="category.sortId">
                         <t t-esc="current"/>
                     </div>
                 </t>
-                <span class="o-emoji p-1 cursor-pointer" t-att-title="emoji.name" t-att-data-index="emoji_index" t-att-data-codepoints="emoji.codepoints">
+                <span class="o-emoji text-center p-1 cursor-pointer" t-att-title="emoji.name" t-att-data-index="emoji_index" t-att-data-codepoints="emoji.codepoints">
                     <t t-esc="emoji.codepoints"/>
                 </span>
             </t>


### PR DESCRIPTION
- visibly better in dark theme
- align emoji position
- grayscale on non-hover emoji top item
- softer separator between search bar and content

**White theme (before/after)**
<img width="286" alt="before-white" src="https://user-images.githubusercontent.com/6569390/201122216-d0c1c0aa-c2cc-48a6-8565-b2f0fdd6ba53.png">
<img width="287" alt="after-white" src="https://user-images.githubusercontent.com/6569390/201122138-68cef97b-a348-4bce-848b-4f55d1babc50.png">

**Dark theme (before/after)**
<img width="292" alt="before-dark" src="https://user-images.githubusercontent.com/6569390/201122403-64f2d9d8-575b-48a6-adbf-e4059893bf14.png">
<img width="286" alt="after-dark" src="https://user-images.githubusercontent.com/6569390/201122432-6a15c7bf-4248-4f67-9a6b-08acbee3687f.png">
