### PR TITLE
[FIX] mail: Fix unwanted authentications in public page

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -198,6 +198,11 @@ class DiscussController(http.Controller):
             return guest.sudo()._init_messaging()
         raise NotFound()
 
+    @http.route('/mail/channel/members', methods=['POST'], type='json', auth='public')
+    def mail_channel_members(self, channel_id, known_member_ids):
+        channel_member = request.env['mail.channel.member']._get_as_sudo_from_request_or_raise(request=request, channel_id=channel_id)
+        return channel_member.channel_id.sudo().load_more_members(known_member_ids)
+
     @http.route('/mail/load_message_failures', methods=['POST'], type='json', auth='user')
     def mail_load_message_failures(self, **kwargs):
         return request.env.user.partner_id._message_fetch_failed()

--- a/addons/mail/static/src/new/core/messaging.js
+++ b/addons/mail/static/src/new/core/messaging.js
@@ -19,6 +19,7 @@ import { sprintf } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 import { url } from "@web/core/utils/urls";
 import { createLocalId } from "./thread_model.create_local_id";
+import { session } from "@web/session";
 
 const PREVIEW_MSG_MAX_SIZE = 350; // optimal for native English speakers
 export const OTHER_LONG_TYPING = 60000;
@@ -200,7 +201,9 @@ export class Messaging {
             if (data.currentGuest) {
                 this.state.currentGuest = Guest.insert(this.state, data.currentGuest);
             }
-            this.loadFailures();
+            if (session.user_context.uid) {
+                this.loadFailures();
+            }
             this.state.partnerRoot = Partner.insert(this.state, data.partner_root);
             for (const channelData of data.channels) {
                 const thread = this.thread.createChannelThread(channelData);

--- a/addons/mail/static/src/new/thread/thread_service.js
+++ b/addons/mail/static/src/new/thread/thread_service.js
@@ -65,8 +65,10 @@ export class ThreadService {
     }
 
     async fetchChannelMembers(thread) {
-        const results = await this.orm.call("mail.channel", "load_more_members", [[thread.id]], {
-            known_member_ids: thread.channelMembers.map((channelMember) => channelMember.id),
+        const known_member_ids = thread.channelMembers.map((channelMember) => channelMember.id);
+        const results = await this.rpc("/mail/channel/members", {
+            channel_id: thread.id,
+            known_member_ids: known_member_ids,
         });
         let channelMembers = [];
         if (

--- a/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
@@ -54,6 +54,10 @@ patch(MockServer.prototype, "mail/controllers/discuss", {
         if (route === "/mail/channel/ping") {
             return;
         }
+        if (route === "/mail/channel/members") {
+            const { channel_id, known_member_ids } = args;
+            return this._mockMailChannelLoadMoreMembers([channel_id], known_member_ids);
+        }
         if (route === "/mail/history/messages") {
             const { min_id, max_id, limit } = args;
             return this._mockRouteMailMessageHistory(min_id, max_id, limit);

--- a/addons/mail/static/tests/new/discuss/discuss_tests.js
+++ b/addons/mail/static/tests/new/discuss/discuss_tests.js
@@ -142,6 +142,7 @@ QUnit.test("can create a new channel", async (assert) => {
         "/mail/inbox/messages",
         "/web/dataset/call_kw/mail.channel/search_read",
         "/web/dataset/call_kw/mail.channel/channel_create",
+        "/mail/channel/members",
         "/mail/channel/messages",
         "/mail/channel/set_last_seen_message",
         "/mail/channel/messages",


### PR DESCRIPTION
By this commit, fetchChannelMembers performs a route rpc with public authentication and loadFailures is called if the session has a uid in its user context.