### PR TITLE
[FIX] mail: chat window name/date separator for current user

### DIFF
--- a/addons/mail/static/src/new/thread/message.xml
+++ b/addons/mail/static/src/new/thread/message.xml
@@ -32,7 +32,9 @@
                         </strong>
                     </span>
                     <small t-if="!message.isTransient" class="o-mail-message-date text-muted opacity-50 ms-2" t-att-title="message.dateTimeStr">
+                        <t t-if="!message.isAuthoredByCurrentUser or !env.inChatWindow">
                         -
+                        </t>
                         <RelativeTime datetime="message.dateTime" />
                     </small>
 


### PR DESCRIPTION
Before this commit, the separator between author name and date on messages was always displayed in the chat window. This is weird visually because the author name is not displayed.

This commit fixes the issue.