### PR TITLE
[FIX] mail: fix im_status crash on unknown partner

### DIFF
--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -265,21 +265,13 @@ export class Messaging {
                     break;
                 case "mail.record/insert":
                     {
-                        const receivedPartner = notif.payload.Partner;
-                        if (receivedPartner) {
-                            // If Partner in the payload is a single object
-                            if (receivedPartner.im_status) {
-                                const im_status = receivedPartner.im_status;
-                                const id = receivedPartner.id;
-                                this.state.partners[id].im_status = im_status;
-                            } else {
-                                // If Partner in the payload is an array of partners
-                                for (const partner of receivedPartner) {
-                                    if (partner.im_status) {
-                                        const im_status = partner.im_status;
-                                        const id = partner.id;
-                                        this.state.partners[id].im_status = im_status;
-                                    }
+                        if (notif.payload.Partner) {
+                            const partners = Array.isArray(notif.payload.Partner)
+                                ? notif.payload.Partner
+                                : [notif.payload.Partner];
+                            for (const partner of partners) {
+                                if (partner.im_status) {
+                                    Partner.insert(this.state, partner);
                                 }
                             }
                         }

--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -58,6 +58,7 @@ export class Messaging {
             },
             /** @type {Object.<number, import("@mail/new/core/follower_model").Follower>} **/
             followers: {},
+            /** @type {Object.<number, Partner>} */
             partners: {},
             partnerRoot: {},
             messages: {},

--- a/addons/mail/static/src/new/core/partner_model.js
+++ b/addons/mail/static/src/new/core/partner_model.js
@@ -7,22 +7,27 @@
  */
 
 export class Partner {
+    /** @type {number} */
+    id;
+    /** @type {string} */
+    name;
+    /** @type {'offline' | 'bot' | 'online' | 'away' | 'im_partner' | undefined} im_status */
+    im_status;
+
     /**
      * @param {import("@mail/new/core/messaging").Messaging['state']} state
      * @param {import("@mail/new/core/partner_model").Data} data
      * @returns {import("@mail/new/core/partner_model").Partner}
      */
     static insert(state, data) {
-        let partner;
-        if (data.id in state.partners) {
-            partner = state.partners[data.id];
-        } else {
+        let partner = state.partners[data.id];
+        if (!partner) {
             partner = new Partner();
+            partner._state = state;
+            state.partners[data.id] = partner;
+            // Get reactive version.
+            partner = state.partners[data.id];
         }
-        partner._state = state;
-        state.partners[data.id] = partner;
-        // return reactive version
-        partner = state.partners[data.id];
         const { id = partner.id, name = partner.name, im_status = partner.im_status } = data;
         Object.assign(partner, {
             id,

--- a/addons/mail/static/src/new/core/partner_model.js
+++ b/addons/mail/static/src/new/core/partner_model.js
@@ -13,14 +13,22 @@ export class Partner {
      * @returns {import("@mail/new/core/partner_model").Partner}
      */
     static insert(state, data) {
+        let partner;
         if (data.id in state.partners) {
-            return state.partners[data.id];
+            partner = state.partners[data.id];
+        } else {
+            partner = new Partner();
         }
-        let partner = new Partner(data);
         partner._state = state;
         state.partners[data.id] = partner;
         // return reactive version
         partner = state.partners[data.id];
+        const { id = partner.id, name = partner.name, im_status = partner.im_status } = data;
+        Object.assign(partner, {
+            id,
+            name,
+            im_status,
+        });
         if (
             partner.im_status !== "im_partner" &&
             !partner.is_public &&
@@ -30,10 +38,6 @@ export class Partner {
         }
         // return reactive version
         return partner;
-    }
-
-    constructor({ id, name }) {
-        Object.assign(this, { id, name, im_status: null });
     }
 
     get avatarUrl() {


### PR DESCRIPTION
Before this commit, the im_status notification coming from the bus would lead to a crash if the partner is not yet known. This is due to the fact that the notification handler assumes the partner exists thus writing on undefined.

This PR fixes this issue by inserting the partner instead of manually udpating its im_status. Therefore, the partner is either created or updated with the values received from the server.