### PR TITLE
[IMP] mail: composer selection state

### DIFF
--- a/addons/mail/static/src/new/composer/composer.xml
+++ b/addons/mail/static/src/new/composer/composer.xml
@@ -43,12 +43,12 @@
                 </div>
                 <div class="d-flex py-1 border-top bg-view" t-att-class="{'border-bottom': normal, 'border': extended }">
                     <div class="d-flex align-items-center px-2" >
-                        <button class="btn border-0 rounded-pill" t-ref="emoji-picker">
+                        <button class="btn border-0 rounded-pill" t-on-click="onClickAddEmoji" t-ref="emoji-picker">
                             <i class="fa fa-smile-o" role="img" aria-label="Emojis"/>
                         </button>
                         <FileUploader multiUpload="true" onUploaded.bind="onFileUpload">
                             <t t-set-slot="toggler">
-                                <button t-att-disabled="!state.active" class="btn fa fa-paperclip border-0 rounded-pill" title="Add attachment" aria-label="Add attachment" type="button" />
+                                <button t-att-disabled="!state.active" class="btn fa fa-paperclip border-0 rounded-pill" title="Add attachment" aria-label="Add attachment" type="button" t-on-click="onClickAddAttachment"/>
                             </t>
                         </FileUploader>
                     </div>

--- a/addons/mail/static/src/new/core/composer_model.js
+++ b/addons/mail/static/src/new/core/composer_model.js
@@ -7,6 +7,12 @@ export class Composer {
     textInputContent;
     /** @type {Thread} */
     thread;
+    /** @type {{ start: number, end: number, direction: "forward" | "backward" | "none"}}*/
+    selection = {
+        start: 0,
+        end: 0,
+        direction: "none",
+    };
 
     /**
      * @param {import("@mail/new/core/messaging").Messaging['state']} state

--- a/addons/mail/static/src/new/discuss/sidebar.js
+++ b/addons/mail/static/src/new/discuss/sidebar.js
@@ -8,6 +8,7 @@ import { useService } from "@web/core/utils/hooks";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { onExternalClick } from "@mail/new/utils/hooks";
 import { Component, useState } from "@odoo/owl";
+import { markEventHandled } from "../utils/misc";
 
 export class Sidebar extends Component {
     setup() {
@@ -22,7 +23,8 @@ export class Sidebar extends Component {
         });
     }
 
-    openThread(id) {
+    openThread(ev, id) {
+        markEventHandled(ev, "sidebar.openThread");
         this.messaging.setDiscussThread(id);
     }
 

--- a/addons/mail/static/src/new/discuss/sidebar.xml
+++ b/addons/mail/static/src/new/discuss/sidebar.xml
@@ -37,7 +37,7 @@
             'o-active bg-200': mailbox.id === messaging.state.discuss.threadId,
             'o-starred-box': mailbox.id === 'starred',
         }"
-        t-on-click="() => this.openThread(mailbox.id)"
+        t-on-click="(ev) => this.openThread(ev, mailbox.id)"
     >
         <ThreadIcon className="'ms-4 me-2'" thread="mailbox"/>
         <div class="me-2 text-truncate">
@@ -103,7 +103,7 @@
             'o-active bg-200': threadId === messaging.state.discuss.threadId,
             'o-unread': thread.isUnread,
         }"
-        t-on-click="() => this.openThread(threadId)"
+        t-on-click="(ev) => this.openThread(ev, threadId)"
     >
         <div class="o-mail-background-inherit position-relative d-flex ms-4 flex-shrink-0" style="width:30px;height:30px">
             <img class="w-100 h-100 rounded-circle" t-att-src="thread.imgUrl" alt="Thread Image"/>
@@ -118,7 +118,7 @@
                 <i t-attf-class="fa fa-cog {{ hover_class }}" title="Channel settings" t-on-click.stop="() => this.openSettings(thread)" role="img"/>
             </t>
             <t t-if="thread.canLeave">
-                <div class="fa fa-times ms-1" t-attf-class="{{ hover_class }}" 
+                <div class="fa fa-times ms-1" t-attf-class="{{ hover_class }}"
                     t-on-click.stop="() => this.leaveChannel(thread)" title="Leave this channel" role="img"/>
             </t>
         </div>

--- a/addons/mail/static/src/new/utils/hooks.js
+++ b/addons/mail/static/src/new/utils/hooks.js
@@ -276,7 +276,7 @@ export function useAttachmentUploader({ threadId, messageId }) {
             ];
         abortByUploadId[upload.id] = upload.xhr.abort.bind(upload.xhr);
         state.attachments.push({
-            extension: upload.title.split('.').pop(),
+            extension: upload.title.split(".").pop(),
             filename: upload.title,
             id: upload.id,
             mimetype: upload.type,
@@ -306,7 +306,7 @@ export function useAttachmentUploader({ threadId, messageId }) {
             ];
         const attachment = {
             ...response,
-            extension: upload.title.split('.').pop(),
+            extension: upload.title.split(".").pop(),
             originThread,
         };
         const index = state.attachments.findIndex(({ id }) => id === upload.id);
@@ -322,4 +322,43 @@ export function useAttachmentUploader({ threadId, messageId }) {
     });
 
     return state;
+}
+
+export function useSelection({ refName, model, preserveOnClickAwayPredicate = () => false }) {
+    const ref = useRef(refName);
+    function onSelectionChange() {
+        if (document.activeElement && document.activeElement === ref.el) {
+            Object.assign(model, {
+                start: ref.el.selectionStart,
+                end: ref.el.selectionEnd,
+                direction: ref.el.selectionDirection,
+            });
+        }
+    }
+    function clear() {
+        ref.el.selectionStart = ref.el.selectionEnd = ref.el.value.length;
+    }
+    onExternalClick(refName, async (ev) => {
+        if (await preserveOnClickAwayPredicate(ev)) {
+            return;
+        }
+        clear();
+        Object.assign(model, {
+            start: ref.el.selectionStart,
+            end: ref.el.selectionEnd,
+            direction: ref.el.selectionDirection,
+        });
+    });
+    onMounted(() => {
+        document.addEventListener("selectionchange", onSelectionChange);
+    });
+    onWillUnmount(() => {
+        document.removeEventListener("selectionchange", onSelectionChange);
+    });
+    return {
+        clear,
+        restore() {
+            ref.el.setSelectionRange(model.start, model.end, model.direction);
+        },
+    };
 }


### PR DESCRIPTION
Restores master behavior for composer selection that is:
- Keep selection when selecting an emoji (thus replacing the selected text by the emoji)
- Keep selection when uploading and attachment
- Keep selection when switching channels, restoring the selection when switching back to the channel having selected text.