### PR TITLE
[REF] mail: simplify Composer model 

### DIFF
--- a/addons/mail/static/src/new/composer/composer.xml
+++ b/addons/mail/static/src/new/composer/composer.xml
@@ -62,7 +62,7 @@
                     imagesHeight="50" />
             </div>
         </div>
-        <t t-if="props.composer.messageId">
+        <t t-if="props.composer.message">
             <span class="text-muted">escape to <a href="#" t-on-click="props.onDiscardCallback">cancel</a>, enter to <a href="#" t-on-click="editMessage">save</a></span>
         </t>
     </div>

--- a/addons/mail/static/src/new/core/thread_model.js
+++ b/addons/mail/static/src/new/core/thread_model.js
@@ -21,13 +21,17 @@ export class Thread {
         if (data.id in state.threads) {
             thread = state.threads[data.id];
         } else {
-            thread = new Thread();
+            thread = new Thread(state);
             thread._state = state;
         }
         thread.update(data);
         state.threads[thread.id] = thread;
         // return reactive version
         return state.threads[thread.id];
+    }
+
+    constructor(state) {
+        Composer.insert(state, { thread: this });
     }
 
     update(data) {
@@ -48,14 +52,10 @@ export class Thread {
             chatPartnerId: false,
             isAdmin: false,
             canLeave: canLeave || false,
-            composer: null,
             serverLastSeenMsgByCurrentUser: serverData ? serverData.seen_message_id : null,
         });
         for (const key in data) {
             this[key] = data[key];
-        }
-        if (!this.composer) {
-            this.composer = Composer.insert(this._state, { threadId: this.id });
         }
         if (this.type === "channel") {
             this._state.discuss.channels.threads.push(this.id);

--- a/addons/mail/static/src/new/thread/message.js
+++ b/addons/mail/static/src/new/thread/message.js
@@ -5,6 +5,7 @@ import { AttachmentList } from "@mail/new/thread/attachment_list";
 import { MessageInReplyTo } from "@mail/new/thread/message_in_reply_to";
 import { isEventHandled, markEventHandled } from "@mail/new/utils/misc";
 import { removeFromArrayWithPredicate } from "@mail/new/utils/arrays";
+import { convertBrToLineBreak } from "@mail/new/utils/format";
 import { onExternalClick } from "@mail/new/utils/hooks";
 import { Component, onPatched, useChildSubEnv, useRef, useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
@@ -165,8 +166,9 @@ export class Message extends Component {
      * @param {MouseEvent} ev
      */
     onClickEdit(ev) {
-        this.message.composer = ComposerModel.insert(this.messaging.state, {
-            messageId: this.props.message.id,
+        ComposerModel.insert(this.messaging.state, {
+            message: this.props.message,
+            textInputContent: convertBrToLineBreak(this.props.message.body),
         });
         this.state.isEditing = true;
     }


### PR DESCRIPTION
- rewrite Composer/insert
- pass Objects rather than IDs to Composer/insert
- add documentation for Composer model
- fix comments formatting of composer_model.js
- put Composer creation in Thread constructor
- properly separate create and update
- use ids instead of references
- composer: avoid overwriting fields with undefined
- pass state to Composer inserted in ThreadModel
- use update in composer constructor
- move check for identifyings in insert (Composer)