### PR TITLE
[FIX] mail: register rtc services in mail/main.js

### DIFF
--- a/addons/mail/static/src/main.js
+++ b/addons/mail/static/src/main.js
@@ -13,6 +13,9 @@ import { systrayService } from "@mail/services/systray_service";
 import { makeMessagingToLegacyEnv } from "@mail/utils/make_messaging_to_legacy_env";
 
 import { registry } from "@web/core/registry";
+import { rtcService } from "./new/rtc/rtc_service";
+import { soundEffects } from "./new/sound_effects_service";
+import { userSettingsService } from "./new/user_settings_service";
 
 const messagingValuesService = {
     start() {
@@ -23,6 +26,9 @@ const messagingValuesService = {
 const serviceRegistry = registry.category("services");
 serviceRegistry.add("mail.activity", activityService);
 serviceRegistry.add("mail.messaging", newMessagingService);
+serviceRegistry.add("mail.rtc", rtcService);
+serviceRegistry.add("mail.soundEffects", soundEffects);
+serviceRegistry.add("mail.userSettings", userSettingsService);
 serviceRegistry.add("messaging", messagingService);
 serviceRegistry.add("messagingValues", messagingValuesService);
 serviceRegistry.add("systray_service", systrayService);

--- a/addons/mail/static/src/new/rtc/rtc_service.js
+++ b/addons/mail/static/src/new/rtc/rtc_service.js
@@ -1,6 +1,5 @@
 /** @odoo-module */
 
-import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 
 import { Rtc } from "./rtc";
@@ -55,5 +54,3 @@ export const rtcService = {
         return rtc;
     },
 };
-
-registry.category("services").add("mail.rtc", rtcService);

--- a/addons/mail/static/src/new/sound_effects_service.js
+++ b/addons/mail/static/src/new/sound_effects_service.js
@@ -1,7 +1,5 @@
 /** @odoo-module */
 
-import { registry } from "@web/core/registry";
-
 class SoundEffects {
     constructor(env) {
         this.soundEffects = {
@@ -72,5 +70,3 @@ export const soundEffects = {
         return new SoundEffects(env);
     },
 };
-
-registry.category("services").add("mail.soundEffects", soundEffects);

--- a/addons/mail/static/src/new/user_settings_service.js
+++ b/addons/mail/static/src/new/user_settings_service.js
@@ -2,8 +2,6 @@
 
 import { browser } from "@web/core/browser/browser";
 
-import { registry } from "@web/core/registry";
-
 class UserSettings {
     constructor(env, rpc, user) {
         this.rpc = rpc;
@@ -232,5 +230,3 @@ export const userSettingsService = {
         return new UserSettings(env, rpc, user);
     },
 };
-
-registry.category("services").add("mail.userSettings", userSettingsService);


### PR DESCRIPTION
Runbot failed in some bundles POS and MRP subcontracting because RTC services were registered for deployment but messaging was unavailable.

The correct fix is to not make rtc services elligible for deployment on these highly customised bundles, same as messaging.