### PR TITLE
[FIX] mail: message color in edit mode

### DIFF
--- a/addons/mail/static/src/new/thread/message.xml
+++ b/addons/mail/static/src/new/thread/message.xml
@@ -89,11 +89,17 @@
                         </div>
                     </div>
                 </div>
-                <div t-else="" class="o-mail-message-editable-content flex-grow-1" t-att-class="{
-                    'p-1': message.isNote,
-                    'o-mail-message-body text-break mb-0 rounded-end-3 rounded-bottom-3 border p-3': !message.isNote,
-                }">
-                    <Composer autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'"/>
+                <div t-else="" class="position-relative">
+                    <div class="o-mail-message-bubble border rounded-end-3 rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100" t-att-class="{
+                            'bg-info-light border-info': !message.isAuthor,
+                            'bg-success-light border-success opacity-25': message.isAuthor,
+                        }"/>
+                    <div class="o-mail-message-editable-content position-relative flex-grow-1" t-att-class="{
+                        'p-1': message.isNote,
+                        'o-mail-message-body mb-0 p-3': !message.isNote,
+                    }">
+                        <Composer autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'"/>
+                    </div>
                 </div>
                 <AttachmentList
                     t-if="message.attachments.length > 0"


### PR DESCRIPTION
Message background in edit mode has been blank for some time. This PR fixes the issue by re-introducing the missing scss that has been removed.