### PR TITLE
[FIX] use onWillDestroy instead of onWillUnmount

### DIFF
--- a/addons/mail/static/src/new/dropzone/dropzone_hook.js
+++ b/addons/mail/static/src/new/dropzone/dropzone_hook.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import { onWillUnmount } from "@odoo/owl";
+import { onWillDestroy } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 
 export function useDropzone(target) {
     const service = useService("dropzone");
     const removeDropzone = service.add(target);
-    onWillUnmount(removeDropzone);
+    onWillDestroy(removeDropzone);
 }


### PR DESCRIPTION
remember, if something is done in the setup, it should be cleaned up in onWillDestroy, not onWillUnmount