### PR TITLE
[FIX] mail: activity menu display

### DIFF
--- a/addons/mail/static/src/new/web/activity/activity_menu.xml
+++ b/addons/mail/static/src/new/web/activity/activity_menu.xml
@@ -12,7 +12,7 @@
                 <div t-if="store.activityGroups.length === 0" class="o-mail-ActivityMenu-empty align-items-center text-muted p-2 opacity-50 d-flex justify-content-center">
                     <span>Congratulations, you're done with your activities.</span>
                 </div>
-                <div class="d-flex flex-column flex-grow-1 overflow-hidden cursor-pointer" name="activityGroups">
+                <div class="d-flex flex-column overflow-hidden cursor-pointer" name="activityGroups">
                     <t t-foreach="store.activityGroups" t-as="group" t-key="group.id" name="activityGroupLoop">
                         <div class="o-mail-ActivityGroup d-flex p-2 border-bottom" t-att-data-model_name="group.model" t-on-click="() => this.openActivityGroup(group)">
                             <img alt="Activity" t-att-src="group.icon"/>

--- a/addons/note/static/src/new/web/activity/activity_menu.xml
+++ b/addons/note/static/src/new/web/activity/activity_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.ActivityMenu" t-inherit-mode="extension">
-        <xpath expr="//*[@name='activityGroups']" position="after">
+        <xpath expr="//*[@name='activityGroupLoop']" position="after">
             <div t-if="!state.addingNote" class="d-grid" t-on-click="() => this.state.addingNote = true">
                 <button type="button" class="btn text-center" t-on-click="() => this.state.addingNote = true">Add new note</button>
             </div>


### PR DESCRIPTION
Before this PR "Add new note"/"Request document" buttons were incorrectly displayed in mobile mode: one was at the top of the menu while the other was at the bottom.

This PR restores master behavior: both are at the top.

At the same time, this PR put the "Add new note" button before the "Request document" one since clicking on it will add a preview of the activity and this preview should be grouped with other activities.


enterprise: https://github.com/odoo-dev/enterprise/pull/518


Before:
![image](https://user-images.githubusercontent.com/48757558/225543950-73de1474-fb9c-4ded-880a-9a479ef20a84.png)
![image](https://user-images.githubusercontent.com/48757558/225544069-4053716c-384c-42ed-973c-1a373c61dfac.png)


After:
![image](https://user-images.githubusercontent.com/48757558/225543732-59e18991-fcd7-49a0-8beb-e510f14ebdbc.png)
