### PR TITLE
[FIX] mail: fix test_eslint (don't use class attributes syntax)

### DIFF
--- a/addons/mail/static/src/new/dropzone/dropzone_container.js
+++ b/addons/mail/static/src/new/dropzone/dropzone_container.js
@@ -5,20 +5,9 @@ import { Dropzone } from "@mail/new/dropzone/dropzone";
 import { Component, useExternalListener, useState, xml } from "@odoo/owl";
 
 export class DropzoneContainer extends Component {
-    static template = xml`
-        <t t-if="state.isDraggingFile">
-            <t t-foreach="[...props.dropzones]" t-as="dropzone" t-key="dropzone.id">
-                <Dropzone ref="dropzone.ref"/>
-            </t>
-        </t>
-    `;
-    static props = { dropzones: Object };
-    static components = { Dropzone };
-
-    isDraggingFile = false;
-    #dragCount = 0;
-
     setup() {
+        this.isDraggingFile = false;
+        this.dragCount = 0;
         this.state = useState({
             isDraggingFile: false,
         });
@@ -28,21 +17,33 @@ export class DropzoneContainer extends Component {
     }
 
     onDragEnter(ev) {
-        if (this.#dragCount === 0 && ev.dataTransfer?.types.includes("Files")) {
+        if (this.dragCount === 0 && ev.dataTransfer?.types.includes("Files")) {
             this.state.isDraggingFile = true;
         }
-        this.#dragCount++;
+        this.dragCount++;
     }
 
     onDragLeave(ev) {
-        this.#dragCount--;
-        if (this.#dragCount === 0) {
+        this.dragCount--;
+        if (this.dragCount === 0) {
             this.state.isDraggingFile = false;
         }
     }
 
     onDrop(ev) {
         this.state.isDraggingFile = false;
-        this.#dragCount = 0;
+        this.dragCount = 0;
     }
 }
+
+Object.assign(DropzoneContainer, {
+    components: { Dropzone },
+    props: { dropzones: Object },
+    template: xml`
+        <t t-if="state.isDraggingFile">
+            <t t-foreach="[...props.dropzones]" t-as="dropzone" t-key="dropzone.id">
+                <Dropzone ref="dropzone.ref"/>
+            </t>
+        </t>
+    `,
+});


### PR DESCRIPTION
Until runbot fails due to linter issues, we should not use ES2022 features. Only when it's a non-issue we can use these ES2022 features.