### PR TITLE
[FIX] mail: proper bg color of chatter in dark theme

### DIFF
--- a/addons/mail/static/src/new/web/chatter.xml
+++ b/addons/mail/static/src/new/web/chatter.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.chatter" owl="1">
-    <div class="o-mail-chatter bg-white h-100 flex-grow-1 d-flex flex-column overflow-auto" t-att-class="props.threadId === false ? 'o-chatter-disabled' : ''" t-ref="root">
+    <div class="o-mail-chatter bg-view h-100 flex-grow-1 d-flex flex-column overflow-auto" t-att-class="props.threadId === false ? 'o-chatter-disabled' : ''" t-ref="root">
         <div class="o-mail-chatter-topbar d-flex flex-shrink-0 flex-grow-0 pe-2">
             <button t-if="props.hasMessageList" class="o-mail-chatter-topbar-send-message-button btn text-nowrap me-2" t-att-class="{ 'btn-odoo': state.thread.composer.type !== 'note', 'btn-light': state.thread.composer.type === 'note', 'o-active': state.thread.composer.type === 'message', 'my-2': !props.compactHeight }" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
                 Send message


### PR DESCRIPTION
before:
<img width="904" alt="Screenshot 2023-03-08 at 14 42 40" src="https://user-images.githubusercontent.com/6569390/223728540-0596dfbd-2e7e-4484-b25d-f7eb1b3600a1.png">

after:
<img width="908" alt="Screenshot 2023-03-08 at 14 42 56" src="https://user-images.githubusercontent.com/6569390/223728588-992f0d53-760c-4cee-bb77-f56307630153.png">
