### PR TITLE
[FIX] mail: fix attachment loading spinner when creating record

### DIFF
--- a/addons/mail/static/src/new/views/chatter.js
+++ b/addons/mail/static/src/new/views/chatter.js
@@ -66,6 +66,7 @@ export class Chatter extends Component {
         onWillStart(() => this.load());
         onWillUpdateProps((nextProps) => {
             if (nextProps.resId !== this.props.resId) {
+                this.state.isLoadingAttachments = false;
                 this.load(nextProps.resId);
                 if (nextProps.resId === false) {
                     this.state.composing = false;
@@ -90,7 +91,6 @@ export class Chatter extends Component {
     }
 
     load(resId = this.props.resId, requestList = ["followers", "attachments", "messages"]) {
-        this.state.isLoadingAttachments = requestList.includes("attachments");
         const { resModel } = this.props;
         const thread = this.messaging.getChatterThread(resModel, resId);
         this.thread = thread;
@@ -98,6 +98,7 @@ export class Chatter extends Component {
             // todo: reset activities/attachments/followers
             return;
         }
+        this.state.isLoadingAttachments = requestList.includes("attachments");
         if (this.props.hasActivity && !requestList.includes("activities")) {
             requestList.push("activities");
         }

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -167,7 +167,11 @@ function getOpenDiscuss(webClient, { context = {}, params = {}, ...props } = {})
 function getOpenFormView(openView) {
     return async function openFormView(
         action,
-        { props, waitUntilDataLoaded = true, waitUntilMessagesLoaded = true } = {}
+        {
+            props,
+            waitUntilDataLoaded = Boolean(action.res_id),
+            waitUntilMessagesLoaded = Boolean(action.res_id),
+        } = {}
     ) {
         action["views"] = [[false, "form"]];
         const func = () => openView(action, props);


### PR DESCRIPTION
Before this commit, the attachment button would have shown the loading spinner when creating a new record.

This was due to the fact that the loading state was based on the request list passed to the `mail/thread/data` route. The spinner was removed after receiving the answer.

In the case of non yet created record, the load method returns without calling the server, thus preventing the load state to end.

This PR fixes this issue by setting the load state when we are sure that the record exists.