### PR TITLE
[FIX] mail: no crash on click non-viewable attachment

### DIFF
--- a/addons/mail/static/src/new/attachment_viewer/attachment_viewer_service.js
+++ b/addons/mail/static/src/new/attachment_viewer/attachment_viewer_service.js
@@ -20,6 +20,9 @@ export const attachmentViewerService = {
          * @param {import("@mail/new/core/attachment_model").Attachment[]} attachments
          */
         function open(attachment, attachments = []) {
+            if (!attachment.isViewable) {
+                return;
+            }
             if (attachments.length > 0) {
                 const viewableAttachments = attachments.filter(
                     (attachment) => attachment.isViewable


### PR DESCRIPTION
Before this commit, when an attachment list contains some viewable and non-viewable attachments, clicking on a non-viewable attachment crashes.

This commit fixes this issue, so that only clicking on viewable attachments in the list prompts the attachment viewer.