### PR TITLE
[FIX] mail: leave call on page reload only when active call

### DIFF
--- a/addons/mail/static/src/new/rtc/rtc.js
+++ b/addons/mail/static/src/new/rtc/rtc.js
@@ -157,7 +157,9 @@ export class Rtc {
         });
 
         browser.addEventListener("beforeunload", async (ev) => {
-            await this.rpcLeaveCall(this.state.channel);
+            if (this.state.channel) {
+                await this.rpcLeaveCall(this.state.channel);
+            }
         });
         /**
          * Call all sessions for which no peerConnection is established at


### PR DESCRIPTION
Runbot crash due to attempting RPC leave call even when there's no active call.