### PR TITLE
[FIX] mail: properly size message bubble to content

### DIFF
--- a/addons/mail/static/src/new/core_ui/message.xml
+++ b/addons/mail/static/src/new/core_ui/message.xml
@@ -43,7 +43,7 @@
                         </div>
                     </t>
                 </div>
-                <div class="flex-grow-1">
+                <div>
                     <div t-if="!props.squashed" class="o-mail-msg-header d-flex flex-wrap align-items-baseline">
                         <span t-if="message.author and shouldDisplayAuthorName" class="o-mail-own-name" t-att-class="{ 'cursor-pointer o_redirect': hasAuthorClickable }" t-att-title="authorText" t-on-click="ev => this.onClickAuthor(ev)">
                             <strong class="me-1 text-truncate" t-esc="message.author.name"/>


### PR DESCRIPTION
Before:
<img width="342" alt="Screenshot 2023-03-01 at 11 55 47" src="https://user-images.githubusercontent.com/6569390/222119873-0e530ecd-628f-49b6-8e09-fb593ac8b847.png">


After:
<img width="343" alt="Screenshot 2023-03-01 at 11 55 23" src="https://user-images.githubusercontent.com/6569390/222119911-261f518d-e18a-447e-93fa-8df4c25f5b64.png">

Note that width is still not perfect: the "5 days ago" affect the width of bubble, which shouldn't be the case. Follow-up PR for that!