### PR TITLE
[FIX] mail: darker background in dark theme for activity menu

### DIFF
--- a/addons/mail/static/src/new/web/activity/activity_menu.xml
+++ b/addons/mail/static/src/new/web/activity/activity_menu.xml
@@ -8,7 +8,7 @@
             <span t-if="store.activityCounter" class="o-mail-activity-menu-counter badge"><t t-esc="store.activityCounter"/></span>
         </t>
         <t t-set-slot="default">
-            <div class="o-mail-activity-menu">
+            <div class="o-mail-activity-menu bg-view">
                 <div t-if="store.activityCounter === 0" class="o-mail-no-activity align-items-center text-muted p-2 opacity-50 d-flex justify-content-center">
                     <span>Congratulations, you're done with your activities.</span>
                 </div>


### PR DESCRIPTION
Before:
<img width="351" alt="Screenshot 2023-03-08 at 18 53 27" src="https://user-images.githubusercontent.com/6569390/223791935-dce3cd58-9533-406e-ae6b-b14c3c65fb94.png">

After:
<img width="354" alt="Screenshot 2023-03-08 at 18 53 37" src="https://user-images.githubusercontent.com/6569390/223791984-b38d1fb9-c63a-491e-9290-18cc82cbd6a2.png">
