### PR TITLE
[FIX] mail: thread insert bug causing unwanted rtc

### DIFF
--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -488,11 +488,9 @@ export class Messaging {
                 }
                 case "mail.channel/legacy_insert":
                     Thread.insert(this.state, {
-                        ...notif.payload,
+                        id: notif.payload.channel.id,
                         model: "mail.channel",
-                        serverData: {
-                            channel: notif.payload.channel,
-                        },
+                        serverData: notif.payload,
                         type: notif.payload.channel.channel_type,
                     });
                     break;


### PR DESCRIPTION
`serverData` is not well handled so the code below will update `rtcSession` into an unwanted one. causing the length of `rtcSession` > 0 and causing the unwanted behavior.
`for (const key in data) {
            this[key] = data[key];
        }`
Also, add some asserts into tests to prevent the bug from happening again, including the test for testing the bad behavior yesterday. 