### PR TITLE
[FIX] mail: selection when ref has been unmounted

### DIFF
--- a/addons/mail/static/src/new/utils/hooks.js
+++ b/addons/mail/static/src/new/utils/hooks.js
@@ -336,10 +336,16 @@ export function useSelection({ refName, model, preserveOnClickAwayPredicate = ()
         }
     }
     function clear() {
+        if (!ref.el) {
+            return;
+        }
         ref.el.selectionStart = ref.el.selectionEnd = ref.el.value.length;
     }
     onExternalClick(refName, async (ev) => {
         if (await preserveOnClickAwayPredicate(ev)) {
+            return;
+        }
+        if (!ref.el) {
             return;
         }
         clear();
@@ -358,7 +364,7 @@ export function useSelection({ refName, model, preserveOnClickAwayPredicate = ()
     return {
         clear,
         restore() {
-            ref.el.setSelectionRange(model.start, model.end, model.direction);
+            ref.el?.setSelectionRange(model.start, model.end, model.direction);
         },
     };
 }


### PR DESCRIPTION
Before this PR, the useSelection hook would access the element of its ref without checking if the element was defined. This makes the chatter crash when hidding the composer, and could also make a message in editing crash for the same reason.

This PR fixes the issue by guarding ref.el calls since they make no sense when the component is being unmounted.