### PR TITLE
[FIX] mail: adapt style and shortcut of some chatter buttons

### DIFF
--- a/addons/mail/static/src/new/thread/thread.xml
+++ b/addons/mail/static/src/new/thread/thread.xml
@@ -11,7 +11,7 @@
                 <t t-foreach="props.order === 'asc' ? props.thread.messages : [...props.thread.messages].reverse()" t-as="messageId" t-key="messageId">
                     <t t-set="msg" t-value="store.messages[messageId]"/>
                     <t t-if="!msg.isEmpty and msg.dateDay !== currentDay">
-                        <div class="o-mail-thread-date-separator d-flex fw-bolder pt-4">
+                        <div class="o-mail-thread-date-separator d-flex align-items-center fw-bolder pt-4">
                             <hr class="flex-grow-1 border-top"/>
                             <span class="px-3"><t t-esc="msg.dateDay"/></span>
                             <hr class="flex-grow-1 border-top"/>

--- a/addons/mail/static/src/new/views/chatter.js
+++ b/addons/mail/static/src/new/views/chatter.js
@@ -31,7 +31,11 @@ import { _t } from "@web/core/l10n/translation";
 
 export class Chatter extends Component {
     static components = { AttachmentList, Dropdown, Thread, Composer, Activity, FileUploader };
+    static defaultProps = {
+        compactHeight: false,
+    };
     static props = [
+        "compactHeight?",
         "hasActivity",
         "resId",
         "resModel",

--- a/addons/mail/static/src/new/views/chatter.scss
+++ b/addons/mail/static/src/new/views/chatter.scss
@@ -1,5 +1,5 @@
-.o-chatter-topbar {
-    min-height: 33px;
+.o-mail-chatter-topbar {
+    padding-inline-start: $o-horizontal-padding;
 }
 
 .o-chatter-disabled .o-mail-message-actions {

--- a/addons/mail/static/src/new/views/chatter.xml
+++ b/addons/mail/static/src/new/views/chatter.xml
@@ -3,25 +3,25 @@
 
 <t t-name="mail.chatter" owl="1">
     <div class="o-mail-chatter h-100 d-flex flex-column" t-att-class="props.resId === false ? 'o-chatter-disabled' : ''" t-ref="root">
-        <div class="o-mail-chatter-topbar d-flex flex-shrink-0 flex-grow-0 pe-2 mb-2">
-            <button class="o-mail-chatter-topbar-send-message-button btn p-2 my-2 mx-3" t-att-class="{'btn-odoo': thread.composer.type !== 'note', 'o-active': thread.composer.type === 'message'}" t-att-disabled="!props.resId" t-on-click="() => this.toggleComposer('message')">
+        <div class="o-mail-chatter-topbar d-flex flex-shrink-0 flex-grow-0 pe-2">
+            <button class="o-mail-chatter-topbar-send-message-button btn text-nowrap me-2" t-att-class="{ 'btn-odoo': thread.composer.type !== 'note', 'btn-light': thread.composer.type === 'note', 'o-active': thread.composer.type === 'message', 'my-2': !props.compactHeight }" t-att-disabled="!props.resId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
                 Send message
             </button>
-            <button class="o-mail-chatter-topbar-log-note-button btn p-2 m-2" t-att-class="{'btn-odoo o-active': thread.composer.type === 'note'}" t-att-disabled="!props.resId" t-on-click="() => this.toggleComposer('note')">
+            <button class="o-mail-chatter-topbar-log-note-button btn text-nowrap me-2" t-att-class="{ 'btn-odoo o-active': thread.composer.type === 'note', 'btn-light': thread.composer.type !== 'note', 'my-2': !props.compactHeight }" t-att-disabled="!props.resId" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
                 Log note
             </button>
-            <div class="border-bottom border-start flex-grow-1 d-flex">
-                <button t-if="props.hasActivity" class="o-mail-chatter-topbar-schedule-activity-button btn p-2 m-2" t-att-disabled="!props.resId" t-on-click="scheduleActivity">
+            <div class="border-bottom flex-grow-1 d-flex" t-att-class="{ 'border-start ps-2': props.hasActivity }">
+                <button t-if="props.hasActivity" class="o-mail-chatter-topbar-schedule-activity-button btn btn-light text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }" t-att-disabled="!props.resId" data-hotkey="shift+a" t-on-click="scheduleActivity">
                     <i class="fa fa-clock-o me-1"/>
-                    Activities
+                    <span>Activities</span>
                 </button>
-                <span class="flex-grow-1"/>
-                <button class="o-mail-chatter-topbar-add-attachments btn px-2" t-att-disabled="!props.resId" t-on-click="() => state.isAttachmentBoxOpened = !state.isAttachmentBoxOpened">
+                <span class="flex-grow-1 border-start pe-2" t-att-class="{ 'ms-2': props.hasActivity }"/>
+                <button class="o-mail-chatter-topbar-add-attachments btn btn-light" t-att-class="{ 'my-2': !props.compactHeight }" t-att-disabled="!props.resId" t-on-click="() => state.isAttachmentBoxOpened = !state.isAttachmentBoxOpened">
                     <i class="fa fa-paperclip fa-lg me-1"/>
                     <span t-if="!state.isLoadingAttachments" t-esc="state.attachments.length + attachmentUploader.attachments.length"/>
                     <i t-else="" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>
                 </button>
-                <Dropdown position="'bottom-end'" isDisabled="isDisabled" class="'o-mail-chatter-topbar-follower-list d-flex'" menuClass="'o-mail-chatter-topbar-follower-list-dropdown flex-column p-0'" menuDisplay="'d-flex'" title="followerButtonLabel" togglerClass="'o-mail-chatter-topbar-follower-list-button btn btn-light px-2'">
+                <Dropdown position="'bottom-end'" isDisabled="isDisabled" class="'o-mail-chatter-topbar-follower-list d-flex'" menuClass="'o-mail-chatter-topbar-follower-list-dropdown flex-column p-0'" menuDisplay="'d-flex'" title="followerButtonLabel" togglerClass="'o-mail-chatter-topbar-follower-list-button btn btn-light px-2 ' + (props.compactHeight ? '' : 'my-2')">
                     <t t-set-slot="toggler">
                         <i class="fa fa-user-o" role="img"/>
                         <span class="o-mail-chatter-topbar-followers-count ps-1" t-esc="thread.followers.length"/>
@@ -54,7 +54,7 @@
                         </div>
                     </t>
                 </Dropdown>
-                <button t-if="thread.followerOfCurrentUser" class="o-mail-chatter-topbar-unfollow btn px-0" t-att-class="{ 'text-success': !unfollowHover.isHover, 'text-warning': unfollowHover.isHover }" t-att-disabled="!props.resId" t-on-click="onClickUnfollow" t-ref="unfollow">
+                <button t-if="thread.followerOfCurrentUser" class="o-mail-chatter-topbar-unfollow btn px-0" t-att-class="{ 'text-success': !unfollowHover.isHover, 'text-warning': unfollowHover.isHover, 'my-2': !props.compactHeight }" t-att-disabled="!props.resId" t-on-click="onClickUnfollow" t-ref="unfollow">
                     <div class="position-relative">
                         <!-- Hidden element used to set the button maximum size -->
                         <span class="invisible">


### PR DESCRIPTION
Pixel perfect match with master branch for send message, log note and activities on aside chatter.
Other buttons and edge cases not yet taken into account.