### PR TITLE
[FIX] mail: no horizontal scroll on long messaging menu item

### DIFF
--- a/addons/mail/static/src/new/messaging_menu/messaging_menu.xml
+++ b/addons/mail/static/src/new/messaging_menu/messaging_menu.xml
@@ -33,7 +33,7 @@
         <div class="m-1" style="width:40px;height:40px;">
             <img class="w-100 h-100 rounded-circle" alt="Thread Image" t-att-src="thread.imgUrl" />
         </div>
-        <div class="d-flex flex-column flex-grow-1 align-self-start m-2">
+        <div class="d-flex flex-column flex-grow-1 align-self-start m-2 overflow-auto">
             <div class="d-flex">
                 <span class="fw-bold text-600 text-truncate"><t t-esc="thread.name"/></span>
                 <span class="flex-grow-1"/>


### PR DESCRIPTION
By default flex items do not skrink below their content, as specified by `min-width: auto` as the default value.
Solution is either to set `min-width: 0`, or change value of `overflow` to something else than `visible`.

This commit fixes the issue by changing `overflow`.