### PR TITLE
[FIX] mail: cursor position after inserting emoji

### DIFF
--- a/addons/mail/static/src/new/composer/composer.js
+++ b/addons/mail/static/src/new/composer/composer.js
@@ -99,6 +99,7 @@ export class Composer extends Component {
         useEffect(
             (focus) => {
                 if (focus && this.ref.el) {
+                    this.selection.restore();
                     this.ref.el.focus();
                 }
             },
@@ -124,8 +125,7 @@ export class Composer extends Component {
                 if (!this.props.composer.forceCursorMove) {
                     return;
                 }
-                this.ref.el.selectionStart = this.props.composer.selection.start;
-                this.ref.el.selectionEnd = this.props.composer.selection.end;
+                this.selection.restore();
                 this.props.composer.forceCursorMove = false;
             },
             () => [this.props.composer.forceCursorMove]
@@ -411,6 +411,7 @@ export class Composer extends Component {
         const firstPart = textContent.slice(0, this.props.composer.selection.start);
         const secondPart = textContent.slice(this.props.composer.selection.end, textContent.length);
         this.props.composer.textInputContent = firstPart + str + secondPart;
+        this.selection.moveCursor((firstPart + str).length);
         this.state.autofocus++;
     }
 }

--- a/addons/mail/static/src/new/utils/hooks.js
+++ b/addons/mail/static/src/new/utils/hooks.js
@@ -386,5 +386,9 @@ export function useSelection({ refName, model, preserveOnClickAwayPredicate = ()
         restore() {
             ref.el?.setSelectionRange(model.start, model.end, model.direction);
         },
+        moveCursor(position) {
+            model.start = model.end = position;
+            ref.el.selectionStart = ref.el.selectionEnd = position;
+        }
     };
 }

--- a/addons/mail/static/tests/new/composer/composer_tests.js
+++ b/addons/mail/static/tests/new/composer/composer_tests.js
@@ -168,6 +168,28 @@ QUnit.test("add emoji replaces (keyboard) text selection", async function (asser
     assert.strictEqual(document.querySelector(".o-mail-composer-textarea").value, "🤠");
 });
 
+QUnit.test(
+    "Cursor is positioned after emoji after adding it",
+    async function (assert) {
+        const pyEnv = await startServer();
+        const mailChannelId1 = pyEnv["mail.channel"].create({ name: "pétanque-tournament-14" });
+        const { click, insertText, openDiscuss } = await start({
+            discuss: {
+                context: { active_id: `mail.channel_${mailChannelId1}` },
+            },
+        });
+        await openDiscuss();
+        const composerTextInputTextArea = document.querySelector(".o-mail-composer-textarea");
+        await insertText(".o-mail-composer-textarea", "Blabla");
+        composerTextInputTextArea.setSelectionRange(2, 2);
+        await click("i[aria-label='Emojis']");
+        await click('.o-emoji[data-codepoints="🤠"]');
+        const expectedCursorPos = 2 + "🤠".length;
+        assert.strictEqual(composerTextInputTextArea.selectionStart, expectedCursorPos);
+        assert.strictEqual(composerTextInputTextArea.selectionEnd, expectedCursorPos);
+    }
+);
+
 QUnit.test("selected text is not replaced after cancelling the selection", async function (assert) {
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv["mail.channel"].create({


### PR DESCRIPTION
Before this PR, the cursor position was wrong after inserting an emoji in the middle of the text.

This was due to the useEffect hooks that were overwritting the selection. Focus/resize all leads to the input being focused and the document selectionchange event being triggered.

This PR solves the issue by moving the cursor to the correct location before focusing the textarea.