### PR TITLE
[FIX] hr_recruitment, mass_mailing, web, project: design fixes

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -78,8 +78,8 @@
                             groups="hr.group_hr_user"
                             attrs="{'invisible': [('emp_id', '=', False)]}">
                         <div class="o_field_widget o_stat_info">
-                            <span class="o_stat_text"><field name="employee_name" readonly="1"/></span>
-                            <span class="o_stat_value">Employee</span>
+                            <span class="o_stat_value"><field name="employee_name" readonly="1"/></span>
+                            <span class="o_stat_text">Employee</span>
                         </div>
                     </button>
                     <button name="action_applications_email"

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -27,13 +27,6 @@
         .o_statusbar_buttons {
             flex-grow: 1;
         }
-
-        .o_statusbar_status {
-            border-left: solid $o-gray-300 1px;
-        }
-    }
-    .o_mass_mailing_mailing_group {
-        margin-top: $o-sheet-cancel-tpadding + 33px;
     }
     .o-mail-Form-chatter {
         margin: 0;
@@ -183,7 +176,6 @@
 }
 
 .o_mass_mailing_mailing_form.o_mass_mailing_form_full_width .alert.alert-info:not(.o_invisible_modifier) {
-    margin: 0 0 0 12px;
     flex: 1;
     padding: unset;
     border-left-width: 1px;

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -58,7 +58,7 @@
             <field name="model">mailing.mailing</field>
             <field name="arch" type="xml">
                 <form string="Mailing" class="o_mass_mailing_mailing_form">
-                    <header style="min-height:31px;">
+                    <header class="pt-3">
                         <button name="action_launch" type="object" class="oe_highlight" string="Send"
                             attrs="{'invisible': [('state', 'in', ('in_queue',  'sending', 'done'))]}" data-hotkey="v"
                             confirm="This will send the email to all recipients. Are you sure you want to proceed?"
@@ -74,7 +74,7 @@
 
                         <field name="state" readonly="1" widget="statusbar"/>
                     </header>
-                    <div class="alert alert-info text-center" role="alert"
+                    <div class="alert alert-info my-0 mx-3 text-center" role="alert"
                         attrs="{'invisible': ['&amp;','&amp;','&amp;','&amp;','&amp;',('state', '!=', 'in_queue'),('sent', '=', 0),('canceled', '=', 0),('scheduled', '=', 0),('failed', '=', 0),('warning_message', '=', False)]}">
                         <div class="o_mails_canceled" attrs="{'invisible': [('canceled', '=', 0)]}">
                             <button class="btn-link py-0"

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.scss
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.scss
@@ -37,9 +37,11 @@ $o-rightpanel-p-tiny: $o-rightpanel-p-small*0.5;
         .o_form_view {
             .oe_button_box {
                 margin: -1px (-$o-rightpanel-p) 0;
+                box-shadow: inset 0 -1px 0 $border-color;
 
                 .oe_stat_button {
                     flex-basis: 25%;
+                    margin: 0;
 
                     &:nth-child(4n):not(:last-child) {
                         border-right-width: 0;

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
@@ -14,7 +14,7 @@
                             <ViewButton
                                 t-if="button.show"
                                 defaultRank="'oe_stat_button'"
-                                className="'h-auto py-2 border border-start-0 border-top-0 text-start'"
+                                className="'flex-grow-0 h-auto py-2 border border-start-0 border-top-0 text-start rounded-0'"
                                 icon="`fa-${button.icon}`"
                                 title="button.text"
                                 clickParams="_getStatButtonClickParams(button)"

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.scss
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.scss
@@ -10,11 +10,9 @@
         align-items: stretch;
 
         > .o_arrow_button {
-            min-height: $o-statusbar-height;
             position: relative;
             padding-left: $o-statusbar-arrow-width*2;
             border-radius: 0;
-            font-size: $font-size-sm;
 
             &:first-child {
                 @include border-end-radius($border-radius);


### PR DESCRIPTION
Various design fixes for milk 

16e25cbf98c22459a6aecc8d49424de1b7eac80a: 

- [GMF] Recruitment - Employee smartbutton on applicant https://i.imgur.com/jgvjbHb.png 

cac395871e13c1ec29dbfbb4e5a66cb0f177f7bf: 

- [SRI] Email marketing: Double stats bar https://cdn.discordapp.com/attachments/715901579403722754/1102885066721460315/image.png -> No double bars anymore but useless margin to remove and missig space between buttons and borders

1a11d046fea01d2fae64949d9047af9b30e72158: 

- [ANSO] Status bar status buttons : should be the same height and font-size as buttons to make the alignment possible

2654c4279f1e1b192e53db7d956c63681d8fa878:
- [aju] https://nimb.ws/e1c5Q6 project.update right-side panel > the alignment of the stat buttons is a bit weird

