### PR TITLE
[FIX] mail: messaging menu fix

### DIFF
--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -793,18 +793,14 @@ export class Messaging {
     fetchPreviews = memoize(async () => {
         const ids = [];
         for (const thread of Object.values(this.state.threads)) {
-            if (thread.type === "channel" || thread.type === "chat") {
+            if (["channel", "group", "chat"].includes(thread.type)) {
                 ids.push(thread.id);
             }
         }
         if (ids.length) {
             const previews = await this.orm.call("mail.channel", "channel_fetch_preview", [ids]);
             for (const preview of previews) {
-                const thread = Thread.insert(this.state, {
-                    id: preview.id,
-                    model: "mail.channel",
-                    type: "channel",
-                });
+                const thread = this.state.threads[preview.id];
                 const data = Object.assign(preview.last_message, {
                     body: markup(preview.last_message.body),
                 });

--- a/addons/mail/static/src/new/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/new/messaging_menu/messaging_menu.js
@@ -34,8 +34,8 @@ export class MessagingMenu extends Component {
         if (filter === "all") {
             return previews;
         }
-        const target = filter === "chats" ? "chat" : "channel";
-        return previews.filter((preview) => preview.type === target);
+        const target = filter === "chats" ? ["chat", "group"] : "channel";
+        return previews.filter((preview) => target.includes(preview.type));
     }
 
     openDiscussion(threadLocalId) {

--- a/addons/mail/static/src/new/messaging_menu/messaging_menu.xml
+++ b/addons/mail/static/src/new/messaging_menu/messaging_menu.xml
@@ -37,7 +37,7 @@
         </div>
         <div class="d-flex flex-column flex-grow-1 align-self-start m-2 overflow-auto">
             <div class="d-flex">
-                <span class="fw-bold text-600 text-truncate"><t t-esc="preview.name"/></span>
+                <span class="fw-bold text-600 text-truncate"><t t-esc="preview.displayName"/></span>
                 <span class="flex-grow-1"/>
                 <small class="text-muted opacity-50 ms-2" t-if="preview.mostRecentMsg">
                     <RelativeTime datetime="preview.mostRecentMsg.dateTime" />


### PR DESCRIPTION
fix several things:
1. missing partner avatar in messaging menu;
2. chat with a partner should only display the partner's name;
3. chat type should not be overwritten in messaging menu by fetching a preview;
4. enable filter support for the group type