### PR TITLE
[FIX] mail: starred/history reply to

### DIFF
--- a/addons/mail/static/src/new/composer/composer.js
+++ b/addons/mail/static/src/new/composer/composer.js
@@ -141,12 +141,13 @@ export class Composer extends Component {
 
     get hasReplyToHeader() {
         const { messageToReplyTo } = this.messaging.state.discuss;
-        if (!messageToReplyTo || !this.props.composer.thread) {
+        const thread = this.props.composer.thread;
+        if (!messageToReplyTo || !thread) {
             return false;
         }
         return (
-            messageToReplyTo.resId === this.props.composer.thread.id ||
-            (this.props.composer.thread.id === "inbox" && messageToReplyTo.needaction)
+            messageToReplyTo.resId === thread.id ||
+            (thread.type === "mailbox" && thread.messages.includes(messageToReplyTo.id))
         );
     }
 
@@ -266,17 +267,19 @@ export class Composer extends Component {
     async sendMessage() {
         return this.processMessage(async (value) => {
             const { messageToReplyTo } = this.messaging.state.discuss;
-            const { id: parentId, isNote, resId, resModel } = messageToReplyTo || {};
+            const thread = messageToReplyTo?.originThread ?? this.props.composer.thread;
             const postData = {
                 attachments: this.attachmentUploader.attachments,
-                isNote: this.props.composer.type === "note" || isNote,
+                isNote: this.props.composer.type === "note" || messageToReplyTo?.isNote,
                 rawMentions: this.suggestion.rawMentions,
-                parentId,
+                parentId: messageToReplyTo?.id,
             };
-            if (messageToReplyTo && this.props.composer.thread.id === "inbox") {
-                await this.messaging.postInboxReply(resId, resModel, value, postData);
-            } else {
-                await this.messaging.postMessage(this.props.composer.thread.id, value, postData);
+            const message = await this.messaging.postMessage(thread.id, value, postData);
+            if (this.props.composer.thread.type === "mailbox") {
+                this.env.services.notification.add(
+                    sprintf(this.env._t('Message posted on "%s"'), message.recordName),
+                    { type: "info" }
+                );
             }
             this.suggestion.clearRawMentions();
             this.messaging.cancelReplyTo();

--- a/addons/mail/static/src/new/core/message_model.js
+++ b/addons/mail/static/src/new/core/message_model.js
@@ -230,7 +230,11 @@ export class Message {
             }
             return Thread.createLocalId({ model: this.resModel, id: this.resId });
         })();
-        return this._state.threads[threadLocalId];
+        return Thread.insert(this._state, {
+            id: threadLocalId,
+            resId: this.resId,
+            resModel: this.resModel,
+        });
     }
 
     get url() {

--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -2,7 +2,6 @@
 
 import { markup, reactive } from "@odoo/owl";
 import { Deferred } from "@web/core/utils/concurrency";
-import { sprintf } from "@web/core/utils/strings";
 import { memoize } from "@web/core/utils/functions";
 import { registry } from "@web/core/registry";
 import { prettifyMessageContent, convertBrToLineBreak, cleanTerm } from "@mail/new/utils/format";
@@ -544,16 +543,6 @@ export class Messaging {
         }
     });
 
-    async postInboxReply(threadId, threadModel, body, postData) {
-        const thread = this.getChatterThread(threadModel, threadId);
-        const message = await this.postMessage(thread.id, body, postData);
-        this.env.services.notification.add(
-            sprintf(this.env._t('Message posted on "%s"'), message.recordName),
-            { type: "info" }
-        );
-        return message;
-    }
-
     async postMessage(threadId, body, { attachments = [], isNote = false, parentId, rawMentions }) {
         const thread = this.state.threads[threadId];
         const command = this.getCommandFromText(thread.type, body);
@@ -572,8 +561,8 @@ export class Messaging {
                 partner_ids: [],
                 subtype_xmlid: subtype,
             },
-            thread_id: threadId,
-            thread_model: "mail.channel",
+            thread_id: Number.isInteger(threadId) ? threadId : thread.resId,
+            thread_model: thread.resModel || "mail.channel",
         };
         if (parentId) {
             params.post_data.parent_id = parentId;


### PR DESCRIPTION
Before this commit, the reply to action was available on starred/history messages but was not handled correctly. On the master branch, this functionnality is not available.

It costs nothing and makes no sense to disable this option for the two other mailboxes.

This commit fixes the issue thus allowing to reply to messages in any mailbox.