### PR TITLE
[IMP] web: prevent mouse over other systray item from closing menu

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -282,17 +282,6 @@ export class Dropdown extends Component {
     }
 
     /**
-     * Opens the dropdown the mouse enters its toggler.
-     * NB: only if its siblings dropdown group is opened and if not a sub dropdown.
-     */
-    onTogglerMouseEnter() {
-        if (this.state.groupIsOpen && !this.state.open) {
-            this.togglerRef.el.focus();
-            this.open();
-        }
-    }
-
-    /**
      * Used to close ourself on outside click.
      *
      * @param {MouseEvent} ev

--- a/addons/web/static/src/core/dropdown/dropdown.xml
+++ b/addons/web/static/src/core/dropdown/dropdown.xml
@@ -21,7 +21,6 @@
         "
         t-att-disabled="props.isDisabled"
         t-on-click.stop="onTogglerClick"
-        t-on-mouseenter="onTogglerMouseEnter"
         t-att-title="props.title"
         t-att-data-hotkey="props.hotkey"
         t-att-data-tooltip="props.tooltip"

--- a/addons/web/static/src/core/dropdown/dropdown_navigation_hook.js
+++ b/addons/web/static/src/core/dropdown/dropdown_navigation_hook.js
@@ -48,15 +48,6 @@ export function useDropdownNavigation() {
         originalOnTogglerClick();
     };
 
-    // Needed to avoid unwanted mouseenter behavior on a subdropdown toggler.
-    const originalOnTogglerMouseEnter = comp.onTogglerMouseEnter.bind(comp);
-    comp.onTogglerMouseEnter = () => {
-        if (comp.parentDropdown) {
-            return;
-        }
-        originalOnTogglerMouseEnter();
-    };
-
     // Needed to avoid unwanted selection when the mouse pointer is not in use
     // but still somewhere in the middle of the dropdown menu list.
     let mouseSelectionActive = true;


### PR DESCRIPTION
This is particularly painful when opening the activity or messaging menu and trying to click on a item of the menu diagonally from the icon.