### PR TITLE
[FIX] mail: Change messages sort function

### DIFF
--- a/addons/mail/static/src/new/core/message_model.js
+++ b/addons/mail/static/src/new/core/message_model.js
@@ -70,13 +70,13 @@ export class Message {
             message = new Message();
             message._state = state;
         }
-        message.update(data, thread);
+        message.update(state, data, thread);
         state.messages[message.id] = message;
         // return reactive version
         return state.messages[message.id];
     }
 
-    update(data, thread) {
+    update(state, data, thread) {
         const {
             attachment_ids: attachments = this.attachments,
             body = this.body,
@@ -127,6 +127,7 @@ export class Message {
             this.originThread.name = data.record_name;
         }
         this._updateReactions(data.messageReactionGroups);
+        state.messages[this.id] = this;
         if (thread) {
             if (!thread.messages.includes(this.id)) {
                 thread.messages.push(this.id);

--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -395,8 +395,8 @@ export class Messaging {
                             continue;
                         }
                         this.updateMessageStarredState(message, starred);
+                        this.state.discuss.starred.sortMessages();
                     }
-                    this.state.discuss.starred.messages.sort();
                     break;
                 }
                 case "mail.channel.member/seen": {
@@ -991,7 +991,9 @@ export class Messaging {
         message.isStarred = isStarred;
         if (isStarred) {
             this.state.discuss.starred.counter++;
-            this.state.discuss.starred.messages.push(message.id);
+            if (this.state.discuss.starred.messages.length > 0) {
+                this.state.discuss.starred.messages.push(message.id);
+            }
         } else {
             this.state.discuss.starred.counter--;
             removeFromArray(this.state.discuss.starred.messages, message.id);

--- a/addons/mail/static/src/new/core/thread_model.js
+++ b/addons/mail/static/src/new/core/thread_model.js
@@ -212,7 +212,14 @@ export class Thread {
     }
 
     sortMessages() {
-        this.messages.sort((msgId1, msgId2) => msgId1 - msgId2);
+        this.messages.sort((msgId1, msgId2) => {
+            const indicator = new Date(this._state.messages[msgId1].dateTime) - new Date(this._state.messages[msgId2].dateTime);
+            if (indicator) {
+                return indicator;
+            } else {
+                return msgId1 - msgId2;
+            }
+        });
     }
 
     get accessRestrictedToGroupText() {


### PR DESCRIPTION
By this commit, messages are sorted by their dateTime, if theere is a same datetime for two messages, then by id.