### PR TITLE
[FIX] mail: incorrect emoji selection when searching

### DIFF
--- a/addons/mail/static/src/composer/emoji_picker.js
+++ b/addons/mail/static/src/composer/emoji_picker.js
@@ -98,10 +98,9 @@ export class EmojiPicker extends Component {
     }
 
     selectEmoji(ev) {
-        const index = ev.target.dataset.index;
-        if (index) {
-            const emoji = this.emojis[index];
-            this.props.onSelect(emoji.codepoints);
+        const codepoints = ev.target.dataset.codepoints;
+        if (codepoints) {
+            this.props.onSelect(codepoints);
             this.props.close();
         }
     }

--- a/addons/mail/static/src/composer/emoji_picker.xml
+++ b/addons/mail/static/src/composer/emoji_picker.xml
@@ -24,7 +24,7 @@
                         <t t-esc="current"/>
                     </div>
                 </t>
-                <span class="o-emoji p-1 cursor-pointer" t-att-title="emoji.name" t-att-data-index="emoji_index">
+                <span class="o-emoji p-1 cursor-pointer" t-att-title="emoji.name" t-att-data-index="emoji_index" t-att-data-codepoints="emoji.codepoints">
                     <t t-esc="emoji.codepoints"/>
                 </span>
             </t>
@@ -33,4 +33,3 @@
 </t>
 
 </templates>
-


### PR DESCRIPTION
This commit fixes a bug where, when searching for an emoji, the emoji picker would insert the wrong emoji in the composer.