### PR TITLE
[FIX] mail: suggestion partners search

### DIFF
--- a/addons/mail/static/src/new/core/partner_model.js
+++ b/addons/mail/static/src/new/core/partner_model.js
@@ -82,7 +82,7 @@ export class Partner {
             // would be notified to the mentioned partner, so this prevents
             // from inadvertently leaking the private message to the
             // mentioned partner.
-            partners = thread.channelMembers;
+            partners = thread.channelMembers.map((member) => member.partner);
         } else {
             partners = Object.values(state.partners);
         }

--- a/addons/mail/static/src/new/core/thread_model.js
+++ b/addons/mail/static/src/new/core/thread_model.js
@@ -96,11 +96,7 @@ export class Thread {
             }
             if (this.type === "chat") {
                 for (const elem of serverData.channel.channelMembers[0][1]) {
-                    Partner.insert(this._state, {
-                        id: elem.persona.partner.id,
-                        name: elem.persona.partner.name,
-                        email: elem.persona.partner.email,
-                    });
+                    Partner.insert(this._state, elem.persona.partner);
                     if (
                         elem.persona.partner.id !== this._state.user.partnerId ||
                         (serverData.channel.channelMembers[0][1].length === 1 &&

--- a/addons/mail/static/src/new/discuss/channel_member_list.js
+++ b/addons/mail/static/src/new/discuss/channel_member_list.js
@@ -3,46 +3,16 @@
 import { Component, onWillUpdateProps, onWillStart } from "@odoo/owl";
 import { useMessaging } from "@mail/new/messaging_hook";
 import { PartnerImStatus } from "./partner_im_status";
-import { Partner } from "../core/partner_model";
-import { ChannelMember } from "../core/channel_member_model";
 
 export class ChannelMemberList extends Component {
     setup() {
         this.messaging = useMessaging();
-        onWillStart(() => this.fetchChannelMembers(this.props));
+        onWillStart(() => this.messaging.fetchChannelMembers(this.props.thread.id));
         onWillUpdateProps((nextProps) => {
             if (nextProps.thread.channelMembers.length === 0) {
-                this.fetchChannelMembers(nextProps);
+                this.messaging.fetchChannelMembers(nextProps.thread.id);
             }
         });
-    }
-
-    async fetchChannelMembers(props) {
-        const results = await this.messaging.orm.call(
-            "mail.channel",
-            "load_more_members",
-            [[props.thread.id]],
-            {
-                known_member_ids: props.thread.channelMembers.map(
-                    (channelMember) => channelMember.id
-                ),
-            }
-        );
-        const channelMembers = results["channelMembers"][0][1];
-        props.thread.memberCount = results["memberCount"];
-        for (const channelMember of channelMembers) {
-            const partnerId = channelMember["persona"]["partner"]["id"];
-            const name = channelMember["persona"]["partner"]["name"];
-            Partner.insert(this.messaging.state, {
-                id: partnerId,
-                name: name,
-            });
-            ChannelMember.insert(this.messaging.state, {
-                id: channelMember.id,
-                partnerId,
-                threadId: props.thread.id,
-            });
-        }
     }
 
     openChatAvatar(member) {

--- a/addons/mail/static/src/new/discuss/channel_member_list.xml
+++ b/addons/mail/static/src/new/discuss/channel_member_list.xml
@@ -20,7 +20,7 @@
             <span t-if="props.thread.unknownMemberCount === 1" class="mx-2 mt-2">And 1 other member.</span>
             <span t-if="props.thread.unknownMemberCount > 1" class="mx-2 mt-2">And <t t-esc="props.thread.unknownMemberCount"/> other members.</span>
             <div t-if="!props.thread.areAllMembersLoaded" class="mx-2 my-1">
-                <button class="btn btn-secondary" title="Load more" t-on-click.stop="() => this.fetchChannelMembers(props)">Load more</button>
+                <button class="btn btn-secondary" title="Load more" t-on-click.stop="() => messaging.fetchChannelMembers(props.thread.id)">Load more</button>
             </div>
         </div>
     </t>

--- a/addons/mail/static/tests/new/composer/composer_tests.js
+++ b/addons/mail/static/tests/new/composer/composer_tests.js
@@ -320,7 +320,7 @@ QUnit.test('display partner mention suggestions on typing "@"', async function (
     assert.containsNone(target, ".o-navigable-list--dropdown-item");
 
     await insertText(".o-mail-composer-textarea", "@");
-    assert.containsOnce(target, ".o-navigable-list--dropdown-item");
+    assert.containsN(target, ".o-navigable-list--dropdown-item", 3);
 });
 
 QUnit.test("show other channel member in @ mention", async function (assert) {
@@ -336,13 +336,12 @@ QUnit.test("show other channel member in @ mention", async function (assert) {
             [0, 0, { partner_id: resPartnerId }],
         ],
     });
-    const { click, insertText, openDiscuss } = await start({
+    const { insertText, openDiscuss } = await start({
         discuss: {
             context: { active_id: mailChannelId1 },
         },
     });
     await openDiscuss();
-    await click(`.o-mail-discuss-actions button[title="Show Member List"]`); // FIXME: load channel members
     await insertText(".o-mail-composer-textarea", "@");
     assert.containsOnce(target, ".o-navigable-list--dropdown-item:contains(TestPartner)");
 });
@@ -360,13 +359,12 @@ QUnit.test("select @ mention insert mention text in composer", async function (a
             [0, 0, { partner_id: resPartnerId }],
         ],
     });
-    const { click, insertText, openDiscuss } = await start({
+    const { insertText, openDiscuss } = await start({
         discuss: {
             context: { active_id: mailChannelId1 },
         },
     });
     await openDiscuss();
-    await click(`.o-mail-discuss-actions button[title="Show Member List"]`); // FIXME: load channel members
     await insertText(".o-mail-composer-textarea", "@");
     await afterNextRender(() =>
         $(target).find(".o-navigable-list--dropdown-item:contains(TestPartner)").click()

--- a/addons/mail/static/tests/new/discuss/channel_member_list_tests.js
+++ b/addons/mail/static/tests/new/discuss/channel_member_list_tests.js
@@ -152,14 +152,13 @@ QUnit.test(
     async function (assert) {
         // Test assumes at most 100 members are loaded at once.
         const pyEnv = await startServer();
-        const channel_member_ids = [[0, 0, { partner_id: pyEnv.currentPartnerId }]];
+        const channel_member_ids = [];
         for (let i = 0; i < 101; i++) {
             const resPartnerId1 = pyEnv["res.partner"].create({ name: "name" + i });
             channel_member_ids.push([0, 0, { partner_id: resPartnerId1 }]);
         }
         const mailChannelId = pyEnv["mail.channel"].create({
             name: "TestChanel",
-            channel_member_ids,
             channel_type: "channel",
         });
         const { click, openDiscuss } = await start({
@@ -170,6 +169,7 @@ QUnit.test(
             },
         });
         await openDiscuss();
+        pyEnv["mail.channel"].write([mailChannelId], { channel_member_ids });
         await click(".o-mail-discuss-actions button[title='Show Member List']");
         assert.containsOnce(target, "button:contains(Load more)");
     }
@@ -178,14 +178,13 @@ QUnit.test(
 QUnit.test("Load more button should load more members", async function (assert) {
     // Test assumes at most 100 members are loaded at once.
     const pyEnv = await startServer();
-    const channel_member_ids = [[0, 0, { partner_id: pyEnv.currentPartnerId }]];
+    const channel_member_ids = [];
     for (let i = 0; i < 101; i++) {
         const resPartnerId1 = pyEnv["res.partner"].create({ name: "name" + i });
         channel_member_ids.push([0, 0, { partner_id: resPartnerId1 }]);
     }
     const mailChannelId = pyEnv["mail.channel"].create({
         name: "TestChanel",
-        channel_member_ids,
         channel_type: "channel",
     });
     const { click, openDiscuss } = await start({
@@ -196,6 +195,7 @@ QUnit.test("Load more button should load more members", async function (assert) 
         },
     });
     await openDiscuss();
+    pyEnv["mail.channel"].write([mailChannelId], { channel_member_ids });
     await click(".o-mail-discuss-actions button[title='Show Member List']");
     await click("button[title='Load more']");
     assert.containsN(target, ".o-mail-channel-member", 102);

--- a/addons/mail/static/tests/new/discuss/discuss_tests.js
+++ b/addons/mail/static/tests/new/discuss/discuss_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { Discuss } from "@mail/new/discuss/discuss";
-import { start, startServer, afterNextRender } from "@mail/../tests/helpers/test_utils";
+import { start, startServer } from "@mail/../tests/helpers/test_utils";
 import {
     click,
     editInput,
@@ -14,7 +14,6 @@ import {
 import { insertText, makeTestEnv, TestServer } from "../helpers/helpers";
 import { browser } from "@web/core/browser/browser";
 import { loadEmoji } from "@mail/new/composer/emoji_picker";
-import { UPDATE_BUS_PRESENCE_DELAY } from "@bus/im_status_service";
 import { makeFakeNotificationService } from "@web/../tests/helpers/mock_services";
 
 let target;
@@ -401,9 +400,8 @@ QUnit.test("sidebar: chat im_status rendering", async function (assert) {
             channel_type: "chat",
         },
     ]);
-    const { advanceTime, openDiscuss } = await start({ hasTimeControl: true });
+    const { openDiscuss } = await start({ hasTimeControl: true });
     await openDiscuss();
-    await afterNextRender(() => advanceTime(UPDATE_BUS_PRESENCE_DELAY));
     assert.strictEqual(
         target.querySelectorAll(".o-mail-discuss-sidebar-threadIcon").length,
         3,


### PR DESCRIPTION
Currently, the channel member is not fetched until the channel member list is open. Should fetch the member once the channel is created and make the suggestion for partners working correctly. 
Also fix the problem where the email data is missing when creating `Partners` from `ChannelMember` Model
And changed some corresponding tests.