### PR TITLE
[FIX] mail: Sort notification groups crashes

### DIFF
--- a/addons/mail/static/src/new/core/messaging_service.js
+++ b/addons/mail/static/src/new/core/messaging_service.js
@@ -163,7 +163,9 @@ export class Messaging {
                     author: this.store.user,
                 })
             );
-            this.store.notificationGroups.sort((n1, n2) => n2.lastMessage.id - n1.lastMessage.id);
+            this.store.notificationGroups.sort(
+                (n1, n2) => (n2.lastMessage?.id ?? 0) - (n1.lastMessage?.id ?? 0)
+            );
         });
     }
 


### PR DESCRIPTION
If notification groups don't have lastMessageId, sort function shouldn't crash.