### PR TITLE
Master milk cp dbo

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.xml
+++ b/addons/base_import/static/src/import_action/import_action.xml
@@ -3,7 +3,7 @@
     <t t-name="ImportAction" owl="1">
         <div class="h-100 d-flex flex-column">
             <Layout className="'o_import_action d-flex h-100 overflow-auto bg-white'" display="display">
-                <t t-set-slot="layout-buttons">
+                <t t-set-slot="control-panel-create-button">
                     <t t-if="isPreviewing">
                         <button t-if="!state.isPaused" type="button" class="btn btn-primary m-1" t-on-click="() => this.handleImport(false)">Import</button>
                         <button t-else="" type="button" class="btn btn-primary m-1" t-on-click="() => this.handleImport(false)">Resume</button>

--- a/addons/web/static/src/search/cog_menu/cog_menu.js
+++ b/addons/web/static/src/search/cog_menu/cog_menu.js
@@ -29,7 +29,7 @@ export class CogMenu extends Component {
     };
 
     get hasItems() {
-        return this.cogItems.length || !!this.slots?.default;
+        return this.cogItems.length || !!this.props.slots?.default;
     }
 
     get cogItems() {

--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -74,12 +74,12 @@ export class ControlPanel extends Component {
         this.mainButtons = useRef("mainButtons");
 
         useEffect(() => {
-            if (!this.env.isSmall) {
-                return;
-            }
             // on small screen, clean-up the dropdown elements
             const dropdownButtons = this.mainButtons.el.querySelectorAll(".dropdown-menu button");
             if (!dropdownButtons.length) {
+                this.mainButtons.el
+                .querySelectorAll(".o_control_panel_collapsed_create")
+                .forEach((el) => el.classList.remove("btn-group"));
                 this.mainButtons.el
                     .querySelectorAll(".dropdown-menu, .dropdown-toggle")
                     .forEach((el) => el.classList.add("d-none"));

--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -75,14 +75,14 @@ export class ControlPanel extends Component {
 
         useEffect(() => {
             // on small screen, clean-up the dropdown elements
-            const dropdownButtons = this.mainButtons.el.querySelectorAll(".dropdown-menu button");
+            const dropdownButtons = this.mainButtons.el.querySelectorAll(".o_control_panel_collapsed_create.dropdown-menu button");
             if (!dropdownButtons.length) {
                 this.mainButtons.el
-                .querySelectorAll(".o_control_panel_collapsed_create")
-                .forEach((el) => el.classList.remove("btn-group"));
-                this.mainButtons.el
-                    .querySelectorAll(".dropdown-menu, .dropdown-toggle")
+                    .querySelectorAll(".o_control_panel_collapsed_create.dropdown-menu, .o_control_panel_collapsed_create.dropdown-toggle")
                     .forEach((el) => el.classList.add("d-none"));
+                this.mainButtons.el
+                .querySelectorAll(".o_control_panel_collapsed_create.btn-group")
+                .forEach((el) => el.classList.remove("btn-group"));
                 return;
             }
             for (const button of dropdownButtons) {

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -3,15 +3,15 @@
 
     <t t-name="web.ControlPanel" owl="1">
         <div class="o_control_panel d-flex flex-column gap-3 gap-lg-1 px-3 pt-2 pb-3" t-ref="root">
-            <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-3 w-100 w-sm-auto">
+            <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-3 flex-grow-1">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0">
                     <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none 2" t-ref="mainButtons">
                         <div class="btn-group d-xl-none o_control_panel_collapsed_create">
                             <t t-slot="control-panel-create-button"/>
-                            <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                                <span class="visually-hidden">Toggle Dropdown</span>
+                            <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split o_control_panel_collapsed_create" data-bs-toggle="dropdown" aria-expanded="false">
+                                 <span class="visually-hidden">Toggle Dropdown</span>
                             </button>
-                            <ul class="dropdown-menu">
+                            <ul class="dropdown-menu o_control_panel_collapsed_create">
                                 <t t-slot="layout-buttons"/>
                                 <t t-slot="control-panel-always-buttons"/>
                             </ul>
@@ -39,7 +39,7 @@
                     <t t-slot="control-panel-selection-actions"/>
                 </div>
 
-                <div class="o_control_panel_navigation d-flex flex-wrap flex-md-nowrap align-items-center justify-content-end gap-3 gap-lg-1 gap-xl-3 order-1 order-lg-2 w-100 w-sm-auto">
+                <div class="o_control_panel_navigation d-flex flex-wrap flex-md-nowrap align-items-center justify-content-end gap-3 gap-lg-1 gap-xl-3 order-1 order-lg-2 flex-grow-1">
                     <div t-if="pagerProps and pagerProps.total > 0" class="o_cp_pager text-nowrap " role="search">
                         <Pager t-props="pagerProps"/>
                     </div>

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -31,7 +31,7 @@
                     <span class="d-none d-xl-block me-auto"/> <!-- Spacer -->
                 </div>
 
-                <div t-if="display.layoutActions" class="o_control_panel_actions d-flex align-items-center justify-content-around order-2 order-lg-1 w-100 w-lg-auto">
+                <div t-if="display.layoutActions" class="o_control_panel_actions d-empty-none d-flex align-items-center justify-content-around order-2 order-lg-1 w-100 w-lg-auto">
                     <t t-slot="layout-actions"/>
                 </div>
 

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -6,12 +6,15 @@
             <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-3 w-100 w-sm-auto">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0">
                     <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none 2" t-ref="mainButtons">
-                        <div class="btn-group d-xl-none">
+                        <div class="btn-group d-xl-none o_control_panel_collapsed_create">
                             <t t-slot="control-panel-create-button"/>
-                            <Dropdown class="'btn-group'" togglerClass="'btn btn-primary'" showCaret="true">
+                            <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                                <span class="visually-hidden">Toggle Dropdown</span>
+                            </button>
+                            <ul class="dropdown-menu">
                                 <t t-slot="layout-buttons"/>
                                 <t t-slot="control-panel-always-buttons"/>
-                            </Dropdown>
+                            </ul>
                         </div>
                         <div class="d-none d-xl-inline-flex gap-1">
                             <t t-slot="control-panel-create-button"/>

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -34,8 +34,9 @@
                     <span class="d-none d-xl-block me-auto"/> <!-- Spacer -->
                 </div>
 
-                <div t-if="display.layoutActions" class="o_control_panel_actions d-empty-none d-flex align-items-center justify-content-around order-2 order-lg-1 w-100 w-lg-auto">
-                    <t t-slot="layout-actions"/>
+                <div class="o_control_panel_actions d-empty-none d-flex align-items-center justify-content-start order-2 order-lg-1 w-100 w-lg-auto">
+                    <t t-if="display.layoutActions" t-slot="layout-actions"/>
+                    <t t-slot="control-panel-selection-actions"/>
                 </div>
 
                 <div class="o_control_panel_navigation d-flex flex-wrap flex-md-nowrap align-items-center justify-content-end gap-3 gap-lg-1 gap-xl-3 order-1 order-lg-2 w-100 w-sm-auto">

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -3,26 +3,21 @@
 
     <t t-name="web.ControlPanel" owl="1">
         <div class="o_control_panel d-flex flex-column gap-3 gap-lg-1 px-3 pt-2 pb-3" t-ref="root">
-            <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-3">
-                <div class="o_control_panel_breadcrumbs d-flex align-items-center justify-content-between w-100 w-md-50 w-lg-auto">
-                    <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none me-md-2 order-1 order-md-0" t-ref="mainButtons">
-                        <t t-if="env.isSmall">
-                            <div class="btn-group">
-                                <t t-slot="control-panel-create-button"/>
-                                <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                                    <span class="visually-hidden">Toggle Dropdown</span>
-                                </button>
-                                <ul class="dropdown-menu">
-                                    <t t-slot="layout-buttons"/>
-                                    <t t-slot="control-panel-always-buttons"/>
-                                </ul>
-                            </div>
-                        </t>
-                        <t t-else="">
+            <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-3 w-100 w-sm-auto">
+                <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0">
+                    <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none 2" t-ref="mainButtons">
+                        <div class="btn-group d-xl-none">
+                            <t t-slot="control-panel-create-button"/>
+                            <Dropdown class="'btn-group'" togglerClass="'btn btn-primary'" showCaret="true">
+                                <t t-slot="layout-buttons"/>
+                                <t t-slot="control-panel-always-buttons"/>
+                            </Dropdown>
+                        </div>
+                        <div class="d-none d-xl-inline-flex gap-1">
                             <t t-slot="control-panel-create-button"/>
                             <t t-slot="layout-buttons"/>
                             <t t-slot="control-panel-always-buttons"/>
-                        </t>
+                        </div>
                     </div>
                     <t t-if="env.config.noBreadcrumbs">
                         <section class="o_control_panel_breadcrumbs_actions d-contents">
@@ -36,41 +31,36 @@
                     <span class="d-none d-xl-block me-auto"/> <!-- Spacer -->
                 </div>
 
-                <div t-if="display.layoutActions" class="o_control_panel_actions d-flex align-items-center justify-content-around w-100 w-lg-auto order-3 order-lg-2">
+                <div t-if="display.layoutActions" class="o_control_panel_actions d-flex align-items-center justify-content-around order-2 order-lg-1 w-100 w-lg-auto">
                     <t t-slot="layout-actions"/>
                 </div>
 
-                <div class="o_control_panel_navigation d-flex flex-wrap flex-md-nowrap align-items-center justify-content-end w-100 w-md-auto gap-3 gap-lg-1 gap-xl-3 order-2 order-lg-3">
-                    <span class="d-none d-xl-block ms-auto"/> <!-- Spacer -->
-                    <div t-if="pagerProps and pagerProps.total > 0" class="o_cp_pager text-nowrap order-2 order-md-1" role="search">
+                <div class="o_control_panel_navigation d-flex flex-wrap flex-md-nowrap align-items-center justify-content-end gap-3 gap-lg-1 gap-xl-3 order-1 order-lg-2 w-100 w-sm-auto">
+                    <div t-if="pagerProps and pagerProps.total > 0" class="o_cp_pager text-nowrap " role="search">
                         <Pager t-props="pagerProps"/>
                     </div>
                     <t t-if="env.config.viewSwitcherEntries?.length > 1">
-                        <t t-if="env.isSmall">
-                            <Dropdown class="'o_cp_switch_buttons order-1 order-md-2'" togglerClass="'btn btn-secondary'" showCaret="true">
-                                <t t-set-slot="toggler">
-                                    <t t-set="activeView" t-value="env.config.viewSwitcherEntries.find((view) => view.active)"/>
-                                    <i class="oi-fw" t-att-class="activeView.icon"/>
-                                </t>
-                                <t t-foreach="env.config.viewSwitcherEntries" t-as="view" t-key="view.type">
-                                    <DropdownItem onSelected="() => this.onViewClicked(view.type)" class="view.active ? 'selected' : ''">
-                                        <i class="oi-fw" t-att-class="view.icon"/>
-                                        <span class="ms-1" t-out="view.name"/>
-                                    </DropdownItem>
-                                </t>
-                            </Dropdown>
-                        </t>
-                        <t t-else="">
-                            <nav class="o_cp_switch_buttons d-print-none btn-group order-1 order-md-2">
-                                <t t-foreach="env.config.viewSwitcherEntries" t-as="view" t-key="view.type">
-                                    <button class="btn btn-secondary o_switch_view "
-                                        t-attf-class="o_{{view.type}} {{view.icon}} {{view.active ? 'active' : ''}}"
-                                        t-att-data-tooltip="view.name"
-                                        t-on-click="() => this.onViewClicked(view.type)"
-                                        />
-                                </t>
-                            </nav>
-                        </t>
+                        <Dropdown class="'o_cp_switch_buttons d-xl-none btn-group'" togglerClass="'btn btn-secondary'" showCaret="true">
+                            <t t-set-slot="toggler">
+                                <t t-set="activeView" t-value="env.config.viewSwitcherEntries.find((view) => view.active)"/>
+                                <i class="oi-fw" t-att-class="activeView.icon"/>
+                            </t>
+                            <t t-foreach="env.config.viewSwitcherEntries" t-as="view" t-key="view.type">
+                                <DropdownItem onSelected="() => this.onViewClicked(view.type)" class="view.active ? 'selected' : ''">
+                                    <i class="oi-fw" t-att-class="view.icon"/>
+                                    <span class="ms-1" t-out="view.name"/>
+                                </DropdownItem>
+                            </t>
+                        </Dropdown>
+                        <nav class="o_cp_switch_buttons d-print-none d-none d-xl-inline-flex btn-group">
+                            <t t-foreach="env.config.viewSwitcherEntries" t-as="view" t-key="view.type">
+                                <button class="btn btn-secondary o_switch_view "
+                                    t-attf-class="o_{{view.type}} {{view.icon}} {{view.active ? 'active' : ''}}"
+                                    t-att-data-tooltip="view.name"
+                                    t-on-click="() => this.onViewClicked(view.type)"
+                                    />
+                            </t>
+                        </nav>
                     </t>
                 </div>
             </div>
@@ -120,7 +110,7 @@
         </div>
 
         <div t-else="" class="o_breadcrumb d-flex gap-1">
-            <div class="active d-flex fs-4 min-w-0">
+            <div class="active d-flex fs-4 min-w-0 align-items-center">
                 <span class="min-w-0 text-truncate" t-call="web.Breadcrumb.Name"/>
             </div>
             <t t-call="web.Breadcrumb.Actions"/>

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -9,6 +9,7 @@ import { fuzzyTest } from "@web/core/utils/search";
 import { SearchBarMenu } from "../search_bar_menu/search_bar_menu";
 import { useDebounced } from "@web/core/utils/timing";
 import { browser } from "@web/core/browser/browser";
+import { SIZES } from "@web/core/ui/ui_service";
 
 import { Component, onMounted, onWillUnmount, useExternalListener, useRef, useState } from "@odoo/owl";
 const parsers = registry.category("parsers");
@@ -23,13 +24,14 @@ export class SearchBar extends Component {
         this.fields = this.env.searchModel.searchViewFields;
         this.searchItemsFields = this.env.searchModel.getSearchItems((f) => f.type === "field");
         this.root = useRef("root");
+        this.ui = useService("ui");
 
         // core state
         this.state = useState({
             expanded: [],
             focusedIndex: 0,
             query: "",
-            showSearchBar: !this.env.isSmall,
+            showSearchBar: this.ui.size > SIZES.SM,
         });
 
         // derived state
@@ -56,10 +58,6 @@ export class SearchBar extends Component {
         this.onResize = useDebounced(this.onResize, 200);
         onMounted(() => browser.addEventListener("resize", this.onResize));
         onWillUnmount(() => browser.removeEventListener("resize", this.onResize));
-    }
-
-    onResize() {
-        this.state.showSearchBar = !this.env.isSmall;
     }
 
     /**
@@ -416,6 +414,10 @@ export class SearchBar extends Component {
     onItemMousemove(focusedIndex) {
         this.state.focusedIndex = focusedIndex;
         this.inputRef.el.focus();
+    }
+
+    onResize() {
+        this.state.showSearchBar = this.ui.size > SIZES.SM;
     }
 
     /**

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -7,8 +7,10 @@ import { KeepLast } from "@web/core/utils/concurrency";
 import { useAutofocus, useBus, useService } from "@web/core/utils/hooks";
 import { fuzzyTest } from "@web/core/utils/search";
 import { SearchBarMenu } from "../search_bar_menu/search_bar_menu";
+import { useDebounced } from "@web/core/utils/timing";
+import { browser } from "@web/core/browser/browser";
 
-import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount, useExternalListener, useRef, useState } from "@odoo/owl";
 const parsers = registry.category("parsers");
 
 const CHAR_FIELDS = ["char", "html", "many2many", "many2one", "one2many", "text", "properties"];
@@ -50,6 +52,14 @@ export class SearchBar extends Component {
 
         useExternalListener(window, "click", this.onWindowClick);
         useExternalListener(window, "keydown", this.onWindowKeydown);
+
+        this.onResize = useDebounced(this.onResize, 200);
+        onMounted(() => browser.addEventListener("resize", this.onResize));
+        onWillUnmount(() => browser.removeEventListener("resize", this.onResize));
+    }
+
+    onResize() {
+        this.state.showSearchBar = !this.env.isSmall;
     }
 
     /**

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -89,7 +89,7 @@
             <SearchBarMenu/>
         </div>
         <t t-portal="'.o_control_panel_navigation'">
-            <button t-attf-class="btn btn-secondary {{state.showSearchBar?'d-lg-none active':''}}" t-on-click="onToggleSearchBar">
+            <button t-attf-class="btn btn-secondary {{state.showSearchBar?'d-md-none active':''}}" t-on-click="onToggleSearchBar">
                 <i class="fa fa-fw fa-search"/>
             </button>
         </t>

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -88,8 +88,8 @@
             </div>
             <SearchBarMenu/>
         </div>
-        <t t-if="env.isSmall" t-portal="'.o_control_panel_navigation'">
-            <button class="btn btn-secondary" t-on-click="onToggleSearchBar">
+        <t t-portal="'.o_control_panel_navigation'">
+            <button t-attf-class="btn btn-secondary {{state.showSearchBar?'d-lg-none active':''}}" t-on-click="onToggleSearchBar">
                 <i class="fa fa-fw fa-search"/>
             </button>
         </t>

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -36,7 +36,7 @@
                 </t>
 
                 <t t-set-slot="control-panel-additional-actions">
-                    <div t-if="nbSelected" class="d-flex ms-3">
+                    <div t-if="nbSelected" class="d-flex ms-3 gap-1">
                         <t t-call="web.ListView.Selection"/>
                         <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id">
                             <MultiRecordViewButton

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -36,7 +36,14 @@
                 </t>
 
                 <t t-set-slot="control-panel-additional-actions">
-                    <div t-if="nbSelected" class="d-flex ms-3 gap-1">
+                    <CogMenu t-if="!nbSelected">
+                        <DropdownItem t-if="nbTotal and !nbSelected and activeActions.exportXlsx and isExportEnable" onSelected.bind="onDirectExportData">
+                            Export All
+                        </DropdownItem>
+                    </CogMenu>
+                </t>
+                <t t-set-slot="control-panel-selection-actions">
+                    <div t-if="nbSelected" class="d-flex gap-1">
                         <t t-call="web.ListView.Selection"/>
                         <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id">
                             <MultiRecordViewButton
@@ -62,23 +69,6 @@
                                 onActionExecuted="() => model.load()"/>
                         </t>
                     </div>
-                    <t t-else="">
-                        <CogMenu>
-                            <DropdownItem t-if="nbTotal and !nbSelected and activeActions.exportXlsx and isExportEnable" onSelected.bind="onDirectExportData">
-                                Export All
-                            </DropdownItem>
-                            <t t-if="props.info.actionMenus">
-                                <ActionMenusItems
-                                    getActiveIds="() => model.root.selection.map((r) => r.resId)"
-                                    context="props.context"
-                                    domain="props.domain"
-                                    items="actionMenuItems"
-                                    isDomainSelected="model.root.isDomainSelected"
-                                    resModel="model.root.resModel"
-                                    onActionExecuted="() => model.load()"/>
-                            </t>
-                        </CogMenu>
-                    </t>
                 </t>
                 <t t-component="props.Renderer" list="model.root" activeActions="activeActions" archInfo="archInfo" allowSelectors="props.allowSelectors" editable="editable" openRecord.bind="openRecord" noContentHelp="props.info.noContentHelp" onAdd.bind="createRecord"/>
             </Layout>


### PR DESCRIPTION
In short;

- move 'list selection ui' to another slot that is in the same div as the searchbar (way more clean in mobile, as it has its own dedicated row)
- cogmenu: do not display actions and print entries if no records is selected (like in v16); only 'global' actions (import, add to spreadsheet, etc.) should be there if no record is selected
- change the cp layout for better mobile (and intermediary sizes) behaviour:
  - searchbar will be hidden automatically under the lg breakpoint
  - collapse 'always' buttons into 'new' dropdown and view switcher into a dropdown under lg as well
The goal is to leave enough place to the breadcrumb and the pager (when there is one), as these elements can be rather sizable in some cases.

https://user-images.githubusercontent.com/9530767/235717452-7ab320b5-956f-4fa6-9244-ccf86c893e79.mp4

