### PR TITLE
[FIX] mail: proper refresh of views when updating activity

### DIFF
--- a/addons/mail/static/src/new/activity/activity_list_popover.js
+++ b/addons/mail/static/src/new/activity/activity_list_popover.js
@@ -9,7 +9,6 @@ import { Component, onWillUpdateProps, useState } from "@odoo/owl";
 export class ActivityListPopover extends Component {
     setup() {
         this.orm = useService("orm");
-        this.activity = useService("mail.activity");
         this.user = useService("user");
         this.state = useState({ activities: [] });
         this.updateFromProps(this.props);
@@ -17,7 +16,7 @@ export class ActivityListPopover extends Component {
     }
 
     onClickAddActivityButton() {
-        this.activity
+        this.env.services["mail.activity"]
             .scheduleActivity(
                 this.props.resModel,
                 this.props.resId,

--- a/addons/mail/static/src/new/activity/activity_list_popover_item.js
+++ b/addons/mail/static/src/new/activity/activity_list_popover_item.js
@@ -9,7 +9,6 @@ import { Component, useState } from "@odoo/owl";
 export class ActivityListPopoverItem extends Component {
     setup() {
         this.user = useService("user");
-        this.activityService = useService("mail.activity");
         this.state = useState({ hasMarkDoneView: false });
     }
 
@@ -46,7 +45,7 @@ export class ActivityListPopoverItem extends Component {
 
     onClickEditActivityButton() {
         this.props.onClickEditActivityButton();
-        this.activityService
+        this.env.services["mail.activity"]
             .scheduleActivity(
                 this.props.activity.res_model,
                 this.props.activity.res_id,


### PR DESCRIPTION
`useService` is incorrectly protecting async functions that don't actually depend on the component when the component is destroyed.