### PR TITLE
[FIX] mail: partner mention suggestions in chatter

### DIFF
--- a/addons/mail/static/src/new/core/partner_model.js
+++ b/addons/mail/static/src/new/core/partner_model.js
@@ -116,7 +116,7 @@ export class Partner {
             if (!isAInternalUser && isBInternalUser) {
                 return 1;
             }
-            if (thread && thread.serverData.channel) {
+            if (thread?.serverData?.channel) {
                 const isAMember = thread.serverData.channel.channelMembers[0][1].includes(a);
                 const isBMember = thread.serverData.channel.channelMembers[0][1].includes(b);
                 if (isAMember && !isBMember) {

--- a/addons/mail/static/tests/new/composer/composer_tests.js
+++ b/addons/mail/static/tests/new/composer/composer_tests.js
@@ -272,6 +272,19 @@ QUnit.test('display partner mention suggestions on typing "@"', async function (
     assert.containsN(target, ".o-composer-suggestion", 3);
 });
 
+QUnit.test('display partner mention suggestions on typing "@" in chatter', async function (assert) {
+    const pyEnv = await startServer();
+    const { click, insertText, openFormView } = await start();
+    await openFormView({
+        res_id: pyEnv.currentPartnerId,
+        res_model: "res.partner",
+    });
+    await click(".o-mail-chatter-topbar-send-message-button");
+    assert.containsNone(target, ".o-composer-suggestion");
+    await insertText(".o-mail-composer-textarea", "@");
+    assert.containsOnce(target, ".o-composer-suggestion:contains(Mitchell Admin)");
+});
+
 QUnit.test("show other channel member in @ mention", async function (assert) {
     const pyEnv = await startServer();
     const resPartnerId = pyEnv["res.partner"].create({


### PR DESCRIPTION
Before this commit, was a traceback when typing `@` mention in the chatter. The thread of composer assumes it has some `serverData`, but only channels have them.