### PR TITLE
[FIX] mail: remove useless css rule on `.o-mail-channel-member-name`

### DIFF
--- a/addons/mail/static/src/new/discuss/channel_member_list.scss
+++ b/addons/mail/static/src/new/discuss/channel_member_list.scss
@@ -6,7 +6,3 @@
     width: $o-mail-thread-avatar-size;
     height: $o-mail-thread-avatar-size;
 }
-
-.o-mail-channel-member-name {
-    min-width: 0;
-}


### PR DESCRIPTION
Text content overflow is already managed with `text-truncate`

Follow-up of https://github.com/odoo-dev/odoo/pull/1506#discussion_r1038039887