### PR TITLE
[FIX] mail: Fix empty attachment preview in creating new record

### DIFF
--- a/addons/mail/static/src/new/attachments/attachment_view.scss
+++ b/addons/mail/static/src/new/attachments/attachment_view.scss
@@ -1,13 +1,13 @@
 .modal {
     @include media-breakpoint-up(xxl, $o-extra-grid-breakpoints) {
-        .o_attachment_preview {
+        .o_attachment_preview_placeholder {
             width: 300px;
         }
     }
 }
 
 @include media-breakpoint-up(xxl, $o-extra-grid-breakpoints) {
-    .o_attachment_preview {
+    .o_attachment_preview_placeholder {
         display: block;
         flex: 1 0 auto;
         overflow: hidden;
@@ -52,7 +52,7 @@
 }
 
 @include media-breakpoint-down(xxl, $o-extra-grid-breakpoints) {
-    .o_attachment_preview {
+    .o_attachment_preview_placeholder {
         display: none;
     }
 }

--- a/addons/mail/static/src/new/web/form_patch.xml
+++ b/addons/mail/static/src/new/web/form_patch.xml
@@ -9,7 +9,7 @@
                 </div>
             </t>
             <t t-if="hasAttachmentViewer()">
-                <div class="o_attachment_preview">
+                <div class="o_attachment_preview_placeholder">
                     <AttachmentView threadId="model.root.resId" threadModel="model.root.resModel"/>
                 </div>
             </t>


### PR DESCRIPTION
There is a similar css class in attachment preview div indicator and attachment view in formView. In creating new record the `o_attachment_preview` width changes with media-breakpoint-up, so it appears in the view.