### PR TITLE
[FIX] mail: thread update wrongly through public

### DIFF
--- a/addons/mail/static/src/new/public/discuss_public.js
+++ b/addons/mail/static/src/new/public/discuss_public.js
@@ -21,6 +21,7 @@ export class DiscussPublic extends Component {
         useEffect(
             (welcome) => {
                 if (!welcome) {
+                    this.threadService.setDiscussThread(this.thread);
                     this.threadService.fetchChannelMembers(this.thread);
                     // Change the URL to avoid leaking the invitation link.
                     window.history.replaceState(
@@ -33,7 +34,6 @@ export class DiscussPublic extends Component {
             () => [this.state.welcome]
         );
         this.threadService = useService("mail.thread");
-        this.threadService.setDiscussThread(this.thread);
     }
 
     get thread() {

--- a/addons/mail/static/src/new/public/welcome_page.js
+++ b/addons/mail/static/src/new/public/welcome_page.js
@@ -30,14 +30,10 @@ export class WelcomePage extends Component {
         }
         if (this.props.data?.discussPublicViewData.addGuestAsMemberOnJoin) {
             await this.messaging.rpc("/mail/channel/add_guest_as_member", {
-                channel_id: this.thread.id,
-                channel_uuid: this.thread.uuid,
+                channel_id: this.props.data.channelData.id,
+                channel_uuid: this.props.data.channelData.uuid,
             });
         }
         this.props.proceed?.();
-    }
-
-    get thread() {
-        return this.store.threads[this.store.discuss.threadLocalId];
     }
 }


### PR DESCRIPTION
should fetch thread only after the welcome page.
bugs due to this: call cannot ended first time into the public page