### PR TITLE
[FIX] mail: show separator on last failure if more items below

### DIFF
--- a/addons/mail/static/src/new/web/messaging_menu/messaging_menu.xml
+++ b/addons/mail/static/src/new/web/messaging_menu/messaging_menu.xml
@@ -68,7 +68,7 @@
                     datetime="failure.datetime"
                     displayName="failure.modelName"
                     iconSrc="failure.iconSrc"
-                    isLast="failure_last"
+                    isLast="displayedPreviews.length === 0 and failure_last"
                     hasMarkAsReadButton="true"
                     onClick="(isMarkAsRead) => isMarkAsRead ? this.cancelNotifications(failure) : this.onClickFailure(failure)"
                     onSwipeRight="hasTouch ? { action: () => this.cancelNotifications(failure), icon: 'fa-times-circle', bgColor: 'bg-warning' } : undefined"


### PR DESCRIPTION
Before:
![Screenshot 2023-03-13 at 18 32 47](https://user-images.githubusercontent.com/6569390/224782149-7f44ed9c-022b-4556-8648-3c7816746306.png)

After:
![Screenshot 2023-03-13 at 18 33 27](https://user-images.githubusercontent.com/6569390/224782185-84c3afac-b3cf-4b50-a476-b5fab2d7c80d.png)
