### PR TITLE
[FIX] mail: chat window header dark theme compliant

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -210,10 +210,12 @@ For more specific needs, you may also assign custom-defined actions
             ('remove', 'mail/static/src/components/*/*.dark.scss'),
 
             'mail/static/src/new/**/*',
+            ('remove', 'mail/static/src/new/**/*.dark.scss'),
             ('remove', 'mail/static/src/new/composer/emoji_data.js'),
         ],
         "web.dark_mode_assets_backend": [
             'mail/static/src/components/*/*.dark.scss',
+            'mail/static/src/new/**/*.dark.scss',
         ],
         'web.assets_backend_prod_only': [
             'mail/static/src/main.js',

--- a/addons/mail/static/src/new/chat/chat_window.dark.scss
+++ b/addons/mail/static/src/new/chat/chat_window.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-chat-window-header {
+    --ChatWindowHeaderView-background-color: #{$o-gray-100};
+}

--- a/addons/mail/static/src/new/chat/chat_window.scss
+++ b/addons/mail/static/src/new/chat/chat_window.scss
@@ -16,7 +16,7 @@
 }
 
 .o-mail-chat-window-header {
+    background-color: var(--ChatWindowHeaderView-background-color, #{$o-brand-odoo});
     height: 36px;
-    background-color: $o-brand-odoo;
     color: #ffffff;
 }


### PR DESCRIPTION
Before:
<img width="344" alt="Screenshot 2022-12-01 at 17 37 24" src="https://user-images.githubusercontent.com/6569390/205108897-c31b3eab-cc08-48b2-be3d-8c9feafc85e3.png">

After:
<img width="341" alt="Screenshot 2022-12-01 at 17 37 00" src="https://user-images.githubusercontent.com/6569390/205108926-98604531-9f2d-4562-bfa5-f3e6f813dea7.png">
