### PR TITLE
[IMP] mail: populate data for mail

### DIFF
--- a/addons/mail/__init__.py
+++ b/addons/mail/__init__.py
@@ -5,3 +5,4 @@ from . import models
 from . import tools
 from . import wizard
 from . import controllers
+from . import populate

--- a/addons/mail/populate/__init__.py
+++ b/addons/mail/populate/__init__.py
@@ -1,0 +1,3 @@
+from . import mail_channel
+from . import mail_channel_member
+from . import mail_message

--- a/addons/mail/populate/mail_channel.py
+++ b/addons/mail/populate/mail_channel.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+from odoo.tools import populate
+
+class Channel(models.Model):
+    _inherit = 'mail.channel'
+    _populate_dependencies = ["res.partner"]
+    _populate_sizes = {'small': 10, 'medium': 100, 'large': 500}
+
+    def _populate_factories(self):
+        return [
+            ('name', populate.constant('channel_{counter}')),
+            ('channel_type', populate.randomize(['channel', 'group'])),
+            ('description', populate.constant('channel_{counter}_description')),
+        ]

--- a/addons/mail/populate/mail_channel_member.py
+++ b/addons/mail/populate/mail_channel_member.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+from odoo.tools import populate
+
+class ChannelMember(models.Model):
+    _inherit = "mail.channel.member"
+    _populate_dependencies = ["res.partner", "mail.channel"]
+    _populate_sizes = {'small': 10, 'medium': 100, 'large': 1000}
+
+    def _populate_factories(self):
+        partner_ids = self.env.registry.populated_models["res.partner"]
+        channel_ids = self.env.registry.populated_models["mail.channel"]
+        return [
+            ("partner_id", populate.randomize(partner_ids)),
+            ("channel_id", populate.randomize(channel_ids)),
+        ]
+
+    def _populate(self, size):
+        channel_ids = self.env.registry.populated_models["mail.channel"]
+        for channel_id in channel_ids:
+            self.env['mail.channel.member'].create({
+                'partner_id': self.env.ref('base.user_admin').partner_id.id,
+                'channel_id': channel_id
+            })
+        return super()._populate(size)

--- a/addons/mail/populate/mail_message.py
+++ b/addons/mail/populate/mail_message.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+from odoo.tools import populate
+
+class Message(models.Model):
+    _inherit = 'mail.message'
+    _populate_dependencies = ['mail.channel', 'mail.channel.member', 'res.partner']
+    _populate_sizes = {'small': 1000, 'medium': 10000, 'large': 500000}
+
+    def _populate_factories(self):
+        channel_ids = self.env.registry.populated_models['mail.channel']
+
+        def get_author_id(values, counter, random):
+            channel = self.env[values['model']].browse(values['res_id'])
+            channel_member_ids = [channel['id'] for channel in channel.channel_member_ids.read(['id'])]
+            return random.choice(channel_member_ids)
+
+        return [
+            ('body', populate.constant('message_body_{counter}')),
+            ('message_type', populate.constant('comment')), ('model', populate.constant('mail.channel')),
+            ('res_id', populate.randomize(channel_ids)),
+            ('author_id', populate.compute(get_author_id)),
+        ]


### PR DESCRIPTION
This PR add a populate command for models `mail.channel`, `mail.channel.member`
and `mail.message`.
It will only create channel of type `channel` and `group`.

I used this bash function to quickly delete/create a database and populate it.

```bash
# Quickly drop the current db (it use the git branch name as database name) and
# create a new one that will be populated.
# usage: odoo-populate model_name size
odoo-populate() {
    dropdb $(git branch --show-current)
    odoo -i mail --stop-after-init
    ./odoo-bin populate --models $1 --size $2 -d $(git branch --show-current) --addons-path=~/projets/pro/odoo/addons,~/projets/pro/enterprise --c ~/projets/pro/.odoorc
}
```