### PR TITLE
[REF] move set definition inside service

### DIFF
--- a/addons/mail/static/src/new/dropzone/dropzone_service.js
+++ b/addons/mail/static/src/new/dropzone/dropzone_service.js
@@ -4,10 +4,9 @@ import { registry } from "@web/core/registry";
 
 import { DropzoneContainer } from "@mail/new/dropzone/dropzone_container";
 
-const dropzones = new Set();
-
 export const dropzoneService = {
     start() {
+        const dropzones = new Set();
         registry.category("main_components").add("mail.DropzoneContainer", {
             Component: DropzoneContainer,
             props: { dropzones },


### PR DESCRIPTION
it feels like it is wrong to have a shared set between multiple dropzone service instances