### PR TITLE
[IMP] mail: Remove tracking value from basic message template

### DIFF
--- a/addons/mail/static/src/new/core_ui/message.xml
+++ b/addons/mail/static/src/new/core_ui/message.xml
@@ -80,18 +80,7 @@
                             </span>
                         </div>
                     </div>
-                    <div t-if="!state.isEditing" class="o-mail-message-content d-flex position-relative">
-                        <t name="hasTrackingValue" t-if="(message.type === 'notification' or message.isTransient) and !message.isBodyEmpty">
-                            <t t-if="message.subtypeDescription">
-                                <p class="mb-0"><t t-esc="message.subtypeDescription"/></p>
-                            </t>
-                            <t t-if="message.trackingValues.length">
-                                <t t-call="mail.tracking_values"/>
-                            </t>
-                            <div t-if="message.body" class="o-mail-message-body text-break mb-0 bg-view w-100">
-                                <t t-out="message.body"/>
-                            </div>
-                        </t>
+                    <div t-if="!state.isEditing" class="o-mail-message-content position-relative" t-att-class="{'d-flex': env.inDiscussApp}">
                         <t t-if="message.type !== 'notification' and !message.isTransient and (!message.isBodyEmpty or message.subtypeDescription)">
                             <div class="position-relative">
                                 <div class="o-mail-message-bubble border rounded-end-3 rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100" t-att-class="{
@@ -171,18 +160,6 @@
                 </div>
             </div>
         </div>
-    </t>
-
-    <t t-name="mail.tracking_values" owl="1">
-        <ul class="mb-0 ps-4">
-            <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
-                <li>
-                    <span class="fw-bold" t-esc="trackingValue.oldValue.value"/>
-                    <i class="fa fa-long-arrow-right mx-1 text-600" />
-                    <span class="text-info fw-bold" t-esc="trackingValue.newValue.value"/> (<t t-esc="trackingValue.changedField"/>)
-                </li>
-            </t>
-        </ul>
     </t>
 
 </templates>

--- a/addons/mail/static/src/new/web/message_patch.xml
+++ b/addons/mail/static/src/new/web/message_patch.xml
@@ -1,21 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.message" t-inherit-mode="extension">
-        <xpath expr="//*[@name='hasTrackingValue']" position="attributes">
-            <attribute name="t-if">message.type === 'notification' or message.isTransient or message.trackingValues.length > 0</attribute>
-        </xpath>
-    </t>
-
-    <t t-inherit="mail.tracking_values" t-inherit-mode="extension">
-        <xpath expr="//*[@name='trackingValues']" position="replace">
-             <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
-                <li class="o-mail-message-tracking mb-1" role="group">
-                    <span class="o-mail-message-tracking-old me-1 px-1 text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.oldValue)"/>
-                    <i class="o-mail-message-tracking-separator fa fa-long-arrow-right mx-1 text-600" />
-                    <span class="o-mail-message-tracking-new me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.newValue)"/>
-                    <span class="o-mail-message-tracking-field ms-1 fst-italic text-muted">(<t t-esc="trackingValue.changedField"/>)</span>
-                </li>
-             </t>
+        <xpath expr="//div[hasclass('o-mail-message-content')]/*[1]" position="before">
+            <t name="hasTrackingValue" t-if="message.type === 'notification' or message.isTransient or message.trackingValues.length > 0">
+                <t t-if="message.subtypeDescription">
+                    <p class="mb-0">
+                        <t t-esc="message.subtypeDescription"/>
+                    </p>
+                </t>
+                <t t-if="message.trackingValues.length">
+                    <ul class="mb-0 ps-4">
+                        <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
+                            <li class="o-mail-message-tracking mb-1" role="group">
+                                <span class="o-mail-message-tracking-old me-1 px-1 text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.oldValue)"/>
+                                <i class="o-mail-message-tracking-separator fa fa-long-arrow-right mx-1 text-600"/>
+                                <span class="o-mail-message-tracking-new me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.newValue)"/>
+                                <span class="o-mail-message-tracking-field ms-1 fst-italic text-muted">(<t t-esc="trackingValue.changedField"/>)</span>
+                            </li>
+                        </t>
+                    </ul>
+                </t>
+                <div t-if="message.body" class="o-mail-message-body text-break mb-0 bg-view w-100">
+                    <t t-out="message.body"/>
+                </div>
+            </t>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
Since we don't show tracking values in public pages, it shouldn't be in the basic message. So with this commit it is only available in web client.