### PR TITLE
[IMP] mail: remove useless attachment view css rules

### DIFF
--- a/addons/mail/static/src/new/attachments/attachment_view.scss
+++ b/addons/mail/static/src/new/attachments/attachment_view.scss
@@ -1,11 +1,3 @@
-.modal {
-    @include media-breakpoint-up(xxl, $o-extra-grid-breakpoints) {
-        .o_attachment_preview_placeholder {
-            width: 300px;
-        }
-    }
-}
-
 @include media-breakpoint-up(xxl, $o-extra-grid-breakpoints) {
     .o_attachment_preview {
         display: block;
@@ -48,11 +40,5 @@
                 }
             }
         }
-    }
-}
-
-@include media-breakpoint-down(xxl, $o-extra-grid-breakpoints) {
-    .o_attachment_preview_placeholder {
-        display: none;
     }
 }


### PR DESCRIPTION
1 - display: none on `.o_attachment_preview` when with < `xxl`: attachment preview is not displayed when size is not `xxl`, see `hasAttachmentViewer` method.

2 - width: 300px on attachment preview contained by `modal`: `attachment_preview` only appears in the form view that is never embedded in a modal.