### PR TITLE
[IMP] web, *: fix layout issues for Milk - Part 2

### DIFF
--- a/addons/mail/static/src/core_ui/message.xml
+++ b/addons/mail/static/src/core_ui/message.xml
@@ -127,7 +127,7 @@
                                     <Composer autofocus="true" composer="message.composer" messageComponent="constructor" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'"/>
                                 </div>
                             </div>
-                            <div t-if="props.hasActions and !message.isTransient" class="o-mail-Message-actions bg-view"
+                            <div t-if="props.hasActions and !message.isTransient" class="o-mail-Message-actions"
                                 t-att-class="{
                                     'position-absolute top-0': !env.inDiscussApp,
                                     'start-0 ms-3': isAlignedRight,
@@ -141,7 +141,7 @@
                                     'o-expanded': state.expandOptions
                                 }"
                             >
-                                <div class="d-flex rounded-1 shadow-sm overflow-hidden alignedRight" t-att-class="{
+                                <div class="d-flex rounded-1 bg-view shadow-sm overflow-hidden alignedRight" t-att-class="{
                                         'mt-3': env.inChatter and !(message.isDiscussion or message.isNotification),
                                         'flex-row-reverse': env.inChatWindow and isAlignedRight,
                                     }"

--- a/addons/mail/static/src/web/message_patch.xml
+++ b/addons/mail/static/src/web/message_patch.xml
@@ -20,7 +20,7 @@
                         </t>
                     </ul>
                 </t>
-                <div t-if="message.body" class="o-mail-Message-body text-break mb-0 bg-view w-100" t-ref="body">
+                <div t-if="message.body" class="o-mail-Message-body text-break mb-0 w-100" t-ref="body">
                     <t t-out="message.body"/>
                 </div>
             </t>

--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -135,7 +135,7 @@ $font-size-sm: $o-font-size-base-small !default;
 $table-striped-color: inherit !default;
 $table-striped-bg-factor: .01 !default;
 $table-hover-bg-factor: .055 !default;
-$table-border-color: $gray-200 !default;
+$table-border-color: $border-color !default;
 $table-group-separator-color: $gray-200 !default;
 $table-cell-padding-x: .75rem !default;
 $table-cell-padding-y: .75rem !default;

--- a/addons/web/static/src/scss/utilities_custom.scss
+++ b/addons/web/static/src/scss/utilities_custom.scss
@@ -183,9 +183,20 @@ $utilities: map-merge(
             values: 0,
         ),
 
-        // Disable 'text-X' and 'text-X' generation.
+        // For the other 'text-X' classes.
         // See bootstrap_review_backend.scss
-        "color": null,
+        "color": (
+            property: color,
+            class: text,
+            local-vars: (
+                "text-opacity": 1
+            ),
+            values: (
+                "body": $body-color,
+                "muted": $text-muted,
+                "reset": inherit,
+            ),
+        ),
         "background-color": null
     )
 );

--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -63,7 +63,7 @@
 
     <t t-name="web.FormView.Buttons" owl="1">
         <div class="o_cp_buttons d-flex align-items-baseline" role="toolbar" aria-label="Main actions" t-ref="cpButtons">
-            <div t-if="model.root.isInEdition" class="o_form_buttons_edit">
+            <div t-if="model.root.isInEdition" class="o_form_buttons_edit d-flex gap-1">
                 <button type="button" class="btn btn-primary o_form_button_save" data-hotkey="s" t-on-click.stop="() => this.saveButtonClicked({closable: true})">
                     Save
                 </button>

--- a/addons/web/static/src/views/graph/graph_renderer.xml
+++ b/addons/web/static/src/views/graph/graph_renderer.xml
@@ -28,8 +28,8 @@
     </t>
 
     <t t-name="web.GraphRenderer" owl="1">
-        <div t-att-class="'o_graph_renderer o_renderer h-100 d-flex flex-column ' + props.class" t-ref="root">
-            <div>
+        <div t-att-class="'o_graph_renderer o_renderer h-100 d-flex flex-column border-top ' + props.class" t-ref="root">
+            <div class="d-flex gap-1 mt-2 mx-3 mb-3">
                 <t t-call="web.GraphView.Buttons"/>
             </div>
             <div class="o_graph_canvas_container flex-grow-1 position-relative" t-ref="container">

--- a/addons/web/static/src/views/pivot/pivot_controller.xml
+++ b/addons/web/static/src/views/pivot/pivot_controller.xml
@@ -2,17 +2,19 @@
 <templates xml:space="preserve">
 
     <t t-name="web.PivotView.Buttons" owl="1">
-        <div class="btn-group" role="toolbar" aria-label="Main actions">
-            <t t-call="web.ReportViewMeasures">
-                <t t-set="measures" t-value="model.metaData.measures"/>
-                <t t-set="activeMeasures" t-value="model.metaData.activeMeasures"/>
-            </t>
-        </div>
-        <div class="btn-group" role="toolbar" aria-label="Pivot settings">
-            <t t-set="noDataDisplayed" t-value="!model.hasData() || !model.metaData.activeMeasures.length"/>
-            <button class="btn btn-secondary fa fa-exchange o_pivot_flip_button" t-on-click="onFlipButtonClicked" data-tooltip="Flip axis" aria-label="Flip axis" t-attf-disabled="{{noDataDisplayed ? 'disabled' : false}}"/>
-            <button class="btn btn-secondary fa fa-arrows o_pivot_expand_button" t-on-click="onExpandButtonClicked" data-tooltip="Expand all" aria-label="Expand all" t-attf-disabled="{{noDataDisplayed ? 'disabled' : false}}"/>
-            <button class="btn btn-secondary fa fa-download o_pivot_download" t-on-click="onDownloadButtonClicked" data-tooltip="Download xlsx" aria-label="Download xlsx" t-attf-disabled="{{noDataDisplayed ? 'disabled' : false}}"/>
+        <div class="d-flex gap-1 mt-2 mx-3 mb-3">
+            <div class="btn-group" role="toolbar" aria-label="Main actions">
+                <t t-call="web.ReportViewMeasures">
+                    <t t-set="measures" t-value="model.metaData.measures"/>
+                    <t t-set="activeMeasures" t-value="model.metaData.activeMeasures"/>
+                </t>
+            </div>
+            <div class="btn-group" role="toolbar" aria-label="Pivot settings">
+                <t t-set="noDataDisplayed" t-value="!model.hasData() || !model.metaData.activeMeasures.length"/>
+                <button class="btn btn-secondary fa fa-exchange o_pivot_flip_button" t-on-click="onFlipButtonClicked" data-tooltip="Flip axis" aria-label="Flip axis" t-attf-disabled="{{noDataDisplayed ? 'disabled' : false}}"/>
+                <button class="btn btn-secondary fa fa-arrows o_pivot_expand_button" t-on-click="onExpandButtonClicked" data-tooltip="Expand all" aria-label="Expand all" t-attf-disabled="{{noDataDisplayed ? 'disabled' : false}}"/>
+                <button class="btn btn-secondary fa fa-download o_pivot_download" t-on-click="onDownloadButtonClicked" data-tooltip="Download xlsx" aria-label="Download xlsx" t-attf-disabled="{{noDataDisplayed ? 'disabled' : false}}"/>
+            </div>
         </div>
     </t>
 

--- a/addons/web/static/src/views/pivot/pivot_renderer.xml
+++ b/addons/web/static/src/views/pivot/pivot_renderer.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.PivotRenderer" owl="1">
         <t t-call="web.PivotView.Buttons"/>
-        <div class="o_pivot table-responsive">
+        <div class="o_pivot table-responsive mx-3">
 
             <table
                 class="table-hover table table-sm table-bordered table-borderless bg-view"
@@ -16,8 +16,9 @@
                             <t t-if="cell.measure" t-call="web.PivotMeasure"/>
                             <t t-elif="cell.isLeaf !== undefined" t-call="web.PivotHeader">
                                 <t t-set="isXAxis" t-value="true"/>
+                                <t t-set="isInHead" t-value="true"/>
                             </t>
-                            <th t-else="" t-att-colspan="cell.width" t-att-rowspan="cell.height" class="fw-normal border-start-0"/>
+                            <th t-else="" t-att-colspan="cell.width" t-att-rowspan="cell.height" class="fw-normal border-start-0" t-att-class="{ 'border-top': cell_index != 0 }"/>
                         </t>
                     </tr>
                 </thead>
@@ -55,12 +56,13 @@
 
     <t t-name="web.PivotHeader" owl="1">
         <th
-            class="text-nowrap cursor-pointer fw-normal user-select-none border-start-0"
+            class="text-nowrap cursor-pointer fw-normal user-select-none"
             t-att-colspan="isXAxis ? cell.width : undefined"
             t-att-rowspan="isXAxis ? cell.height : undefined"
             t-att-class="{
                 o_pivot_header_cell_closed: cell.isLeaf,
                 o_pivot_header_cell_opened: !cell.isLeaf,
+                'border-top': isInHead,                
             }"
             t-attf-style="{{
                 isXAxis

--- a/addons/web/static/src/views/view_button/view_button.js
+++ b/addons/web/static/src/views/view_button/view_button.js
@@ -25,7 +25,7 @@ function iconFromString(iconString) {
     const icon = {};
     if (iconString.startsWith("fa-")) {
         icon.tag = "i";
-        icon.class = `o_button_icon fa ${iconString}`;
+        icon.class = `o_button_icon fa me-1 ${iconString}`;
     } else {
         icon.tag = "img";
         icon.src = iconString;

--- a/addons/website/static/src/systray_items/edit_website.scss
+++ b/addons/website/static/src/systray_items/edit_website.scss
@@ -1,5 +1,3 @@
 .o_edit_website_container {
-    &:not(.o_translatable) {
-        margin: -$o-navbar-padding-v 0;
-    }
+    margin: -$o-navbar-padding-v 0;
 }

--- a/addons/website/static/src/systray_items/translate_website.scss
+++ b/addons/website/static/src/systray_items/translate_website.scss
@@ -1,3 +1,3 @@
 .o_translate_website_container {
-    @include button-variant($o-brand-primary, $o-brand-primary);
+    margin: -$o-navbar-padding-v 0;
 }

--- a/addons/website/static/src/systray_items/translate_website.xml
+++ b/addons/website/static/src/systray_items/translate_website.xml
@@ -3,7 +3,7 @@
 
     <t t-name="website.TranslateWebsiteSystray" owl="1">
         <div class="o_translate_website_container d-none d-md-block">
-            <a href="#" accesskey="t" t-on-click="startTranslate" class="text-reset">
+            <a href="#" accesskey="t" t-on-click="startTranslate" class="btn btn-secondary d-flex align-items-center h-100 rounded-0 border-0">
                 <span t-if="websiteContext.translation" class="fa fa-refresh fa-spin me-2"/>
                 TRANSLATE
             </a>


### PR DESCRIPTION
effd3a814f956159a934ef234ddc3a2c713e1259 (move `btn-group` in a parent div) & b6da2ed50fe12c7ebc7e94f25b6ef033e8f63276 :
-  Missing some padding for buttons in the Pivot and Graph views  https://www.awesomescreenshot.com/image/39360610?key=2d594d971863f8fa6b37cdd84c3b2bb2 


55d5d4ae651f21ffb5d1c6024c73b20c3da8a00b :
- Fix the table borders for Pivot


70eed1e7a689061348e997c169d9e160d9883249 :
- Website preview (iframe): Edit/translate buttons are not properly colorized https://bit.ly/44bgQB9 


548e876fef6726a2cba6979c16753001cfb546d3 :
- Missing padding between save/discard buttons in the Settings  https://tinyurl.com/2cnnbzp2


afc0a9eb4feea08f5cd950a5b3aa23297bb2a995 :
- Missing padding-right for "arrow" icons in shortcuts in the Settings (happens for a lot of links in the Settings, it's not juste for "users" section)  https://tinyurl.com/2aqfm2lz
- Missing padding for icons in buttons (e.g. <button type="object" name="something" icon="fa-clock" string="Start"/>​)  https://tinyurl.com/2xjt9j24


f8aaefef9f1b8cb86fb54f42cfdc74940ce7cadd :
- VOIP tab has mauve in its header (why not), which clashes with the "close" btn which is primary-color (title should be bg-white + text normal, or close btn should be white)  https://tinyurl.com/2c8dfrep
- Low contrast in Documents/mail thread "preview" download button (there are other buttons in some cases)   https://tinyurl.com/2yv4hatm


62472fd7d91bddc92ce2a32299fe9247f76b5c92 :
- Chatter : unwanted white background : https://tinyurl.com/5xaprr2w
- Chatter : unwanted padding : https://tinyurl.com/mr2dhay4


Requires:
- https://github.com/odoo-dev/enterprise/pull/538