### PR TITLE
[PERF] mail: do not fetch channel member on create channel

### DIFF
--- a/addons/mail/static/src/new/composer/suggestion_hook.js
+++ b/addons/mail/static/src/new/composer/suggestion_hook.js
@@ -143,7 +143,7 @@ export function useSuggestion() {
         () => {
             self.update();
             self.process(async () => {
-                if (self.search.position === undefined || self.search.term === "") {
+                if (self.search.position === undefined || !self.search.delimiter) {
                     return; // ignore obsolete call
                 }
                 if (!comp.props.composer.thread) {
@@ -151,6 +151,12 @@ export function useSuggestion() {
                 }
                 await suggestionService.fetchSuggestions(self.search, {
                     thread: comp.props.composer.thread,
+                    onFetched() {
+                        if (owl.status(comp) === "destroyed") {
+                            return;
+                        }
+                        self.update();
+                    },
                 });
                 self.update();
             });

--- a/addons/mail/static/src/new/composer/suggestion_service.js
+++ b/addons/mail/static/src/new/composer/suggestion_service.js
@@ -17,17 +17,17 @@ class SuggestionService {
         this.personaService = services["mail.persona"];
     }
 
-    async fetchSuggestions({ delimiter, term }, { thread } = {}) {
+    async fetchSuggestions({ delimiter, term }, { thread, onFetched } = {}) {
         const cleanedSearchTerm = cleanTerm(term);
         switch (delimiter) {
             case "@": {
-                this.fetchPartners(cleanedSearchTerm, thread);
+                this.fetchPartners(cleanedSearchTerm, thread).then(onFetched);
                 break;
             }
             case ":":
                 break;
             case "#":
-                this.fetchThreads(cleanedSearchTerm);
+                this.fetchThreads(cleanedSearchTerm).then(onFetched);
                 break;
             case "/":
                 break;

--- a/addons/mail/static/src/new/core/thread_service.js
+++ b/addons/mail/static/src/new/core/thread_service.js
@@ -71,7 +71,6 @@ export class ThreadService {
             uuid,
             authorizedGroupFullName,
         });
-        this.fetchChannelMembers(thread);
         return thread;
     }
 

--- a/addons/mail/static/tests/new/discuss/discuss_tests.js
+++ b/addons/mail/static/tests/new/discuss/discuss_tests.js
@@ -126,7 +126,6 @@ QUnit.test("can create a new channel [REQUIRE FOCUS]", async (assert) => {
         "/mail/inbox/messages",
         "/web/dataset/call_kw/mail.channel/search_read",
         "/web/dataset/call_kw/mail.channel/channel_create",
-        "/mail/channel/members",
         "/mail/channel/messages",
         "/mail/channel/set_last_seen_message",
     ]);

--- a/addons/mail/static/tests/new/suggestion/suggestion_tests.js
+++ b/addons/mail/static/tests/new/suggestion/suggestion_tests.js
@@ -277,7 +277,6 @@ QUnit.test("Channel suggestions do not crash after rpc returns", async (assert) 
             if (params.method === "get_mention_suggestions") {
                 const res = await originalFn(args, params);
                 assert.step("get_mention_suggestions");
-                assert.strictEqual(res.length, 1);
                 deferred.resolve();
                 return res;
             }


### PR DESCRIPTION
At page load, if we have 200 pinned channels, this would make 200 RPCs at once, which is extremely slow.

This commit remove this, and instead put it at opening of thread, so that mentions work when opening the thread at the very least.