### PR TITLE
[REF] mail: clean code of rtc (step 2)

### DIFF
--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -746,10 +746,10 @@ export class Messaging {
                 break;
         }
         if (rtcSessions.length > oldCount) {
-            this.soundEffects.play("channelJoin");
+            this.soundEffects.play("channel-join");
         }
         if (rtcSessions.length < oldCount) {
-            this.soundEffects.play("memberLeave");
+            this.soundEffects.play("member-leave");
         }
     }
 

--- a/addons/mail/static/src/new/rtc/call_action_list.js
+++ b/addons/mail/static/src/new/rtc/call_action_list.js
@@ -36,7 +36,7 @@ export class CallActionList extends Component {
         }
     }
     get cameraButtonTitle() {
-        if (this.rtc.state.sendUserVideo) {
+        if (this.rtc.state.sendCamera) {
             return _t("Stop camera");
         } else {
             return _t("Turn camera on");
@@ -57,7 +57,7 @@ export class CallActionList extends Component {
         }
     }
     get screenSharingButtonTitle() {
-        if (this.rtc.state.sendDisplay) {
+        if (this.rtc.state.sendScreen) {
             return _t("Stop screen sharing");
         } else {
             return _t("Share screen");
@@ -127,8 +127,6 @@ export class CallActionList extends Component {
         if (this.rtc.state.hasPendingRtcRequest) {
             return;
         }
-        await this.rtc.toggleCall(this.props.thread.id, {
-            startWithVideo: true,
-        });
+        await this.rtc.toggleCall(this.props.thread.id, true);
     }
 }

--- a/addons/mail/static/src/new/rtc/call_action_list.xml
+++ b/addons/mail/static/src/new/rtc/call_action_list.xml
@@ -35,20 +35,20 @@
                     </button>
                     <button class="o-mail-call-action-list-button o-mail-call-action-list-videoButton btn d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover"
                         t-att-class="{
-                            'o-isActive': rtc.state.sendUserVideo,
+                            'o-isActive': rtc.state.sendCamera,
                             'o-isSmall p-2': isSmall,
                             'p-3': !isSmall,
                         }"
                         t-att-aria-label="cameraButtonTitle"
                         t-att-title="cameraButtonTitle"
-                        t-on-click="() => this.rtc.toggleVideoBroadcast('user-video')">
+                        t-on-click="() => this.rtc.toggleVideoBroadcast('camera')">
                         <div class="o-mail-call-action-list-buttonIconWrapper fa-stack" t-att-class="{ 'o-isSmall': isSmall }">
-                            <i class="fa fa-video-camera fa-stack-1x" t-att-class="{ 'fa-lg': !isSmall, 'text-success': rtc.state.sendUserVideo }"/>
+                            <i class="fa fa-video-camera fa-stack-1x" t-att-class="{ 'fa-lg': !isSmall, 'text-success': rtc.state.sendCamera }"/>
                         </div>
                     </button>
                     <button t-if="!isMobileDevice" class="o-mail-call-action-list-button o-mail-call-action-list-videoButton btn d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover"
                         t-att-class="{
-                            'o-isActive': rtc.state.sendDisplay,
+                            'o-isActive': rtc.state.sendScreen,
                             'o-isSmall p-2': isSmall,
                             'p-3': !isSmall,
                         }"
@@ -56,7 +56,7 @@
                         t-att-title="screenSharingButtonTitle"
                         t-on-click="() => this.rtc.toggleVideoBroadcast('display')">
                         <div class="o-mail-call-action-list-buttonIconWrapper fa-stack" t-att-class="{ 'o-isSmall': isSmall }">
-                            <i class="fa fa-desktop fa-stack-1x" t-att-class="{ 'fa-lg': !isSmall, 'text-success': rtc.state.sendDisplay }"/>
+                            <i class="fa fa-desktop fa-stack-1x" t-att-class="{ 'fa-lg': !isSmall, 'text-success': rtc.state.sendScreen }"/>
                         </div>
                     </button>
                     <button t-if="!callView.isFullScreen" class="o-mail-call-action-list-button btn d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover"

--- a/addons/mail/static/src/new/sound_effects_service.js
+++ b/addons/mail/static/src/new/sound_effects_service.js
@@ -3,16 +3,19 @@
 class SoundEffects {
     constructor(env) {
         this.soundEffects = {
-            channelJoin: { defaultVolume: 0.3, path: "/mail/static/src/audio/channel_01_in" },
-            channelLeave: { path: "/mail/static/src/audio/channel_04_out" },
+            "channel-join": { defaultVolume: 0.3, path: "/mail/static/src/audio/channel_01_in" },
+            "channel-leave": { path: "/mail/static/src/audio/channel_04_out" },
             deafen: { defaultVolume: 0.15, path: "/mail/static/src/audio/deafen_new_01" },
-            incomingCall: { defaultVolume: 0.15, path: "/mail/static/src/audio/call_02_in_" },
-            memberLeave: { defaultVolume: 0.5, path: "/mail/static/src/audio/channel_01_out" },
+            "incoming-call": { defaultVolume: 0.15, path: "/mail/static/src/audio/call_02_in_" },
+            "member-leave": { defaultVolume: 0.5, path: "/mail/static/src/audio/channel_01_out" },
             mute: { defaultVolume: 0.2, path: "/mail/static/src/audio/mute_1" },
-            newMessage: { path: "/mail/static/src/audio/dm_02" },
-            pushToTalkOn: { defaultVolume: 0.05, path: "/mail/static/src/audio/ptt_push_1" },
-            pushToTalkOff: { defaultVolume: 0.05, path: "/mail/static/src/audio/ptt_release_1" },
-            screenSharing: { defaultVolume: 0.5, path: "/mail/static/src/audio/share_02" },
+            "new-message": { path: "/mail/static/src/audio/dm_02" },
+            "push-to-talk-on": { defaultVolume: 0.05, path: "/mail/static/src/audio/ptt_push_1" },
+            "push-to-talk-off": {
+                defaultVolume: 0.05,
+                path: "/mail/static/src/audio/ptt_release_1",
+            },
+            "screen-sharing": { defaultVolume: 0.5, path: "/mail/static/src/audio/share_02" },
             undeafen: { defaultVolume: 0.15, path: "/mail/static/src/audio/undeafen_new_01" },
             unmute: { defaultVolume: 0.2, path: "/mail/static/src/audio/unmute_1" },
         };

--- a/addons/mail/static/tests/new/call/call_tests.js
+++ b/addons/mail/static/tests/new/call/call_tests.js
@@ -25,7 +25,7 @@ QUnit.test("basic rendering", async function (assert) {
     assert.containsOnce(target, ".o-mail-call-participant-card-overlay:contains(Mitchell Admin)");
     assert.containsOnce(target, ".o-mail-call-action-list");
     assert.containsN(target, ".o-mail-call-action-list button", 6);
-    assert.containsOnce(target, ".o-mail-call-action-list button[aria-label='Unmute']");
+    assert.containsOnce(target, ".o-mail-call-action-list button[aria-label='Unmute']"); // FIXME depends on current browser navigation
     assert.containsOnce(target, ".o-mail-call-action-list button[aria-label='Deafen']");
     assert.containsOnce(target, ".o-mail-call-action-list button[aria-label='Turn camera on']");
     assert.containsOnce(target, ".o-mail-call-action-list button[aria-label='Share screen']");


### PR DESCRIPTION
[REF] mail: move handler in place with arrow function [REF] mail: remove _ prefix in rtc
  It's easier to read without _
[REF] mail: move RTC handle methods inline in handleNotification [REF] mail: turn positional on mandatory param event of notifyPeers [REF] mail: rtc some codestyle (more compact)
[REF] mail: make all param or recoverConnection positional (all mandatory) [REF] mail: make all notifyPeers param positional
[REF] mail: remove type param in notifyPeers (deduceable) [REF] mail: several code simplification of rtc
- method with no use of this become utility functions
- rename `setXState` => `setX`
- remove unused param in toggleCall/joinCall (e.g. startWithAudio) [REF] mail: rename rtc userVideo to camera
  Also rename "display" to "screen"
[REF] mail: turn sound effect name into kebab-case
[REF] mail: turn rtc updateRemoteTrack param into positional
[REF] mail: rename isNotifyPeersRPCInProgress to pendingNotifyPeers
[REF] mail: rename fallbackTimeout to recoverTimeouts (consistent naming)
[REF] mail: rename setSoundBroadcast to setTalking
[REF] mail: rename localAudioTrack methods to reset/refresh