### PR TITLE
[IMP] mail:tests: add some messaging menu tests coverage

### DIFF
--- a/addons/mail/static/src/new/messaging_menu/messaging_menu.xml
+++ b/addons/mail/static/src/new/messaging_menu/messaging_menu.xml
@@ -9,7 +9,7 @@
         </t>
         <t t-set-slot="default">
             <div class="o-mail-messaging-menu">
-                <div class="border-bottom d-flex flex-shrink-0" t-on-click="activateTab">
+                <div class="o-mail-messaging-menu-topbar border-bottom d-flex flex-shrink-0" t-on-click="activateTab">
                     <button class="btn btn-link" t-att-class="state.filter === 'all' ? 'fw-bolder' : 'text-500'" type="button" role="tab" data-tab-id="all">All</button>
                     <button class="btn btn-link" t-att-class="state.filter === 'chats' ? 'fw-bolder' : 'text-500'" type="button" role="tab" data-tab-id="chats">Chats</button>
                     <button class="btn btn-link" t-att-class="state.filter === 'channels' ? 'fw-bolder' : 'text-500'" type="button" role="tab" data-tab-id="channels">Channels</button>


### PR DESCRIPTION
Add test coverage of most of old test "basic rendering" of messaging menu

- initial assertion turned into single test of presence of messaging menu in systray
- dedicated test for topbar buttons

The "new messages" feature is still not implemented. That's why it's still in `skipRefactoring`