### PR TITLE
[FIX] mail: message reception on channel join/knowledge of unpinned channels

### DIFF
--- a/addons/im_livechat/static/src/new/discuss/sidebar.js
+++ b/addons/im_livechat/static/src/new/discuss/sidebar.js
@@ -1,0 +1,12 @@
+/** @odoo-module */
+
+import { Sidebar } from "@mail/new/web/discuss/sidebar";
+import { patch } from "@web/core/utils/patch";
+
+patch(Sidebar.prototype, "im_livechat", {
+    get shouldDisplayLivechatCategory() {
+        return this.store.discuss.livechat.threads.some((localId) => {
+            this.store.threads[localId]?.is_pinned;
+        });
+    },
+});

--- a/addons/im_livechat/static/src/new/discuss/sidebar_patch.xml
+++ b/addons/im_livechat/static/src/new/discuss/sidebar_patch.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="im_livechat.DiscussSidebar" t-inherit="mail.DiscussSidebar" t-inherit-mode="extension" owl="1">
         <xpath expr="//*[@name='chatCategory']" position="before">
-            <t t-if="store.discuss.livechat.threads.length > 0" t-call="mail.DiscussCategory">
+            <t t-if="shouldDisplayLivechatCategory" t-call="mail.DiscussCategory">
                 <t t-set="category" t-value="store.discuss.livechat"/>
             </t>
         </xpath>

--- a/addons/mail/static/src/new/core/messaging_service.js
+++ b/addons/mail/static/src/new/core/messaging_service.js
@@ -382,7 +382,7 @@ export class Messaging {
                     if (!thread) {
                         return;
                     }
-                    this.threadService.remove(thread);
+                    thread.is_pinned = false;
                     this.notificationService.add(
                         sprintf(_t("You unpinned your conversation with %s"), thread.displayName),
                         { type: "info" }

--- a/addons/mail/static/src/new/web/discuss/sidebar.js
+++ b/addons/mail/static/src/new/web/discuss/sidebar.js
@@ -130,12 +130,12 @@ export class Sidebar extends Component {
     }
 
     filteredThreads(category) {
-        if (!this.state.quickSearchVal) {
-            return category.threads;
-        }
         return category.threads.filter((threadLocalId) => {
             const thread = this.store.threads[threadLocalId];
-            return thread.name.includes(this.state.quickSearchVal);
+            return (
+                (thread.is_pinned || thread.group_based_subscription) &&
+                (!this.state.quickSearchVal || thread.name.includes(this.state.quickSearchVal))
+            );
         });
     }
 


### PR DESCRIPTION
1 -

When a channel is joined by the user (that is, when a user joined without being invited), messages are not received until next page refresh.

This is due to the subscription being evaluated on channel insertion/ deletion. In thise case, the channel is inserted partially by the `joinChannel` method. The `onChange` method checks whether or not the current user is member or the channel in order to trigger the subscription, but since data is missing, the user is not yet part of the channel so the subscription is not trigerred.

In order to solve this issue, subscription is also evaluated when the channel members of a thread change.

2 -

When unpinning a channel, the thread is deleted from the `store`. This triggers a subscription while it should not: the user is stil listening to this thread, he just doesn't want it to be in the sidebar.

In order to solve this issue, the threads are now kept in memory when unpinned. (deleting it is not a good option imo because we most of the time, we will receive other messages and we will need to call the `channel_info` method, this could lead to lots of useless RPCs).