### PR TITLE
[FIX] mail: transient message as latest message

### DIFF
--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -436,14 +436,14 @@ export class Messaging {
 
     async fetchThreadMessagesNew(threadId) {
         const thread = this.state.threads[threadId];
-        const min = thread.mostRecentMsgId;
+        const min = thread.mostRecentNonTransientMessage?.id;
         const fetchedMsgs = await this.fetchThreadMessages(thread, { min });
-        const mostRecentMsgId = thread.mostRecentMsgId;
+        const mostRecentNonTransientMessage = thread.mostRecentNonTransientMessage;
         if (thread.isUnread && ["chat", "channel"].includes(thread.type)) {
             if (fetchedMsgs.length > 0) {
                 this.rpc("/mail/channel/set_last_seen_message", {
                     channel_id: thread.id,
-                    last_message_id: mostRecentMsgId,
+                    last_message_id: mostRecentNonTransientMessage?.id,
                 });
             }
         }
@@ -459,7 +459,7 @@ export class Messaging {
     async fetchThreadMessagesMore(threadId) {
         const thread = this.state.threads[threadId];
         const fetchedMsgs = await this.fetchThreadMessages(thread, {
-            max: thread.oldestMsgId,
+            max: thread.oldestNonTransientMessage?.id,
         });
         if (fetchedMsgs.length < FETCH_MSG_LIMIT) {
             thread.loadMore = false;

--- a/addons/mail/static/src/new/core/thread_model.js
+++ b/addons/mail/static/src/new/core/thread_model.js
@@ -122,15 +122,28 @@ export class Thread {
         return Math.max(...this.messages);
     }
 
+    get mostRecentNonTransientMessage() {
+        if (this.messages.length === 0) {
+            return undefined;
+        }
+        const oldestNonTransientMessageId = [...this.messages]
+            .reverse()
+            .find((messageId) => Number.isInteger(messageId));
+        return this._state.messages[oldestNonTransientMessageId];
+    }
+
     get isEmpty() {
         return this.messages.length === 0;
     }
 
-    get oldestMsgId() {
+    get oldestNonTransientMessage() {
         if (this.messages.length === 0) {
             return undefined;
         }
-        return Math.min(...this.messages);
+        const oldestNonTransientMessageId = this.messages.find((messageId) =>
+            Number.isInteger(messageId)
+        );
+        return this._state.messages[oldestNonTransientMessageId];
     }
 
     sortMessages() {

--- a/addons/mail/static/src/new/thread/thread.js
+++ b/addons/mail/static/src/new/thread/thread.js
@@ -21,13 +21,13 @@ export class Thread extends Component {
         this.messagesRef = useRef("messages");
         this.pendingLoadMore = false;
         this.loadMoreState = useVisible("load-more", () => this.loadMore());
-        this.oldestMessageId = null;
+        this.oldestNonTransientMessageId = null;
         useScrollSnapshot("messages", {
             onWillPatch: () => {
                 return {
                     hasMoreMsgsAbove:
-                        this.thread.oldestMsgId !== this.oldestMessageId &&
-                        this.props.order === "asc",
+                        this.thread.oldestNonTransientMessage?.id !==
+                            this.oldestNonTransientMessage && this.props.order === "asc",
                 };
             },
             onPatched: ({ hasMoreMsgsAbove, scrollTop, scrollHeight }) => {
@@ -37,14 +37,14 @@ export class Thread extends Component {
                     el.scrollTop = scrollTop + el.scrollHeight - scrollHeight;
                     this.pendingLoadMore = false;
                 }
-                this.oldestMessageId = this.thread.oldestMsgId;
+                this.oldestNonTransientMessage = this.thread.oldestNonTransientMessage?.id;
                 if (!wasPendingLoadMore) {
                     this.loadMore();
                 }
             },
         });
         onMounted(() => {
-            this.oldestMessageId = this.thread.oldestMsgId;
+            this.oldestNonTransientMessage = this.thread.oldestNonTransientMessage?.id;
             this.loadMore();
         });
         onWillStart(() => this.requestMessages(this.props.id));


### PR DESCRIPTION
when having transient message as the most recent message, triggering channel message fetch will throw an error (due to the transient message having a float id and shouldn't be taken into account).