### PR TITLE
[IMP] mail: Add insert function to ChannelMember model

### DIFF
--- a/addons/mail/static/src/new/core/channel_member_model.js
+++ b/addons/mail/static/src/new/core/channel_member_model.js
@@ -5,10 +5,25 @@
  * @typedef Data
  * @property {number} id
  * @property {number} partnerId
+ * @property {number} threadId
  */
 export class ChannelMember {
-    constructor(_state, { id, partnerId }) {
-        Object.assign(this, { _state, id, partnerId });
+    static insert(state, data) {
+        let channelMember = state.channelMembers[data.id];
+        if (!channelMember) {
+            channelMember = new ChannelMember();
+            channelMember._state = state;
+            state.channelMembers[data.id] = channelMember;
+        }
+        Object.assign(channelMember, {
+            id: data.id,
+            partnerId: data.partnerId,
+            threadId: data.threadId || channelMember.threadId,
+        });
+        if (!channelMember.thread.channelMembers.includes(channelMember)) {
+            channelMember.thread.channelMembers.push(channelMember);
+        }
+        return channelMember;
     }
 
     get partner() {
@@ -29,5 +44,9 @@ export class ChannelMember {
 
     get isCurrentUser() {
         return this.partner.isCurrentUser;
+    }
+
+    get thread() {
+        return this._state.threads[this.threadId];
     }
 }

--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -56,6 +56,8 @@ export class Messaging {
                 uid: user.context.uid,
                 avatarUrl: `/web/image?field=avatar_128&id=${user.userId}&model=res.users`,
             },
+            /** @type {Object.<number, import("@mail/new/core/channel_member_model").ChannelMember>} */
+            channelMembers: {},
             /** @type {Object.<number, import("@mail/new/core/follower_model").Follower>} */
             followers: {},
             /** @type {Object.<number, Partner>} */

--- a/addons/mail/static/src/new/core/thread_model.js
+++ b/addons/mail/static/src/new/core/thread_model.js
@@ -6,6 +6,8 @@ import { Partner } from "./partner_model";
 export class Thread {
     /** @type {import("@mail/new/core/follower_model").Follower[]} */
     followers = [];
+    /** @type {import("@mail/new/core/channel_member_model").channelMember[]} */
+    channelMembers = [];
     /** @type {import("@mail/new/core/messaging").Messaging['state']} */
     _state;
 
@@ -48,7 +50,6 @@ export class Thread {
             canLeave: canLeave || false,
             composer: null,
             serverLastSeenMsgByCurrentUser: serverData ? serverData.seen_message_id : null,
-            channelMembers: [],
         });
         for (const key in data) {
             this[key] = data[key];

--- a/addons/mail/static/src/new/discuss/channel_member_list.js
+++ b/addons/mail/static/src/new/discuss/channel_member_list.js
@@ -22,7 +22,6 @@ export class ChannelMemberList extends Component {
             fields,
             {}
         );
-        const members = [];
         for (const mailChannelMember of results) {
             const partnerId = mailChannelMember.partner_id[0];
             const name = mailChannelMember.partner_id[1];
@@ -30,11 +29,12 @@ export class ChannelMemberList extends Component {
                 id: partnerId,
                 name: name,
             });
-            members.push(
-                new ChannelMember(this.messaging.state, { id: mailChannelMember.id, partnerId })
-            );
+            ChannelMember.insert(this.messaging.state, {
+                id: mailChannelMember.id,
+                partnerId,
+                threadId: props.thread.id,
+            });
         }
-        props.thread.channelMembers = members;
     }
 
     openChatAvatar(member) {


### PR DESCRIPTION
By this commit, channelMembers moves to massaging state and every channel gets its channelMembers from the messaging state by its threadId