### PR TITLE
[FIX] mail: starring reply displays parent message in starred inbox

### DIFF
--- a/addons/mail/static/src/new/core/message_model.js
+++ b/addons/mail/static/src/new/core/message_model.js
@@ -129,7 +129,7 @@ export class Message {
             linkPreviews: linkPreviews.map((data) => new LinkPreview(data)),
             needaction_partner_ids,
             parentMessage: this.parentMessage
-                ? Message.insert(this._state, this.parentMessage, thread)
+                ? Message.insert(this._state, this.parentMessage, this.parentMessage.originThread)
                 : undefined,
             recordName,
             resId,


### PR DESCRIPTION
Before this commit, starring a reply would have displayed its parent message in the starred mailbox after reloading the page.

This commit fixes the issue.