### PR TITLE
[FIX] mail: fix channel suggestions

### DIFF
--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -729,7 +729,8 @@ export class Messaging {
             partners.push(partner);
         }
         for (const threadId of rawMentionedThreadIds) {
-            const thread = this.state.threads[threadId];
+            const thread =
+                this.state.threads[Thread.createLocalId({ model: "mail.channel", id: threadId })];
             const index = body.indexOf(`#${thread.displayName}`);
             if (index === -1) {
                 continue;
@@ -1156,7 +1157,10 @@ export class Messaging {
             { search: term }
         );
         suggestedThreads.map((data) => {
-            Thread.insert(this.state, data);
+            Thread.insert(this.state, {
+                model: "mail.channel",
+                ...data,
+            });
         });
     }
 


### PR DESCRIPTION
Before this PR, the processing of the channel suggestions from the server caused a crash. This was due to the fact that a Thread.insert was done without any model.

Also, channel mentions could not be posted since it was retrieving the thread from its id instead of its local id.

This commit both the issues.