### PR TITLE
[IMP] mail: Clean avatarUrl code

### DIFF
--- a/addons/mail/static/src/new/composer/composer.js
+++ b/addons/mail/static/src/new/composer/composer.js
@@ -175,13 +175,6 @@ export class Composer extends Component {
         this.stopTyping();
     }
 
-    get avatarUrl() {
-        if (this.store.self?.type === "guest") {
-            return `/mail/channel/${this.props.composer.thread.id}/guest/${this.store.self.id}/avatar_128?unique=${this.store.self.name}`;
-        }
-        return this.store.user.avatarUrl;
-    }
-
     get hasSuggestions() {
         return this.suggestion.state.items.length > 0;
     }

--- a/addons/mail/static/src/new/composer/composer.xml
+++ b/addons/mail/static/src/new/composer/composer.xml
@@ -14,7 +14,7 @@
                     'o-has-current-partner-avatar px-3': !this.env.inChatWindow and thread,
                 }">
             <div class="o-mail-composer-sidebar-main flex-shrink-0" t-if="!compact">
-                <img class="o-mail-composer-avatar mt-1 rounded-circle" t-att-src="avatarUrl" alt="Avatar of user"/>
+                <img class="o-mail-composer-avatar mt-1 rounded-circle" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
             </div>
             <div class="o-mail-composer-core-header text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread === props.composer.thread">
                 <span class="cursor-pointer" t-on-click="() => props.highlightReplyTo and props.highlightReplyTo(props.messageToReplyTo.message.id)">

--- a/addons/mail/static/src/new/core/channel_member_model.js
+++ b/addons/mail/static/src/new/core/channel_member_model.js
@@ -24,16 +24,6 @@ export class ChannelMember {
         this.personaLocalId = persona?.localId;
     }
 
-    get avatarUrl() {
-        if (this.persona.type === "partner") {
-            return `/mail/channel/${this.thread.id}/partner/${this.persona.id}/avatar_128`;
-        }
-        if (this.persona.type === "guest") {
-            return `/mail/channel/${this.thread.id}/guest/${this.persona.id}/avatar_128?unique=${this.persona.name}`;
-        }
-        return "";
-    }
-
     get thread() {
         return this._store.threads[createLocalId("mail.channel", this.threadId)];
     }

--- a/addons/mail/static/src/new/core/messaging_service.js
+++ b/addons/mail/static/src/new/core/messaging_service.js
@@ -124,6 +124,7 @@ export class Messaging {
             this.store.guest = this.persona.insert({
                 ...data.currentGuest,
                 type: "guest",
+                channelId: data.channels[0]?.id,
             });
         }
         if (session.user_context.uid) {
@@ -540,6 +541,7 @@ export class Messaging {
                             ...notif.payload.persona.partner,
                             ...notif.payload.persona.guest,
                             type: notif.payload.persona.partner ? "partner" : "guest",
+                            channelId: notif.payload.persona.guest ? channel.id : null,
                         }),
                         threadId: channel.id,
                     });

--- a/addons/mail/static/src/new/core/persona_model.js
+++ b/addons/mail/static/src/new/core/persona_model.js
@@ -26,6 +26,7 @@ export class Persona {
     /** @type {ImStatus} */
     im_status;
     isAdmin = false;
+    channelId;
     /** @type {import("@mail/new/core/store_service").Store} */
     _store;
 
@@ -34,7 +35,7 @@ export class Persona {
             case "partner":
                 return `/mail/channel/1/partner/${this.id}/avatar_128`;
             case "guest":
-                return `/web/image/mail.guest/${this.id}/avatar_128?unique=${this.name}`;
+                return `/mail/channel/${this.channelId}/guest/${this.id}/avatar_128?unique=${this.name}`;
             default:
                 return "";
         }

--- a/addons/mail/static/src/new/discuss/channel_member_list.xml
+++ b/addons/mail/static/src/new/discuss/channel_member_list.xml
@@ -29,7 +29,7 @@
         <div class="o-mail-channel-member d-flex align-items-center mx-2 p-2 bg-light" t-att-class="{'cursor-pointer': member.persona !== store.self}" t-on-click.stop="() => this.openChatAvatar(member)">
             <div class="o-mail-background-inherit o-mail-channel-member-avatar-container position-relative d-flex ms-4 flex-shrink-0">
                 <img class="w-100 h-100 rounded-circle o_object_fit_cover o_redirect"
-                    t-att-src="member.avatarUrl"/>
+                    t-att-src="member.persona.avatarUrl"/>
                 <PartnerImStatus className="'position-absolute bottom-0 end-0'" partner="member"/>
             </div>
             <span class="o-mail-channel-member-name ms-2 text-truncate" t-esc="member.persona.name"/>

--- a/addons/mail/static/src/new/discuss/discuss.js
+++ b/addons/mail/static/src/new/discuss/discuss.js
@@ -169,12 +169,4 @@ export class Discuss extends Component {
             await this.personaService.updateGuestName(this.store.self, newName);
         }
     }
-
-    get avatarUrl() {
-        if (this.store.guest) {
-            return `/mail/channel/${this.thread.id}/guest/${this.store.guest.id}/avatar_128?unique=${this.store.guest.name}`;
-        } else {
-            return this.store.user.avatarUrl;
-        }
-    }
 }

--- a/addons/mail/static/src/new/discuss/discuss.xml
+++ b/addons/mail/static/src/new/discuss/discuss.xml
@@ -41,7 +41,7 @@
                         <i class="fa fa-lg fa-gear text-700"/>
                     </button>
                     <div t-if="props.public and !env.isSmall" class="d-flex align-items-center">
-                        <img class="o-mail-discuss-self-avatar mx-1 rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="avatarUrl"/>
+                        <img class="o-mail-discuss-self-avatar mx-1 rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl"/>
                         <div class="lead fw-bold flex-shrink-1 text-dark">
                             <t t-if="store.user" t-esc="store.user.name"/>
                             <t t-else="">

--- a/addons/mail/static/src/new/rtc/call_participant_card.js
+++ b/addons/mail/static/src/new/rtc/call_participant_card.js
@@ -41,10 +41,6 @@ export class CallParticipantCard extends Component {
         return this.props.session.channelMember?.persona.name;
     }
 
-    get avatarUrl() {
-        return this.props.session.channelMember?.avatarUrl;
-    }
-
     get hasVideo() {
         return Boolean(this.props.session.videoStream);
     }

--- a/addons/mail/static/src/new/rtc/call_participant_card.xml
+++ b/addons/mail/static/src/new/rtc/call_participant_card.xml
@@ -23,7 +23,7 @@
                         'o-isInvitation': !props.session,
                         }"
                         class="o-mail-call-participant-card-avatarImage h-100 rounded-circle border-5 o_object_fit_cover"
-                        t-att-src="avatarUrl"
+                        t-att-src="props.session.channelMember?.persona.avatarUrl"
                         draggable="false"
                 />
             </div>

--- a/addons/mail/static/src/new/rtc/rtc_service.js
+++ b/addons/mail/static/src/new/rtc/rtc_service.js
@@ -1160,6 +1160,7 @@ export class Rtc {
                     ...channelMember.persona.partner,
                     ...channelMember.persona.guest,
                     type: channelMember.persona.partner ? "partner" : "guest",
+                    channelId: channelMember.persona.guest && channelMember.channel.id,
                 }),
                 threadId: channelMember.channel.id,
             });

--- a/addons/mail/static/src/new/rtc/rtc_session_model.js
+++ b/addons/mail/static/src/new/rtc/rtc_session_model.js
@@ -36,13 +36,6 @@ export class RtcSession {
         return this._store.threads[createLocalId("mail.channel", this.channelId)];
     }
 
-    /**
-     * @returns {string}
-     */
-    get avatarUrl() {
-        return this.channelMember?.avatarUrl;
-    }
-
     get isMute() {
         return this.isSelfMuted || this.isDeaf;
     }

--- a/addons/mail/static/src/new/thread/message.js
+++ b/addons/mail/static/src/new/thread/message.js
@@ -128,14 +128,6 @@ export class Message extends Component {
         }
     }
 
-    get avatarUrl() {
-        if (this.message.author?.type === "guest") {
-            return `/mail/channel/${this.message.originThread.id}/guest/${this.message.author.id}/avatar_128?unique=${this.message.author.name}`;
-        } else {
-            return this.message.author?.avatarUrl;
-        }
-    }
-
     get message() {
         return this.props.message;
     }

--- a/addons/mail/static/src/new/thread/message.xml
+++ b/addons/mail/static/src/new/thread/message.xml
@@ -28,7 +28,7 @@
                 <div class="o-mail-message-sidebar d-flex flex-shrink-0" t-att-class="{ 'justify-content-end': isAlignedRight }">
                     <div t-if="!props.squashed" class="o-mail-avatar-container position-relative bg-view">
                         <img class="o-mail-message-author-avatar w-100 h-100 rounded-circle o_object_fit_cover o_redirect"
-                            t-att-src="avatarUrl"
+                            t-att-src="message.author?.avatarUrl"
                             t-att-class="{ 'cursor-pointer': hasOpenChatFeature }"
                             t-on-click="openChatAvatar" />
                         <PartnerImStatus t-if="message.author" partner="message.author" className="'position-absolute bottom-0 end-0'"/>

--- a/addons/mail/static/src/new/thread/message_in_reply_to.js
+++ b/addons/mail/static/src/new/thread/message_in_reply_to.js
@@ -20,12 +20,12 @@ export class MessageInReplyTo extends Component {
         const parentMessage = this.props.message.parentMessage;
         if (
             parentMessage.author &&
-            (parentMessage.resModel === "mail.channel" || !parentMessage.resModel)
+            (parentMessage.resModel !== "mail.channel" || !parentMessage.resModel)
         ) {
             return `/web/image/res.partner/${parentMessage.author.id}/avatar_128`;
         }
         if (parentMessage.author && parentMessage.resModel === "mail.channel") {
-            return `/mail/channel/${parentMessage.resId}/partner/${parentMessage.author.id}/avatar_128`;
+            return parentMessage.author.avatarUrl;
         }
         if (parentMessage.type === "email") {
             return "/mail/static/src/img/email_icon.png";

--- a/addons/mail/static/src/new/thread/message_service.js
+++ b/addons/mail/static/src/new/thread/message_service.js
@@ -239,6 +239,7 @@ export class MessageService {
             message.author = this.persona.insert({
                 ...data.guestAuthor,
                 type: "guest",
+                channelId: message.originThread.id,
             });
         }
         if (data.recipients) {

--- a/addons/mail/static/src/new/thread/thread_service.js
+++ b/addons/mail/static/src/new/thread/thread_service.js
@@ -105,6 +105,7 @@ export class ThreadService {
                     persona: this.persona.insert({
                         ...channelMember.persona.guest,
                         type: "guest",
+                        channelId: thread.id,
                     }),
                     threadId: thread.id,
                 });
@@ -427,7 +428,11 @@ export class ThreadService {
                         this.persona.insert({ ...elem.persona.partner, type: "partner" });
                     }
                     if (elem.persona?.guest) {
-                        this.persona.insert({ ...elem.persona.guest, type: "guest" });
+                        this.persona.insert({
+                            ...elem.persona.guest,
+                            type: "guest",
+                            channelId: serverData.channel.id,
+                        });
                     }
                 });
             }


### PR DESCRIPTION
By this commit, getting avatarUrl via '/mail/channel' route is integrated in persona avatarUrl.