### PR TITLE
[FIX] mail: fix traceback when changing the activity type

### DIFF
--- a/addons/mail/static/src/new/web/activity/activity.js
+++ b/addons/mail/static/src/new/web/activity/activity.js
@@ -44,9 +44,7 @@ export class Activity extends Component {
         onWillUpdateProps((nextProps) => {
             this.delay = computeDelay(nextProps.data.date_deadline);
         });
-        if (this.props.data.activity_category === "upload_file") {
-            this.attachmentUploader = useAttachmentUploader(this.thread);
-        }
+        this.attachmentUploader = useAttachmentUploader(this.thread);
     }
 
     get displayName() {


### PR DESCRIPTION
To reproduce:
- Create a todo activity (or anything else that is not "Upload a document")
- Edit this activity and change the type to "Upload a document"
- Try to upload a document => stacktrace

This is because the setup isn't refreshed when changing the activity type.