### PR TITLE
[FIX] mail: activity popover feedback min-height

### DIFF
--- a/addons/mail/static/src/new/activity/activity_markasdone_popover.scss
+++ b/addons/mail/static/src/new/activity/activity_markasdone_popover.scss
@@ -1,3 +1,3 @@
-.o_ActivityMarkDonePopoverContent_feedback {
+.o-mail-activity-mark-as-done-feedback {
     min-height: 70px;
 }


### PR DESCRIPTION
classname was changed during refactoring, but SCSS was still referring to old classname