### PR TITLE
[IMP] mail: do not fetch audio source during test

### DIFF
--- a/addons/mail/static/tests/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/helpers/webclient_setup.js
@@ -128,6 +128,20 @@ async function setupMessagingServiceRegistries({
         },
     });
 
+    const OriginalAudio = window.Audio;
+    patchWithCleanup(
+        window,
+        {
+            Audio: function () {
+                const audio = new OriginalAudio();
+                audio.preload = "none";
+                audio.play = () => {};
+                return audio;
+            },
+        },
+        { pure: true }
+    );
+
     const messagingValues = {
         start() {
             return {


### PR DESCRIPTION
Before this commit, each single test would lead to a fetch request to retrieve its source. This is a lot of (useless) requests.

This commit solves this issue by preventing the preload of the audio source during tests as well as canceling the sound as it is annoying.