### PR TITLE
[FIX] mail: call settings padding around container

### DIFF
--- a/addons/mail/static/src/new/rtc/call_settings.xml
+++ b/addons/mail/static/src/new/rtc/call_settings.xml
@@ -2,11 +2,13 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.settings" owl="1">
-        <div class="py-2 fw-bolder text-700 text-truncate text-uppercase">
-            Voice Settings
-        </div>
-        <div>
-            Input Device
+        <div class="p-2">
+            <div class="py-2 fw-bolder text-700 text-truncate text-uppercase">
+                Voice Settings
+            </div>
+            <div>
+                Input Device
+            </div>
         </div>
     </t>
 


### PR DESCRIPTION
Content was to close to container contour