### PR TITLE
[FIX] web: behavior of btn-link with custom contextual classes

### DIFF
--- a/addons/web/static/src/scss/bootstrap_review_backend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_backend.scss
@@ -83,11 +83,26 @@
 //    '$o-theme-text-colors' ones.
 $-o-theme-text-colors: map-merge($theme-colors, $o-theme-text-colors);
 
-// 2. Use different colors for links end buttons when in conjunction with
+// 2. Use different colors for links and buttons when in conjunction with
 //    'text-x' classes to keep consistency with previous versions of Bootstrap.
 //    To do so we pass the values through the 'text-emphasis-variant' mixin.
 @each $-name, $-value in $-o-theme-text-colors {
     @include text-emphasis-variant(".text-#{$-name}", $-value);
+}
+
+// 3. Adapt the behaviour of .btn-link buttons when in conjuction with contextual
+//    classes (eg. text-warning). 'muted' is set as default text color, while
+//    the contextual-class color will be used on ':hover'.
+//    Note: For the custom classes, this is duplicated below where the classes are
+//    generated with the o-gray
+.btn-link {
+    font-weight: $btn-font-weight;
+
+    @each $-name, $-color in $-o-theme-text-colors{
+        &.btn-#{$-name}, &.text-#{$-name} {
+            @include o-btn-link-variant($o-main-color-muted!important, o-text-color($-name) or $-color!important);
+        }
+    }
 }
 
 // 3. Cleanup temporary map
@@ -203,9 +218,22 @@ $-o-bg-colors-custom: map-merge($o-bg-colors-custom, $o-grays);
     }
 }
 
-// 3. Cleanup temporary maps
+// 4. Cleanup temporary maps
 $-o-text-colors-custom: null;
 $-o-bg-colors-custom: null;
+
+// 5. Adapt the behaviour of .btn-link buttons when in conjuction with the custom
+//    contextual classes (eg. text-action). 'muted' is set as default text color,
+//    while the contextual-class color will be used on ':hover'.
+//    Note: the same is done above for the '$theme-colors'. Here on the
+//    '$o-text-colors-custom' because we don't want it to apply on the '$o-grays'.
+.btn-link {
+    @each $-name, $-color in $o-text-colors-custom{
+        &.btn-#{$-name}, &.text-#{$-name} {
+            @include o-btn-link-variant($o-main-color-muted!important, o-text-color($-name) or $-color!important);
+        }
+    }
+}
 
 // Cards
 // ============================================================================

--- a/addons/web/static/src/views/fields/many2one/many2one_field.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.xml
@@ -45,7 +45,7 @@
                 <t t-if="hasExternalButton">
                     <button
                         type="button"
-                        class="btn btn-secondary fa o_external_button"
+                        class="btn btn-link text-action fa o_external_button"
                         t-att-class="env.inDialog ? 'fa-external-link' : 'fa-arrow-right'"
                         tabindex="-1"
                         draggable="false"

--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -58,28 +58,6 @@ kbd {
   line-height: 1.1;
 }
 
-//== Btn-link
-.btn-link {
-  font-weight: $btn-font-weight;
-
-  // -- Btn-link variations
-  // Adapt the behavieur of .btn-link buttons when in conjuction with contextual
-  // classes (eg. text-warning). 'muted' is set as default text color, while
-  // the contextual-class color will be used on ':hover'.
-
-  // Apply all theme-colors variations except "secondary"
-  @each $-name, $-color in map-remove($theme-colors, "secondary") {
-    &.btn-#{$-name}, &.text-#{$-name} {
-      @include o-btn-link-variant($o-main-color-muted!important, o-text-color($-name) or $-color!important);
-    }
-  }
-
-  // Specific behavieur for "secondary"
-  &.btn-secondary {
-    @include o-btn-link-variant($body-color, $headings-color);
-  }
-}
-
 // Set position of our custom o-dropdown-menu (not bootstrap)
 .o-dropdown-menu {
   top: 100%;


### PR DESCRIPTION
This change was initially done to fix the btn-link hover behavior in the many2one selection fields.

To fix this we had to make use of the `o-btn-link-variant` mixin on the text custom colors to apply the contextual class color on hover.

The mixin has been moved from the webclient to the bootstrap_review_backend file to use it on `$-o-theme-text-colors` map.

A duplication of the .btn-link adaptation using the mixin had to be done to be applied on the second map `$o-text-colors-custom`.