### PR TITLE
[FIX] mail: message order problem

### DIFF
--- a/addons/mail/static/src/new/core/message_service.js
+++ b/addons/mail/static/src/new/core/message_service.js
@@ -466,12 +466,7 @@ export class MessageService {
      */
     sortMessages(thread) {
         thread.messages.sort((msg1, msg2) => {
-            const indicator = msg1.datetime - msg2.datetime;
-            if (indicator) {
-                return indicator;
-            } else {
-                return msg1.id - msg2.id;
-            }
+            return msg1.id - msg2.id;
         });
     }
 }


### PR DESCRIPTION
the messages were ordered by datetime but when the newest message with a smaller id, the unread counter always returns a buggy number.