### PR TITLE
[IMP] mail: better composer state in chatter

### DIFF
--- a/addons/mail/static/src/new/composer/composer.js
+++ b/addons/mail/static/src/new/composer/composer.js
@@ -224,7 +224,7 @@ export class Composer extends Component {
             const { id: parentId, isNote, resId, resModel } = messageToReplyTo || {};
             const postData = {
                 attachments: this.attachmentUploader.attachments,
-                isNote: this.props.type === "note" || isNote,
+                isNote: this.props.composer.type === "note" || isNote,
                 parentId,
             };
             if (messageToReplyTo && this.props.composer.thread.id === "inbox") {
@@ -282,7 +282,6 @@ Object.assign(Composer, {
     defaultProps: {
         mode: "normal",
         onDiscardCallback: () => {},
-        type: "message",
     }, // mode = compact, normal, extended
     props: [
         "composer",
@@ -292,7 +291,6 @@ Object.assign(Composer, {
         "onPostCallback?",
         "mode?",
         "placeholder?",
-        "type?",
         "dropzoneRef?",
     ],
     template: "mail.composer",

--- a/addons/mail/static/src/new/core/composer_model.js
+++ b/addons/mail/static/src/new/core/composer_model.js
@@ -13,6 +13,8 @@ export class Composer {
         end: 0,
         direction: "none",
     };
+    /** @typedef {'message' | 'note'| false} */
+    type;
 
     /**
      * @param {import("@mail/new/core/messaging").Messaging['state']} state
@@ -42,6 +44,7 @@ export class Composer {
         }
         Object.assign(this, {
             textInputContent: "",
+            type: thread?.type === "chatter" ? false : "message",
             _state: state,
         });
         return this.update(data);

--- a/addons/mail/static/src/new/core/thread_model.js
+++ b/addons/mail/static/src/new/core/thread_model.js
@@ -21,17 +21,13 @@ export class Thread {
         if (data.id in state.threads) {
             thread = state.threads[data.id];
         } else {
-            thread = new Thread(state);
+            thread = new Thread();
             thread._state = state;
         }
         thread.update(data);
         state.threads[thread.id] = thread;
         // return reactive version
         return state.threads[thread.id];
-    }
-
-    constructor(state) {
-        Composer.insert(state, { thread: this });
     }
 
     update(data) {
@@ -80,6 +76,7 @@ export class Thread {
                 }
             }
         }
+        Composer.insert(this._state, { thread: this });
     }
 
     /**

--- a/addons/mail/static/src/new/views/chatter.js
+++ b/addons/mail/static/src/new/views/chatter.js
@@ -39,7 +39,6 @@ export class Chatter extends Component {
             activities: [],
             attachments: [],
             showActivities: true,
-            composing: false, // false, 'message' or 'note'
             isAttachmentBoxOpened: this.props.isAttachmentBoxOpenedInitially,
             isLoadingAttachments: false,
         });
@@ -53,7 +52,7 @@ export class Chatter extends Component {
         });
         useDropzone(this.rootRef, {
             onDrop: (ev) => {
-                if (this.state.composing) {
+                if (this.thread.composer.type) {
                     return;
                 }
                 if (isDragSourceExternalFile(ev.dataTransfer)) {
@@ -69,7 +68,7 @@ export class Chatter extends Component {
                 this.state.isLoadingAttachments = false;
                 this.load(nextProps.resId);
                 if (nextProps.resId === false) {
-                    this.state.composing = false;
+                    this.thread.composer.type = false;
                 }
             }
         });
@@ -187,10 +186,10 @@ export class Chatter extends Component {
     }
 
     toggleComposer(mode = false) {
-        if (this.state.composing === mode) {
-            this.state.composing = false;
+        if (this.thread.composer.type === mode) {
+            this.thread.composer.type = false;
         } else {
-            this.state.composing = mode;
+            this.thread.composer.type = mode;
         }
     }
 

--- a/addons/mail/static/src/new/views/chatter.xml
+++ b/addons/mail/static/src/new/views/chatter.xml
@@ -4,10 +4,10 @@
 <t t-name="mail.chatter" owl="1">
     <div class="o-mail-chatter h-100 d-flex flex-column" t-att-class="props.resId === false ? 'o-chatter-disabled' : ''" t-ref="root">
         <div class="o-mail-chatter-topbar d-flex flex-shrink-0 flex-grow-0 pe-2 mb-2">
-            <button class="o-mail-chatter-topbar-send-message-button btn btn-odoo p-2 my-2 mx-3" t-att-class="{'btn-odoo': state.composing !== 'note'}" t-att-disabled="!props.resId" t-on-click="() => this.toggleComposer('message')">
+            <button class="o-mail-chatter-topbar-send-message-button btn p-2 my-2 mx-3" t-att-class="{'btn-odoo': thread.composer.type !== 'note'}" t-att-disabled="!props.resId" t-on-click="() => this.toggleComposer('message')">
                 Send message
             </button>
-            <button class="o-mail-chatter-topbar-log-note-button btn p-2 m-2" t-att-class="{'btn-odoo': state.composing === 'note'}" t-att-disabled="!props.resId" t-on-click="() => this.toggleComposer('note')">
+            <button class="o-mail-chatter-topbar-log-note-button btn p-2 m-2" t-att-class="{'btn-odoo': thread.composer.type === 'note'}" t-att-disabled="!props.resId" t-on-click="() => this.toggleComposer('note')">
                 Log note
             </button>
             <div class="border-bottom border-start flex-grow-1 d-flex">
@@ -71,13 +71,13 @@
                 <button t-if="!thread.followerOfCurrentUser" class="o-mail-chatter-topbar-follow btn btn-link text-600" t-on-click="onClickFollow">Follow</button>
             </div>
         </div>
-        <t t-if="state.composing">
-            <t t-if="state.composing === 'message'">
+        <t t-if="thread.composer.type">
+            <t t-if="thread.composer.type === 'message'">
                 <small class="px-3 pb-1 pt-2" style="margin-left:48px;"><em class="text-muted">To followers of:</em> <b class="px-1">"<t t-esc="props.displayName"/>"</b></small>
             </t>
-            <t t-set="placeholder" t-value="state.composing === 'message' ? 'Send a message to followers...' : 'Log an internal note...'"/>
-            <t t-set="type" t-value="state.composing === 'message' ? 'message' : 'note'"/>
-            <Composer composer="thread.composer" autofocus="true" mode="'extended'" onPostCallback.bind="toggleComposer" placeholder="placeholder" type="type" dropzoneRef="rootRef"/>
+            <t t-set="placeholder" t-value="thread.composer.type === 'message' ? 'Send a message to followers...' : 'Log an internal note...'"/>
+            <t t-set="type" t-value="thread.composer.type === 'message' ? 'message' : 'note'"/>
+            <Composer composer="thread.composer" autofocus="true" mode="'extended'" onPostCallback.bind="toggleComposer" placeholder="placeholder" dropzoneRef="rootRef"/>
             <hr/>
         </t>
         <div class="overflow-auto">


### PR DESCRIPTION
This PR focuses on improving the composer state in the chatter, especially when switching from aside to bottom chatter. This commit takes care of the following points (when switching between modes):
- Keeping the composer text.
- Keeping the current composer type (note/message).
- Keeping the toggle state of the composer.