### PR TITLE
[FIX] mail: better spacing between avatar and message in non-squashed

### DIFF
--- a/addons/mail/static/src/new/thread/message.xml
+++ b/addons/mail/static/src/new/thread/message.xml
@@ -2,10 +2,8 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.message" owl="1">
-    <div class="o-mail-message position-relative py-1 mt-1" t-att-class="{
+    <div class="o-mail-message position-relative py-1 mt-1 px-3" t-att-class="{
             'o-mail-is-author': message.isAuthoredByCurrentUser,
-            'px-3': !env.inChatWindow,
-            'px-1': env.inChatWindow,
             'o-highlighted bg-view shadow-lg': props.highlighted,
             'opacity-50': props.grayedOut,
         }"
@@ -14,7 +12,7 @@
     >
         <MessageInReplyTo t-if="message.parentMessage" alignedRight="isAlignedRight" message="message" onClick="props.onParentMessageClick"/>
         <div class="o-mail-message-core position-relative d-flex flex-shrink-0">
-            <div class="o-mail-message-sidebar d-flex flex-shrink-0 justify-content-center">
+            <div class="o-mail-message-sidebar d-flex flex-shrink-0" t-att-class="{ 'justify-content-end': isAlignedRight }">
                 <div t-if="!props.squashed" class="o-mail-avatar-container position-relative bg-view">
                     <img class="w-100 h-100 rounded-circle o_object_fit_cover o_redirect"
                         t-att-src="message.author and message.author.avatarUrl"


### PR DESCRIPTION

Before
<img width="348" alt="Screenshot 2022-12-14 at 16 07 39" src="https://user-images.githubusercontent.com/6569390/207633606-484d4c8a-9934-4a9a-891e-b505f5ab9ddd.png">
After
<img width="335" alt="Screenshot 2022-12-14 at 16 07 16" src="https://user-images.githubusercontent.com/6569390/207633631-f2711bb8-7363-4231-b704-a2883b758f5f.png">


=====================

Also increase padding of message in chat window, so that there's no
overlap with scroll bar.

![Dec-14-2022 16-12-15](https://user-images.githubusercontent.com/6569390/207633796-4c3e65fe-29db-42b6-b605-d1b38d0a419a.gif)

