### PR TITLE
[IMP] call: make the disconnection on browser shutdown more consistent

### DIFF
--- a/addons/mail/static/src/new/rtc/rtc_service.js
+++ b/addons/mail/static/src/new/rtc/rtc_service.js
@@ -225,9 +225,16 @@ export class Rtc {
             );
         });
 
-        browser.addEventListener("beforeunload", async (ev) => {
+        browser.addEventListener("pagehide", () => {
             if (this.state.channel) {
-                await this.rpcLeaveCall(this.state.channel);
+                const data = JSON.stringify({
+                    params: { channel_id: this.state.channel.id },
+                });
+                const blob = new Blob([data], { type: "application/json" });
+                // using sendBeacon allows sending a post request even when the
+                // browser prevents async requests from firing when the browser
+                // is closed. Alternatives like synchronous XHR are not reliable.
+                browser.navigator.sendBeacon("/mail/rtc/channel/leave_call", blob);
             }
         });
         /**


### PR DESCRIPTION
Before this commit,

1) We were using the `beforeunload` event which is not compatabile with the back/forward cache feature. We now use the `pageHide` event which does not have this downside.

2) Using odoo's rpc service or even synchronous XHR may not work in some browsers when the page is closed, `navigator.sendBeacon` is a more reliable way to send POST requests at that moment.