### PR TITLE
[FIX] mail: fix legacy emoji picker

### DIFF
--- a/addons/mail/static/src/models/emoji_registry.js
+++ b/addons/mail/static/src/models/emoji_registry.js
@@ -9,13 +9,13 @@ Model({
         async loadEmojiData() {
             this.update({ isLoading: true });
             await getBundle("mail.assets_model_data").then(loadBundle);
-            const { emojiCategoriesData, emojisData } = await odoo.runtimeImport(
+            const { categories, emojis } = await odoo.runtimeImport(
                 "@mail/new/composer/emoji_data"
             );
             if (!this.exists()) {
                 return;
             }
-            this._populateFromEmojiData(emojiCategoriesData, emojisData);
+            this._populateFromEmojiData(categories, emojis);
         },
         async _populateFromEmojiData(dataCategories, dataEmojis) {
             dataCategories.map((category) => {


### PR DESCRIPTION
Was not working due to recent rename of
exports in emoji_data.