### PR TITLE
[FIX] mail: composer with avatar misaligned on left

### DIFF
--- a/addons/mail/static/src/new/composer/composer.xml
+++ b/addons/mail/static/src/new/composer/composer.xml
@@ -11,7 +11,7 @@
                 t-att-class="{
                     'px-3 py-2 o-mail-extended-composer': extended,
                     'p-3': normal,
-                    'o-has-current-partner-avatar pe-3 ps-1': !this.env.inChatWindow and thread,
+                    'o-has-current-partner-avatar px-3': !this.env.inChatWindow and thread,
                 }">
             <div class="o-mail-composer-sidebar-main flex-shrink-0" t-if="!compact">
                 <img class="o-mail-composer-avatar mt-1 rounded-circle" t-att-src="messaging.state.user.avatarUrl" alt="Avatar of user"/>


### PR DESCRIPTION

Before:
![Screenshot 2022-12-07 at 22 39 19](https://user-images.githubusercontent.com/6569390/206302336-20066c46-abbc-41db-bb0d-3c5ca5c5f5e9.png)


After:
![Screenshot 2022-12-07 at 22 37 56](https://user-images.githubusercontent.com/6569390/206302386-15b57380-6df8-4ff1-b25b-95c604e81636.png)
