### PR TITLE
[FIX] mail: resolve messaging menu show latest deleted message

### DIFF
--- a/addons/mail/static/src/new/core/thread_model.js
+++ b/addons/mail/static/src/new/core/thread_model.js
@@ -246,7 +246,7 @@ export class Thread {
         if (this.messages.length === 0) {
             return undefined;
         }
-        return this._store.messages[Math.max(...this.messages.map((m) => m.id))];
+        return this._store.messages[Math.max(...this.nonEmptyMessages.map((m) => m.id))];
     }
 
     get mostRecentNeedactionMsg() {


### PR DESCRIPTION
This commit resolve a bug where the messaging menu showed
the latest message even if this message had been deleted
Instead, messaging menu now shows the latest non-deleted
message
This commit also adds a test to verify this behavior