### PR TITLE
[FIX] mail: fix message edit display

### DIFF
--- a/addons/mail/static/src/new/composer/composer.xml
+++ b/addons/mail/static/src/new/composer/composer.xml
@@ -11,7 +11,7 @@
                 t-att-class="{
                     'px-3 py-2 o-mail-extended-composer': extended,
                     'p-3': normal,
-                    'o-has-current-partner-avatar pe-3 ps-1': !this.env.inChatWindow,
+                    'o-has-current-partner-avatar pe-3 ps-1': !this.env.inChatWindow and thread,
                 }">
             <div class="o-mail-composer-sidebar-main flex-shrink-0" t-if="!compact">
                 <img class="o-mail-composer-avatar mt-1 rounded-circle" t-att-src="messaging.state.user.avatarUrl" alt="Avatar of user"/>


### PR DESCRIPTION
Before this PR, the display of a message in edit mode was broken: the grid kept a spot for the user avatar while there is no user avatar resulting in a large blank space between the bubble and the composer.

This PR fixes the issue.

before:
![image](https://user-images.githubusercontent.com/48757558/206230579-0cad8e43-a9bb-4c13-a0fa-586593d062e6.png)

after:
![image](https://user-images.githubusercontent.com/48757558/206230456-c5f8f49c-105e-402a-9cb0-f6d652e874b5.png)
