### PR TITLE
[FIX] mail: runbot red again

### DIFF
--- a/addons/im_livechat/static/src/new/core/thread_service_patch.js
+++ b/addons/im_livechat/static/src/new/core/thread_service_patch.js
@@ -23,9 +23,10 @@ patch(ThreadService.prototype, "im_livechat", {
     /**
      * @override
      * @param {import("@mail/new/core/thread_model").Thread} thread
+     * @param {boolean} pushState
      */
-    setDiscussThread(thread) {
-        this._super(thread);
+    setDiscussThread(thread, pushState) {
+        this._super(thread, pushState);
         if (this.store.isSmall && thread.type === "livechat") {
             this.store.discuss.activeTab = "livechat";
         }

--- a/addons/mail/static/src/new/core/thread_service.js
+++ b/addons/mail/static/src/new/core/thread_service.js
@@ -414,8 +414,9 @@ export class ThreadService {
 
     /**
      * @param {import("@mail/new/core/thread_model").Thread} thread
+     * @param {boolean} pushState
      */
-    setDiscussThread(thread) {
+    setDiscussThread(thread, pushState = true) {
         this.store.discuss.threadLocalId = thread.localId;
         const activeId =
             typeof thread.id === "string" ? `mail.box_${thread.id}` : `mail.channel_${thread.id}`;
@@ -426,7 +427,9 @@ export class ThreadService {
             : ["chat", "group"].includes(thread.type)
             ? "chat"
             : "channel";
-        this.router.pushState({ active_id: activeId });
+        if (pushState) {
+            this.router.pushState({ active_id: activeId });
+        }
     }
 
     async createGroupChat({ default_display_mode, partners_to }) {

--- a/addons/mail/static/src/new/public/discuss_public.js
+++ b/addons/mail/static/src/new/public/discuss_public.js
@@ -22,7 +22,7 @@ export class DiscussPublic extends Component {
         useEffect(
             (welcome) => {
                 if (!welcome) {
-                    this.threadService.setDiscussThread(this.thread);
+                    this.threadService.setDiscussThread(this.thread, false);
                     this.threadService.fetchChannelMembers(this.thread);
                     // Change the URL to avoid leaking the invitation link.
                     window.history.replaceState(


### PR DESCRIPTION
`pushState: makeDebouncedPush("push")` will have a race problem with `window.history.replaceState()`, which leads to the URL change again after we hide it from `window.history.replaceState()`