### PR TITLE
[IMP] mail: move delete attachment function

### DIFF
--- a/addons/mail/static/src/new/attachments/attachment_uploader_hook.js
+++ b/addons/mail/static/src/new/attachments/attachment_uploader_hook.js
@@ -24,11 +24,11 @@ export function useAttachmentUploader(pThread, message, isPending = false) {
     const component = useComponent();
     const { bus, upload } = useService("file_upload");
     const notification = useService("notification");
-    /** @type {import("@mail/new/core/messaging_service").Messaging} */
-    const messaging = useService("mail.messaging");
     /** @type {import("@mail/new/core/store_service").Store} */
     const store = useService("mail.store");
+    /** @type {import("@mail/new/core/thread_service").ThreadService} */
     const threadService = useService("mail.thread");
+    /** @type {import("@mail/new/attachments/attachment_service").AttachmentService} */
     const attachmentService = useService("mail.attachment");
     const abortByAttachmentId = new Map();
     const deferredByAttachmentId = new Map();
@@ -67,7 +67,7 @@ export function useAttachmentUploader(pThread, message, isPending = false) {
                 abort();
                 return;
             }
-            await messaging.unlinkAttachment(attachment);
+            await attachmentService.delete(attachment);
             removeFromArrayWithPredicate(state.attachments, ({ id }) => id === attachment.id);
         },
         async unlinkAll() {

--- a/addons/mail/static/src/new/core/messaging_service.js
+++ b/addons/mail/static/src/new/core/messaging_service.js
@@ -4,7 +4,7 @@ import { markup, reactive } from "@odoo/owl";
 import { Deferred } from "@web/core/utils/concurrency";
 import { memoize } from "@web/core/utils/functions";
 import { cleanTerm, htmlToTextContentInline } from "@mail/new/utils/format";
-import { removeFromArray, removeFromArrayWithPredicate } from "@mail/new/utils/arrays";
+import { removeFromArray } from "@mail/new/utils/arrays";
 import { LinkPreview } from "./link_preview_model";
 import { CannedResponse } from "./canned_response_model";
 import { browser } from "@web/core/browser/browser";
@@ -691,24 +691,6 @@ export class Messaging {
             views: [[false, "form"]],
             res_id: id,
         });
-    }
-
-    /**
-     * @param {import("@mail/new/attachments/attachment_model").Attachment} attachment
-     */
-    async unlinkAttachment(attachment) {
-        // TODO also unlink from message when applicable
-        if (attachment.originThread) {
-            removeFromArrayWithPredicate(
-                attachment.originThread.attachments,
-                ({ id }) => id === attachment.id
-            );
-        }
-        if (attachment.id > 0) {
-            await this.rpc("/mail/attachment/delete", {
-                attachment_id: attachment.id,
-            });
-        }
     }
 
     insertCannedResponse(data) {

--- a/addons/mail/static/src/new/core_ui/message.js
+++ b/addons/mail/static/src/new/core_ui/message.js
@@ -4,7 +4,6 @@ import { PartnerImStatus } from "@mail/new/discuss/partner_im_status";
 import { AttachmentList } from "@mail/new/attachments/attachment_list";
 import { MessageInReplyTo } from "./message_in_reply_to";
 import { isEventHandled, markEventHandled } from "@mail/new/utils/misc";
-import { removeFromArrayWithPredicate } from "@mail/new/utils/arrays";
 import { convertBrToLineBreak, htmlToTextContentInline } from "@mail/new/utils/format";
 import { onExternalClick } from "@mail/new/utils/hooks";
 import {
@@ -83,6 +82,8 @@ export class Message extends Component {
         this.threadService = useState(useService("mail.thread"));
         /** @type {import("@mail/new/core/message_service").MessageService} */
         this.messageService = useState(useService("mail.message"));
+        /** @type {import("@mail/new/attachments/attachment_service").AttachmentService} */
+        this.attachmentService = useService("mail.attachment");
         this.user = useService("user");
         useChildSubEnv({
             alignedRight: this.isAlignedRight,
@@ -275,8 +276,7 @@ export class Message extends Component {
     }
 
     async onClickAttachmentUnlink(attachment) {
-        await this.messaging.unlinkAttachment(attachment);
-        removeFromArrayWithPredicate(this.message.attachments, ({ id }) => id === attachment.id);
+        await this.attachmentService.delete(attachment);
     }
 
     openChatAvatar(ev) {


### PR DESCRIPTION
Move delete attachment function inside the attachment service. Loop on all know message to delete all instance of this attachment. This keep the attachment box in sync correctly.