### PR TITLE
[FIX] mail: avatar in public channel member list

### DIFF
--- a/addons/mail/static/src/new/core/channel_member_model.js
+++ b/addons/mail/static/src/new/core/channel_member_model.js
@@ -27,4 +27,14 @@ export class ChannelMember {
     get thread() {
         return this._store.threads[createLocalId("mail.channel", this.threadId)];
     }
+
+    get avatarUrl() {
+        if (this.persona.type === "partner") {
+            return `/mail/channel/${this.thread.id}/partner/${this.persona.id}/avatar_128`;
+        }
+        if (this.persona.type === "guest") {
+            return `/mail/channel/${this.thread.id}/guest/${this.persona.id}/avatar_128?unique=${this.persona.name}`;
+        }
+        return "";
+    }
 }

--- a/addons/mail/static/src/new/core_ui/message_in_reply_to.js
+++ b/addons/mail/static/src/new/core_ui/message_in_reply_to.js
@@ -15,21 +15,4 @@ export class MessageInReplyTo extends Component {
         this.store = useStore();
         this.user = useService("user");
     }
-
-    get avatarUrl() {
-        const parentMessage = this.props.message.parentMessage;
-        if (
-            parentMessage.author &&
-            (parentMessage.resModel !== "mail.channel" || !parentMessage.resModel)
-        ) {
-            return `/web/image/res.partner/${parentMessage.author.id}/avatar_128`;
-        }
-        if (parentMessage.author && parentMessage.resModel === "mail.channel") {
-            return parentMessage.author.avatarUrl;
-        }
-        if (parentMessage.type === "email") {
-            return "/mail/static/src/img/email_icon.png";
-        }
-        return "/mail/static/src/img/smiley/avatar.jpg";
-    }
 }

--- a/addons/mail/static/src/new/core_ui/message_in_reply_to.xml
+++ b/addons/mail/static/src/new/core_ui/message_in_reply_to.xml
@@ -9,7 +9,7 @@
             <small class="position-relative d-block text-small mb-1" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'justify-content-end pe-5': 'ps-5' }}" t-on-click="props.onClick">
                 <span class="o-mail-message-in-reply-corner position-absolute bottom-0 top-50 pe-4 border-top text-300" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'o-isRightAlign border-end' : 'o-isLeftAlign border-start' }}" t-att-class="{ 'ms-n2': store.discuss.isActive }"/>
                 <span t-if="!message.parentMessage.isEmpty" class="cursor-pointer d-flex align-items-center text-muted opacity-75 opacity-100-hover"  t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'pe-3': 'ps-3' }}">
-                    <img class="o-mail-message-in-reply-avatar me-2 rounded-circle" t-att-src="avatarUrl" t-att-title="message.parentMessage.author.name" alt="Avatar"/>
+                    <img class="o-mail-message-in-reply-avatar me-2 rounded-circle" t-att-src="message.parentMessage.authorAvatarUrl" t-att-title="message.parentMessage.author.name" alt="Avatar"/>
                     <span class="o-mail-message-in-reply-wrap-inner overflow-hidden">
                         <b>@<t t-out="message.parentMessage.author.name"/></b>:
                         <span class="o-mail-message-in-reply-body ms-1 text-break">

--- a/addons/mail/static/src/new/discuss/channel_member_list.xml
+++ b/addons/mail/static/src/new/discuss/channel_member_list.xml
@@ -29,7 +29,7 @@
         <div class="o-mail-channel-member d-flex align-items-center mx-2 p-2 bg-light" t-att-class="{ 'cursor-pointer': canOpenChatWith(member) }" t-on-click.stop="() => this.openChatAvatar(member)">
             <div class="o-mail-background-inherit o-mail-channel-member-avatar-container position-relative d-flex ms-4 flex-shrink-0">
                 <img class="w-100 h-100 rounded-circle o_object_fit_cover o_redirect"
-                    t-att-src="member.persona.avatarUrl"/>
+                    t-att-src="member.avatarUrl"/>
                 <ImStatus className="'position-absolute bottom-0 end-0'" persona="member.persona"/>
             </div>
             <span class="o-mail-channel-member-name ms-2 text-truncate" t-esc="member.persona.name"/>

--- a/addons/mail/static/src/new/rtc/call_invitation.xml
+++ b/addons/mail/static/src/new/rtc/call_invitation.xml
@@ -5,7 +5,7 @@
         <div class="o-mail-call-invitation d-flex flex-column m-2 p-5 border border-dark rounded-1 bg-900" t-attf-class="{{ className }}" t-ref="root">
             <div t-if="props.thread.rtcInvitingSession" class="o-mail-call-invitation-partnerInfo d-flex flex-column justify-content-around align-items-center text-nowrap">
                 <img class="o-mail-call-invitation-partnerInfoImage mb-2 rounded-circle cursor-pointer"
-                    t-att-src="props.thread.rtcInvitingSession?.channelMember?.persona.avatarUrl"
+                    t-att-src="props.thread.rtcInvitingSession?.channelMember?.avatarUrl"
                     t-on-click="onClickAvatar"
                     alt="Avatar"/>
                 <span class="w-100 fw-bolder text-truncate text-center overflow-hidden" t-esc="props.thread.rtcInvitingSession.channelMember.persona.name"/>

--- a/addons/mail/static/src/new/rtc/call_participant_card.xml
+++ b/addons/mail/static/src/new/rtc/call_participant_card.xml
@@ -23,7 +23,7 @@
                         'o-isInvitation': !rtcSession,
                         }"
                         class="o-mail-call-participant-card-avatarImage h-100 rounded-circle border-5 o_object_fit_cover"
-                        t-att-src="channelMember?.persona.avatarUrl"
+                        t-att-src="channelMember?.avatarUrl"
                         draggable="false"
                 />
             </div>


### PR DESCRIPTION
Also clean up the avatars we have, we should only keep 3:
1. persona avatar -> can be used everywhere where without thread id constraints, like composer;
2. channel member avatar -> with thread id constraints, only used within specific thread
3. message author avatar -> the author can be non-human;