### PR TITLE
[FIX] mail: display send button on composer when device is small

### DIFF
--- a/addons/mail/static/src/new/composer/composer.xml
+++ b/addons/mail/static/src/new/composer/composer.xml
@@ -75,8 +75,16 @@
                         <button t-if="thread and thread.type === 'chatter'" class="btn btn-light fa fa-expand mx-1 border-0 rounded-pill" title="Full composer" aria-label="Full composer" type="button" t-on-click="onClickFullComposer"/>
                     </div>
                 </div>
-
-                <t t-if="!compact" t-call="mail.Composer.actionButtons"/>
+                <button t-if="!compact or store.isSmall" class="o-mail-composer-send-button btn btn-primary o-last border-start-0"
+                    t-att-class="{'mt-2': extended, 'rounded-0 rounded-end-3': !extended and !compact, 'align-self-stretch': !extended}"
+                    t-on-click="sendMessage"
+                    type="button"
+                    t-att-disabled="isSendButtonDisabled"
+                    aria-label="Send"
+                >
+                    <t t-if="this.store.isSmall"><i class="fa fa-paper-plane-o"/></t>
+                    <t t-else="">Send</t>
+                </button>
             </div>
             <div class="o-mail-composer-footer overflow-auto">
                 <AttachmentList
@@ -126,26 +134,4 @@
             <t t-esc="option.label"/>
         </em>
     </t>
-
-    <t t-name="mail.Composer.actionButtons" owl="1">
-        <div class="d-flex"
-            t-att-class="{
-                'border-end border-start border-bottom': compact,
-                'rounded-end-3 bg-view align-self-stretch' : normal,
-                'flex-column' : extended,
-            }"
-        >
-            <button class="o-mail-composer-send-button btn btn-primary o-last border-start-0"
-                t-att-class="{'mt-2': extended, 'rounded-0 rounded-end-3': !extended}"
-                t-on-click="sendMessage"
-                type="button"
-                t-att-disabled="isSendButtonDisabled"
-            >
-                Send
-            </button>
-        </div>
-    </t>
-
-
-
 </templates>

--- a/addons/mail/static/tests/new/composer/composer_tests.js
+++ b/addons/mail/static/tests/new/composer/composer_tests.js
@@ -25,6 +25,7 @@ import {
     triggerHotkey,
 } from "@web/../tests/helpers/utils";
 import { Composer } from "@mail/new/composer/composer";
+import { patchUiSize, SIZES } from "../../helpers/patch_ui_size";
 
 let target;
 
@@ -333,6 +334,18 @@ QUnit.test('send button on mail.channel should have "Send" as label', async func
         target.querySelector(".o-mail-composer-send-button").textContent.trim(),
         "Send"
     );
+});
+
+QUnit.test("Show send button in mobile", async function (assert) {
+    const pyEnv = await startServer();
+    patchUiSize({ size: SIZES.SM });
+    pyEnv["mail.channel"].create({ name: "minecraft-wii-u" });
+    const { openDiscuss } = await start();
+    await openDiscuss();
+    await click("button:contains(Channel)");
+    await click(".o-mail-notification-item:contains(minecraft-wii-u)");
+    assert.containsOnce(target, ".o-mail-composer button[aria-label='Send']");
+    assert.containsOnce(target, ".o-mail-composer button[aria-label='Send'] i.fa-paper-plane-o");
 });
 
 QUnit.test(


### PR DESCRIPTION
This commit displays the send button on the composer when
this.store.isSmall is true, and display the button with an enveloppe
icon instead of "Send" text

This commit also adds a test for this behavior