### PR TITLE
[FIX] mail: message model attachment origin thread

### DIFF
--- a/addons/mail/static/src/new/core/message_model.js
+++ b/addons/mail/static/src/new/core/message_model.js
@@ -115,7 +115,9 @@ export class Message {
             attachments: attachments.map((attachment) => ({
                 ...attachment,
                 extension: attachment.name.split(".").pop(),
-                originThread: Thread.insert(this._state, attachment.originThread[0][1]),
+                originThread: Array.isArray(attachment.originThread)
+                    ? Thread.insert(this._state, attachment.originThread[0][1])
+                    : attachment.originThread,
             })),
             author: data.author ? Partner.insert(this._state, data.author) : this.author,
             body,


### PR DESCRIPTION
Before this commit, the message model would have crashed when updating a message having already processed attachments. This was due to the fact that it assumed the origin thread was a command that is an array, while it can be a Thread object.

This commit fixes the issue.