### PR TITLE
 [FIX] mail: fix partner name change after mention

### DIFF
--- a/addons/mail/static/src/new/core/message_service.js
+++ b/addons/mail/static/src/new/core/message_service.js
@@ -390,10 +390,10 @@ export class MessageService {
             notification_status: data.notification_status,
             notification_type: data.notification_type,
             failure_type: data.failure_type,
-            partner: data.res_partner_id
+            persona: data.res_partner_id
                 ? this.personaService.insert({
                       id: data.res_partner_id[0],
-                      name: data.res_partner_id[1],
+                      displayName: data.res_partner_id[1],
                       type: "partner",
                   })
                 : undefined,

--- a/addons/mail/static/src/new/core/notification_model.js
+++ b/addons/mail/static/src/new/core/notification_model.js
@@ -14,7 +14,7 @@ export class Notification {
     /** @type {string} */
     failure_type;
     /** @type {import("@mail/new/core/persona_model").Persona} */
-    partner;
+    persona;
     /** @type {import("@mail/new/core/store_service").Store} */
     _store;
 

--- a/addons/mail/static/src/new/core/persona_model.js
+++ b/addons/mail/static/src/new/core/persona_model.js
@@ -19,6 +19,8 @@ export class Persona {
     type;
     /** @type {string} */
     name;
+    /** @type {string} */
+    displayName;
     /** @type {{ code: string, id: number, name: string}|undefined} */
     country;
     /** @type {string} */

--- a/addons/mail/static/src/new/core_ui/message_notification_popover.xml
+++ b/addons/mail/static/src/new/core_ui/message_notification_popover.xml
@@ -5,7 +5,7 @@
         <div class="o-mail-message-notification-popover m-2">
             <div t-foreach="props.message.notifications" t-as="notification" t-key="notification.id">
                 <i class="me-2" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
-                <span t-if="notification.partner" t-esc="notification.partner.name"/>
+                <span t-if="notification.persona" t-esc="notification.persona.name || notification.persona.displayName"/>
             </div>
         </div>
     </t>

--- a/addons/mail/static/tests/new/thread/thread_tests.js
+++ b/addons/mail/static/tests/new/thread/thread_tests.js
@@ -725,13 +725,13 @@ QUnit.test(
 
 QUnit.test("basic rendering of canceled notification", async function (assert) {
     const pyEnv = await startServer();
-    const channeld = pyEnv["mail.channel"].create({ name: "test" });
+    const channelId = pyEnv["mail.channel"].create({ name: "test" });
     const partnerId = pyEnv["res.partner"].create({ name: "Someone" });
     const messageId = pyEnv["mail.message"].create({
         body: "not empty",
         message_type: "email",
         model: "mail.channel",
-        res_id: channeld,
+        res_id: channelId,
     });
     pyEnv["mail.notification"].create({
         failure_type: "SMTP",
@@ -741,7 +741,7 @@ QUnit.test("basic rendering of canceled notification", async function (assert) {
         res_partner_id: partnerId,
     });
     const { openDiscuss } = await start();
-    await openDiscuss(channeld);
+    await openDiscuss(channelId);
     assert.containsOnce(target, ".o-mail-message-notification .fa-envelope-o");
 
     await click(".o-mail-message-notification");


### PR DESCRIPTION
When doing a mention of a partner, the name of the partner
should not change to the displayName of the partner