### PR TITLE
Poc fields supportedOptions

### DIFF
--- a/addons/sms/static/src/components/phone_field/phone_field.js
+++ b/addons/sms/static/src/components/phone_field/phone_field.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { _lt } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 import { PhoneField, phoneField, formPhoneField } from "@web/views/fields/phone/phone_field";
 import { SendSMSButton } from '@sms/components/sms_button/sms_button';
@@ -25,6 +26,16 @@ const patchDescr = {
         props.enableButton = options.enable_sms;
         return props;
     },
+    supportedOptions: [{
+        name: "enable_sms",
+        string: _lt("Enable SMS"),
+        type: "boolean",
+        getValue({ options }) {
+            return options && "enable_sms" in options
+                ? options.enable_sms
+                : true;
+        },
+    }],
 };
 
 patch(phoneField, "sms.PhoneField", patchDescr);

--- a/addons/web/static/src/views/fields/boolean_icon/boolean_icon_field.js
+++ b/addons/web/static/src/views/fields/boolean_icon/boolean_icon_field.js
@@ -24,6 +24,13 @@ export class BooleanIconField extends Component {
 export const booleanIconField = {
     component: BooleanIconField,
     displayName: _lt("Boolean Icon"),
+    supportedOptions: [
+        {
+            name: "icon",
+            string: _lt("Icon"),
+            type: "string",
+        },
+    ],
     supportedTypes: ["boolean"],
     extractProps: ({ options, string }) => ({
         icon: options.icon,

--- a/addons/web/static/src/views/fields/daterange/daterange_field.js
+++ b/addons/web/static/src/views/fields/daterange/daterange_field.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { _lt } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { loadJS } from "@web/core/assets";
 import { luxonToMoment, momentToLuxon } from "@web/core/l10n/dates";
@@ -157,6 +158,18 @@ export class DateRangeField extends Component {
 
 export const dateRangeField = {
     component: DateRangeField,
+    supportedOptions: [
+        {
+            name: "related_start_date",
+            string: _lt("Related Start Date"),
+            type: "selection",
+        },
+        {
+            name: "related_end_date",
+            string: _lt("Related End Date"),
+            type: "selection",
+        },
+    ],
     supportedTypes: ["date", "datetime"],
     extractProps: ({ attrs, options }) => ({
         relatedEndDateField: options.related_end_date,

--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -134,6 +134,20 @@ export class ImageField extends Component {
 export const imageField = {
     component: ImageField,
     displayName: _lt("Image"),
+    supportedOptions: [
+        {
+            name: "size",
+            string: _lt("Size"),
+            type: "selection",
+            getChoices() {
+                return [
+                    { label: _lt("Small"), value: [0, 90] },
+                    { label: _lt("Medium"), value: [0, 180] },
+                    { label: _lt("Large"), value: [0, 270] },
+                ];
+            },
+        },
+    ],
     supportedTypes: ["binary"],
     fieldDependencies: [{ name: "write_date", type: "datetime" }],
     extractProps: ({ attrs, options }) => ({

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -255,6 +255,13 @@ export class Many2ManyTagsField extends Component {
 export const many2ManyTagsField = {
     component: Many2ManyTagsField,
     displayName: _lt("Tags"),
+    supportedOptions: [
+        {
+            name: "color_field",
+            string: _lt("Use colors"),
+            type: "boolean",
+        },
+    ],
     supportedTypes: ["many2many"],
     isSet: (value) => value.count > 0,
     relatedFields: ({ options }) => {

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
@@ -147,6 +147,42 @@ export class ProgressBarField extends Component {
 export const progressBarField = {
     component: ProgressBarField,
     displayName: _lt("Progress Bar"),
+    supportedOptions: [
+        {
+            name: "editable",
+            string: _lt("Editable"),
+            type: "boolean",
+        },
+        {
+            name: "edit_max_value",
+            string: _lt("Edit max value"),
+            type: "boolean",
+        },
+        {
+            name: "current_value",
+            string: _lt("Current value"),
+            type: "selection",
+            getChoices({ fields }) {
+                return fields
+                    .filter((f) => ["integer", "float"].includes(f.type))
+                    .map((f) => {
+                        return { label: `${f.string} (${f.name})`, value: f.name };
+                    });
+            },
+        },
+        {
+            name: "max_value",
+            string: _lt("Max value"),
+            type: "selection",
+            getChoices({ fields }) {
+                return fields
+                    .filter((f) => ["integer", "float"].includes(f.type))
+                    .map((f) => {
+                        return { label: `${f.string} (${f.name})`, value: f.name };
+                    });
+            },
+        },
+    ],
     supportedTypes: ["integer", "float"],
     extractProps: ({ attrs, options }) => ({
         maxValueField: options.max_value,

--- a/addons/web/static/src/views/fields/radio/radio_field.js
+++ b/addons/web/static/src/views/fields/radio/radio_field.js
@@ -70,6 +70,13 @@ export class RadioField extends Component {
 export const radioField = {
     component: RadioField,
     displayName: _lt("Radio"),
+    supportedOptions: [
+        {
+            name: "horizontal",
+            string: _lt("Display horizontally"),
+            type: "boolean",
+        },
+    ],
     supportedTypes: ["many2one", "selection"],
     isEmpty: (record, fieldName) => record.data[fieldName] === false,
     extractProps: ({ options, string }) => ({

--- a/addons/web/static/src/views/fields/signature/signature_field.js
+++ b/addons/web/static/src/views/fields/signature/signature_field.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { _lt } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { SignatureDialog } from "@web/core/signature/signature_dialog";
 import { useService } from "@web/core/utils/hooks";
@@ -137,6 +138,20 @@ export class SignatureField extends Component {
 
 export const signatureField = {
     component: SignatureField,
+    supportedOptions: [
+        {
+            name: "full_name",
+            string: _lt("Auto-complete with"),
+            type: "selection",
+            getChoices({ fields }) {
+                return fields
+                    .filter((f) => ["char", "many2one"].includes(f.type))
+                    .map((f) => {
+                        return { label: `${f.string} (${f.name})`, value: f.name };
+                    });
+            },
+        },
+    ],
     extractProps: ({ attrs, options }) => ({
         defaultFont: options.default_font || "",
         fullName: options.full_name,


### PR DESCRIPTION
I moved the declaration of options directly to field metadata instead of manually describing them in a dedicated file that no one will update after a field has been created