### PR TITLE
[FIX] mail: no blank footer for compact composer

### DIFF
--- a/addons/mail/static/src/new/composer/composer.xml
+++ b/addons/mail/static/src/new/composer/composer.xml
@@ -59,12 +59,11 @@
             </div>
             <div class="o-mail-composer-footer overflow-auto">
                 <AttachmentList
+                    t-if="attachmentUploader.attachments.length > 0"
                     attachments="attachmentUploader.attachments"
                     unlinkAttachment="attachmentUploader.unlink"
                     imagesHeight="50" />
-            </div>
-            <div t-if="thread and !env.inChatWindow" class="o-mail-composer-core-footer overflow-auto" t-att-class="{ 'o-composer-is-compact': compact, 'ms-0': !compact }">
-                <div class="o-mail-composer-is-typing">
+                <div t-if="thread and !compact" class="o-mail-composer-is-typing">
                     <Typing channel_id="thread.id" size="'medium'" />
                 </div>
             </div>


### PR DESCRIPTION

Before:
![Screenshot 2022-12-07 at 23 02 24](https://user-images.githubusercontent.com/6569390/206306164-d1450302-5141-4add-a703-3c90ea088e5a.png)

After:
![Screenshot 2022-12-07 at 23 01 35](https://user-images.githubusercontent.com/6569390/206306180-0351262b-9f60-4bb0-a4f6-3b07ccce34fe.png)
