### PR TITLE
[FIX] mail: download log button

### DIFF
--- a/addons/mail/static/src/rtc/call_settings.js
+++ b/addons/mail/static/src/rtc/call_settings.js
@@ -62,16 +62,17 @@ export class CallSettings extends Component {
     }
 
     onClickDownloadLogs() {
-        const data = window.JSON.stringify(Object.fromEntries(this.rtc.state.logs));
-        const blob = new window.Blob([data], { type: "application/json" });
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `RtcLogs_Channel_${this.rtc.state.logs.channelId}_Session_${
-            this.rtc.state.logs.selfSessionId
-        }_${luxon.DateTime.now().toFormat("yyyy-ll-dd_HH-mm")}.json`;
-        a.click();
-        window.URL.revokeObjectURL(url);
+        const data = JSON.stringify(Object.fromEntries(this.rtc.state.logs));
+        const blob = new Blob([data], { type: "application/json" });
+        const downloadLink = document.createElement("a");
+        const channelId = this.rtc.state.logs.get("channelId");
+        const sessionId = this.rtc.state.logs.get("selfSessionId");
+        const now = luxon.DateTime.now().toFormat("yyyy-ll-dd_HH-mm");
+        downloadLink.download = `RtcLogs_Channel_${channelId}_Session_${sessionId}_${now}.json`;
+        const url = URL.createObjectURL(blob);
+        downloadLink.href = url;
+        downloadLink.click();
+        URL.revokeObjectURL(url);
     }
 
     onClickRegisterKeyButton() {

--- a/addons/mail/static/src/rtc/call_settings.xml
+++ b/addons/mail/static/src/rtc/call_settings.xml
@@ -98,7 +98,7 @@
                     </label>
                 </div>
                 <div t-if="userSettings.logRtc" class="mb-3 d-flex align-items-center flex-wrap">
-                    <button class="btn btn-primary" t-on-click="onClickDownloadLogs">Download logs</button>
+                    <button class="btn btn-primary" t-att-disabled="rtc.state.logs.size === 0" t-on-click="onClickDownloadLogs">Download logs</button>
                 </div>
             </div>
         </div>

--- a/addons/mail/static/src/rtc/rtc_service.js
+++ b/addons/mail/static/src/rtc/rtc_service.js
@@ -1464,8 +1464,6 @@ export const rtcService = {
                 }
             }
         });
-        // debugging. remove this
-        window.rtc = rtc;
         return rtc;
     },
 };


### PR DESCRIPTION
Before this PR, the log button was always displayed when checking "log RTC events" setting.

This is wrong because there is possibly no rtc session, so the log file would be empty and would contain undefined in its name `RtcLogs_undefined_Session_undefined...`.

Moreover, the move of the download button to the user settings is questionable: once a RTC session has been initiated, the "download logs" button will be available in every single channel, while logs only relate to one channel (the one of the last RTC session).

Since this feature is linked to a single call, this commit put it back to its original place: the call action list.