### PR TITLE
[FIX]: mail: activity not updating after delete

### DIFF
--- a/addons/mail/static/src/new/views/chatter.js
+++ b/addons/mail/static/src/new/views/chatter.js
@@ -1,7 +1,7 @@
 /* @odoo-module */
 
 import { Thread } from "../thread/thread";
-import { useMessaging } from "../core/messaging_hook";
+import { useMessaging, useStore } from "../core/messaging_hook";
 import { useDropzone } from "@mail/new/dropzone/dropzone_hook";
 import { AttachmentList } from "@mail/new/thread/attachment_list";
 import { Composer } from "../composer/composer";
@@ -55,7 +55,7 @@ export class Chatter extends Component {
         this.attachment = useService("mail.attachment");
         this.chatter = useState(useService("mail.chatter"));
         this.threadService = useService("mail.thread");
-        this.store = useService("mail.store");
+        this.store = useStore();
         this.orm = useService("orm");
         this.rpc = useService("rpc");
         this.state = useState({


### PR DESCRIPTION
Activities in chatter are based on the store service but the said service is not wrapped into useState. This caused issue where activity were not always cleared after a "mark as done" action.

This commit fixes the issue by wrapping the chatter's store service into useState.