### PR TITLE
[FIX] mail: Remove unwanted call component from thread on public page

### DIFF
--- a/addons/mail/static/src/new/core/messaging_service.js
+++ b/addons/mail/static/src/new/core/messaging_service.js
@@ -411,6 +411,7 @@ export class Messaging {
                     const { channel, invited_by_user_id: invitedByUserId } = notif.payload;
                     const thread = this.thread.insert({
                         ...channel,
+                        rtcSessions: channel.rtcSessions[0][1],
                         model: "mail.channel",
                         serverData: {
                             channel: channel.channel,


### PR DESCRIPTION
This commit removes rtcSession from channel data insertion in handling channel/joined notification to prevent call component be rendered in the first step after guest joins the channel