### PR TITLE
[IMP] hr_skills: fix `::before` alignment

### DIFF
--- a/addons/hr_skills/static/src/fields/resume_one2many.scss
+++ b/addons/hr_skills/static/src/fields/resume_one2many.scss
@@ -16,12 +16,15 @@
             }
 
             &:before {
-                @include o-position-absolute(0, $left: ($o-hrs-timeline-dot-size * .5 + $o-hrs-timeline-entry-padding));
-                width: 1px;
+                @include o-position-absolute(0, $left: ($o-hrs-timeline-dot-size * .5 + o-to-rem($o-horizontal-padding) - o-to-rem($border-width)));
+                width: $border-width;
                 height: 100%;
-                margin-left: 2.1rem;
                 background-color: $border-color;
                 content: "";
+
+                @include media-breakpoint-up(lg, $o-extra-grid-breakpoints) {
+                    left: ($o-hrs-timeline-dot-size * .5 + o-to-rem($o-horizontal-padding) * 2 - o-to-rem($border-width))
+                }
             }
         }
     }


### PR DESCRIPTION
This PR is related to this issue in the pad : 

**[CHGO][GMF] Employee Resume lines, the dot should be on the line https://i.imgur.com/XRQ3eoE.png** 

== ISSUE ==

Before this commit, the `:before` line in Employee resume is not aligned with the dots. This is due to the fact that the variable `$o-hrs-timeline-entry-padding` used in the mixin isn't the right value we should use.

There was also an issue with responsive.

== After this commit ==

We now use a calc, which process the half of the circle plus the padding minus the border-width. The `$o-horizontal-padding` is the variable used to define the padding of the line inside the form view.

We adapt this in a smaller media query since the `$o-horizontal-padding` value is different.

task-2818586