### PR TITLE
[FIX] mail: starred/history reply to

### DIFF
--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -536,16 +536,6 @@ export class Messaging {
         }
     });
 
-    async postInboxReply(threadId, threadModel, body, postData) {
-        const thread = this.getChatterThread(threadModel, threadId);
-        const message = await this.postMessage(thread.id, body, postData);
-        this.env.services.notification.add(
-            sprintf(this.env._t('Message posted on "%s"'), message.recordName),
-            { type: "info" }
-        );
-        return message;
-    }
-
     async postMessage(threadId, body, { attachments = [], isNote = false, parentId, rawMentions }) {
         const command = this.getCommandFromText(threadId, body);
         if (command) {
@@ -564,8 +554,8 @@ export class Messaging {
                 partner_ids: [],
                 subtype_xmlid: subtype,
             },
-            thread_id: threadId,
-            thread_model: "mail.channel",
+            thread_id: Number.isInteger(threadId) ? threadId : thread.resId,
+            thread_model: thread.resModel || "mail.channel",
         };
         if (parentId) {
             params.post_data.parent_id = parentId;

--- a/addons/mail/static/tests/new/discuss/discuss_tests.js
+++ b/addons/mail/static/tests/new/discuss/discuss_tests.js
@@ -13,6 +13,7 @@ import {
 } from "@web/../tests/helpers/utils";
 import { insertText, makeTestEnv, TestServer } from "../helpers/helpers";
 import { browser } from "@web/core/browser/browser";
+import { makeFakeNotificationService } from "@web/../tests/helpers/mock_services";
 import { loadEmoji } from "@mail/new/composer/emoji_picker";
 import { UPDATE_BUS_PRESENCE_DELAY } from "@bus/im_status_service";
 import { makeFakeNotificationService } from "@web/../tests/helpers/mock_services";
@@ -654,6 +655,82 @@ QUnit.module("mail", (hooks) => {
         assert.notOk(
             document.querySelector(".o-mail-message").classList.contains("o-selected"),
             "message should not longer be selected after posting reply"
+        );
+    });
+
+    QUnit.test("Can reply to starred message", async function (assert) {
+        assert.expect(5);
+
+        const pyEnv = await startServer();
+        const mailChannelId = pyEnv["mail.channel"].create({ name: "RandomName" });
+        pyEnv["mail.message"].create({
+            body: "not empty",
+            model: "mail.channel",
+            starred_partner_ids: [pyEnv.currentPartnerId],
+            res_id: mailChannelId,
+        });
+        const { click, insertText, openDiscuss } = await start({
+            discuss: {
+                context: {
+                    active_id: "starred",
+                },
+            },
+            services: {
+                notification: makeFakeNotificationService((message) => assert.step([message])),
+            },
+        });
+        await openDiscuss();
+        await click("i[aria-label='Reply']");
+        assert.containsOnce(
+            target,
+            ".o-mail-composer-origin-thread:contains('RandomName')",
+            "Composer should display origin thread of the message to reply to"
+        );
+        await insertText(".o-mail-composer-textarea", "abc");
+        await click(".o-mail-composer-send-button");
+        assert.verifySteps(['Message posted on "RandomName"']);
+        assert.containsOnce(
+            target,
+            ".o-mail-message",
+            "Reply should not be visible on starred mailbox"
+        );
+    });
+
+    QUnit.test("Can reply to history message", async function (assert) {
+        assert.expect(5);
+
+        const pyEnv = await startServer();
+        const mailChannelId = pyEnv["mail.channel"].create({ name: "RandomName" });
+        pyEnv["mail.message"].create({
+            body: "not empty",
+            model: "mail.channel",
+            history_partner_ids: [pyEnv.currentPartnerId],
+            res_id: mailChannelId,
+        });
+        const { click, insertText, openDiscuss } = await start({
+            discuss: {
+                context: {
+                    active_id: "history",
+                },
+            },
+            services: {
+                notification: makeFakeNotificationService((message) => assert.step(message)),
+            },
+        });
+        await openDiscuss();
+        await click("i[aria-label='Reply']");
+        assert.containsOnce(
+            target,
+            ".o-mail-composer-origin-thread:contains('RandomName')",
+            "Composer should display origin thread of the message to reply to"
+        );
+        await insertText(".o-mail-composer-textarea", "abc");
+        await click(".o-mail-composer-send-button");
+        assert.verifySteps(['Message posted on "RandomName"']);
+        assert.containsOnce(
+            target,
+            ".o-mail-message",
+            "Reply should not be visible on history mailbox"
         );
     });
 });


### PR DESCRIPTION
Before this commit, the reply to action was available on starred/history messages but was not handled correctly. On the master branch, this functionnality is not available.

It costs nothing and makes no sense to disable this option for the two other mailboxes.

This commit fixes the issue thus allowing to reply to messages in any mailbox.