### PR TITLE
[FIX][IMP] web, *: ribbon fixes

### DIFF
--- a/addons/account/views/account_account_tag_views.xml
+++ b/addons/account/views/account_account_tag_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <form string="Tags">
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="name"/>

--- a/addons/account/views/account_incoterms_view.xml
+++ b/addons/account/views/account_incoterms_view.xml
@@ -20,7 +20,7 @@
             <field name="arch" type="xml">
                 <form string="Incoterms">
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="name"/>

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -40,7 +40,7 @@
                                     </div>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title">
                             <label for="name"/>
                             <h1><field name="name" placeholder="e.g. Customer Invoices"/></h1>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -716,10 +716,10 @@
                         <widget name="web_ribbon" title="Partial"
                                 attrs="{'invisible': ['|', ('payment_state', '!=', 'partial'), ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]}"/>
                         <widget name="web_ribbon" title="Reversed"
-                                bg_color="bg-danger"
+                                bg_color="text-bg-danger"
                                 attrs="{'invisible': [('payment_state', '!=', 'reversed')]}"/>
                          <widget name="web_ribbon" text="Invoicing App Legacy"
-                                bg_color="bg-info"
+                                bg_color="text-bg-info"
                                 attrs="{'invisible': [('payment_state', '!=', 'invoicing_legacy')]}"
                                 tooltip="This entry has been generated through the Invoicing app, before installing Accounting. It has been disabled by the 'Invoicing Switch Threshold Date' setting so that it does not impact your accounting."/>
 

--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -35,7 +35,7 @@
                     <sheet>
                         <field name="active" invisible="1"/>
                         <field name="fiscal_country_codes" invisible="1"/>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title">
                             <label for="name" string="Payment Terms"/>
                             <h1><field name="name" nolabel="1" placeholder="e.g. 30 days"/></h1>

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -242,7 +242,7 @@
                         </div>
 
                         <widget name="web_ribbon" text="Invoicing App Legacy"
-                                bg_color="bg-info"
+                                bg_color="text-bg-info"
                                 attrs="{'invisible': [('state', '!=', 'invoicing_legacy')]}"
                                 tooltip="This payment has been generated through the Invoicing app, before installing Accounting. It has been disabled by the 'Invoicing Switch Threshold Date' setting so that it does not impact your accounting."
                         />

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -36,7 +36,7 @@
 
                     <sheet>
                     <div class="oe_button_box" name="button_box"/>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <group>
                         <group>
                             <field name="active" invisible="1"/>

--- a/addons/analytic/views/analytic_account_views.xml
+++ b/addons/analytic/views/analytic_account_views.xml
@@ -17,7 +17,7 @@
                                 </div>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title">
                             <label for="name"/>
                             <h1>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -109,7 +109,7 @@
                     <div class="oe_button_box" name="button_box">
                         <button string="Document" icon="fa-bars" type="object" name="action_open_calendar_event" attrs="{'invisible': ['|', ('res_model', '=', False), ('res_id', '=', False)]}"/>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="res_model" invisible="1" />
                     <field name="res_id" invisible="1" />
                     <field name="attendee_status" invisible="1"/>

--- a/addons/crm/static/src/scss/crm.scss
+++ b/addons/crm/static/src/scss/crm.scss
@@ -7,27 +7,6 @@
 }
 
 .o_opportunity_kanban .o_kanban_renderer {
-    .ribbon {
-        &::before, &::after {
-            display: none;
-        }
-        span {
-            padding: 5px;
-            font-size: small;
-            z-index: 0;
-        }
-    }
-
-    .ribbon-top-right {
-        margin-top: -9px;
-        span {
-            left: 12px;
-            right: 30px;
-            height: 25px;
-            top: 18px;
-        }
-    }
-
     .oe_kanban_card_ribbon {
         min-height: 105px;
         .o_kanban_record_title {

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -46,7 +46,7 @@
                                 </div>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Lost" bg_color="bg-danger" attrs="{'invisible': ['|', ('probability', '&gt;', 0), ('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Lost" bg_color="text-bg-danger" attrs="{'invisible': ['|', ('probability', '&gt;', 0), ('active', '=', True)]}"/>
                         <widget name="web_ribbon" title="Won" attrs="{'invisible': [('probability', '&lt;', 100)]}" />
                         <div class="oe_title">
                             <h1><field class="text-break" options="{'line_breaks': False}" widget="text" name="name" placeholder="e.g. Product Pricing"/></h1>
@@ -561,7 +561,7 @@
                             <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''} #{lost_ribbon ? 'oe_kanban_card_ribbon' : ''} oe_kanban_global_click oe_kanban_card d-flex flex-column">
                                 <div class="ribbon ribbon-top-right"
                                     attrs="{'invisible': ['|', ('probability', '&gt;', 0), ('active', '=', True)]}">
-                                    <span class="bg-danger">Lost</span>
+                                    <span class="text-bg-danger">Lost</span>
                                 </div>
 
                                 <div class="oe_kanban_content flex-grow-1">
@@ -643,8 +643,8 @@
                     <div class="ribbon ribbon-top-right"
                         attrs="{'invisible': ['&amp;', '|', ('probability', '&gt;', 0), ('active', '=', True),
                             '|', ('probability', '&lt;', 100), ('active', '=', False)]}">
-                        <span t-if="won_ribbon" class="bg-success">Won</span>
-                        <span t-elif="lost_ribbon" class="bg-danger">Lost</span>
+                        <span t-if="won_ribbon" class="text-bg-success">Won</span>
+                        <span t-elif="lost_ribbon" class="text-bg-danger">Lost</span>
                     </div>
                 </xpath>
                 <xpath expr="//div[hasclass('o_kanban_record_subtitle')]" position="replace">

--- a/addons/crm/views/crm_lost_reason_views.xml
+++ b/addons/crm/views/crm_lost_reason_views.xml
@@ -28,7 +28,7 @@
                             </div>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <div>
                             <label for="name"/>

--- a/addons/delivery/views/delivery_carrier_views.xml
+++ b/addons/delivery/views/delivery_carrier_views.xml
@@ -74,7 +74,7 @@
                             </div>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title" name="title">
                         <label for="name" string="Shipping Method"/>
                         <h1>

--- a/addons/event/static/src/scss/event.scss
+++ b/addons/event/static/src/scss/event.scss
@@ -24,26 +24,6 @@
         }
     }
     .oe_kanban_card_ribbon {
-        min-height: 95px;
-        .ribbon {
-            &::before, &::after {
-                display: none;
-            }
-            span {
-                padding: 5px;
-                font-size: small;
-                z-index: 0;
-            }
-        }
-        .ribbon-top-right {
-            margin-top: -1px;
-            span {
-                left: 7px;
-                right: 30px;
-                height: 25px;
-                top: 18px;
-            }
-        }
         // Used for "Group By"
         div.row {
             min-height: 95px;

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -33,7 +33,7 @@
                     <field name="legend_blocked" invisible="1"/>
                     <field name="legend_normal" invisible="1"/>
                     <field name="legend_done" invisible="1"/>
-                    <widget name="web_ribbon" text="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" text="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="kanban_state" widget="state_selection" class="ms-auto float-end"/>
                     <div class="oe_title">
                         <label for="name" string="Event Name"/>

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -139,14 +139,14 @@
                         </div>
                     </t>
                     <t t-name="kanban-box">
-                        <div t-attf-class="#{!record.active.raw_value ? 'oe_kanban_card_ribbon' : ''} oe_kanban_global_click o_event_registration_kanban container-fluid p-0">
+                        <div t-attf-class="#{!record.active.raw_value ? 'oe_kanban_card_ribbon' : ''} oe_kanban_global_click o_event_registration_kanban container-fluid">
                             <div t-if="!record.active.raw_value" class="ribbon ribbon-top-right">
                                 <span class="text-bg-danger">Archived</span>
                             </div>
-                            <div class="row h-100">
-                                <div class="col-9 pe-0">
+                            <div class="row g-0 h-100">
+                                <div class="col-9">
                                     <div class="oe_kanban_content h-100">
-                                        <div class="o_kanban_record_body pt-1 ps-2 h-100 d-flex flex-column">
+                                        <div class="o_kanban_record_body h-100 d-flex flex-column">
                                             <b class="o_kanban_record_title"><field name="name"/></b>
                                             <field class="o_text_overflow" name="event_id" invisible="context.get('default_event_id')" />
                                             <span class="o_text_overflow" attrs="{'invisible': [('partner_id', '=', False)]}">Booked by <field name="partner_id" /></span>
@@ -160,7 +160,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div id="event_attendees_kanban_icons" class="col-3 ps-0">
+                                <div id="event_attendees_kanban_icons" class="col-3">
                                     <t t-call="event_attendees_kanban_icons_desktop"/>
                                     <t t-call="event_attendees_kanban_icons_mobile"/>
                                 </div>

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -57,7 +57,7 @@
                 </header>
                 <sheet string="Registration">
                     <div class="oe_button_box" name="button_box"/>
-                    <widget name="web_ribbon" text="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" text="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <group>
                         <group string="Attendee" name="attendee">
                             <field class="o_text_overflow" name="name"/>
@@ -141,7 +141,7 @@
                     <t t-name="kanban-box">
                         <div t-attf-class="#{!record.active.raw_value ? 'oe_kanban_card_ribbon' : ''} oe_kanban_global_click o_event_registration_kanban container-fluid p-0">
                             <div t-if="!record.active.raw_value" class="ribbon ribbon-top-right">
-                                <span class="bg-danger">Archived</span>
+                                <span class="text-bg-danger">Archived</span>
                             </div>
                             <div class="row h-100">
                                 <div class="col-9 pe-0">

--- a/addons/event_booth/views/event_booth_category_views.xml
+++ b/addons/event_booth/views/event_booth_category_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <form string="Booth Type">
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="image_1920" widget='image' class="oe_avatar" options='{"preview_image": "image_128"}'/>
                     <div class="oe_title">
                         <label for="name" string="Booth Category"/>

--- a/addons/event_crm/views/event_lead_rule_views.xml
+++ b/addons/event_crm/views/event_lead_rule_views.xml
@@ -36,7 +36,7 @@
         <field name="arch" type="xml">
             <form string="Lead Generation Rule">
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <label for="name"/>
                         <h1><field name="name" placeholder="e.g. B2B Fairs"/></h1>

--- a/addons/event_sale/views/event_registration_views.xml
+++ b/addons/event_sale/views/event_registration_views.xml
@@ -47,7 +47,7 @@
             </xpath>
             <xpath expr="//group" position="before">
                 <field name="is_paid" invisible="1"/>
-                <widget name="web_ribbon" title="Paid" bg_color="bg-success" attrs="{'invisible': [('is_paid', '=', False)]}"/>
+                <widget name="web_ribbon" title="Paid" bg_color="text-bg-success" attrs="{'invisible': [('is_paid', '=', False)]}"/>
             </xpath>
             <group name="utm_link" position="before">
                 <group string="Transaction" groups="base.group_no_one">

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -15,7 +15,7 @@
                 </header>
                 <sheet>
                     <field name="active" invisible="1"/>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="currency_id" invisible="1"/>
                     <div class="oe_title">
                         <h1><field name="name"/></h1>
@@ -230,7 +230,7 @@
                     <field name="state" widget="statusbar" options="{'clickable': '1'}"/>
                 </header>
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <group col="2">
                         <group>
                             <field name="description" />

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <form string="Model">
                 <sheet>
-                    <widget name="web_ribbon" text="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" text="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_button_box" name="button_box">
                         <button name="action_model_vehicle" type="object" icon="fa-car" class="oe_stat_button"
                             attrs="{'invisible': [('vehicle_count', '=', 0)]}">

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -71,7 +71,7 @@
                             <field name="odometer_count" widget="statinfo" string="Odometer"/>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="image_128" widget='image' class="oe_avatar"/>
                     <div class="oe_title">
                         <label for="model_id"/>

--- a/addons/hr/views/hr_department_views.xml
+++ b/addons/hr/views/hr_department_views.xml
@@ -16,7 +16,7 @@
                                 <field string="Plans" name="plans_count" widget="statinfo"/>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name="active" invisible="1"/>
                         <group>
                             <group>

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -42,7 +42,7 @@
                         <div class="oe_button_box" name="button_box">
                             <!-- Used by other modules-->
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="row justify-content-between position-relative w-100 m-0 mb-2">
                             <div class="oe_title ps-0 pe-2">
                                 <label for="name" string="Employee Name"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -60,7 +60,7 @@
                     <sheet>
                         <div name="button_box" class="oe_button_box">
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name="avatar_128" invisible="1"/>
                         <div class="row justify-content-between position-relative w-100 m-0 mb-2">
                             <div class="oe_title mw-75 ps-0 pe-2">

--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -11,7 +11,7 @@
                     <field name="company_id" invisible="1"/>
                     <sheet>
                         <div class="oe_button_box" name="button_box"/>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title">
                             <label for="name"/>
                             <h1><field name="name" options="{'line_breaks': False}" widget="text" placeholder="e.g. Sales Manager"/></h1>

--- a/addons/hr/views/hr_plan_views.xml
+++ b/addons/hr/views/hr_plan_views.xml
@@ -36,7 +36,7 @@
                 <form string="Planning">
                     <field name="company_id" invisible="1"/>
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title">
                             <label for="name" string="Plan Name"/>
                             <h1>

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -176,7 +176,7 @@
                                 </div>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title pe-0 w-100 mw-100" name="title">
                             <h1 class="d-flex flex-row justify-content-between">
                                 <field name="name" class="text-truncate" placeholder="Contract Reference"/>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -500,7 +500,7 @@
             <field name="arch" type="xml">
                 <form string="Expense Categories">
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name='product_variant_count' invisible='1'/>
                         <field name="id" invisible="1"/>
                         <field name="image_1920" widget="image" class="oe_avatar" options="{'image_preview': 'image_128'}"/>
@@ -739,8 +739,8 @@
                             <field name="expense_number" widget="statinfo" string="Expenses"/>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Paid" bg_color="bg-success" attrs="{'invisible': [('payment_state', '!=', 'paid')]}"/>
-                    <widget name="web_ribbon" title="Partial" bg_color="bg-info" attrs="{'invisible': [('payment_state', '!=', 'partial')]}"/>
+                    <widget name="web_ribbon" title="Paid" bg_color="text-bg-success" attrs="{'invisible': [('payment_state', '!=', 'paid')]}"/>
+                    <widget name="web_ribbon" title="Partial" bg_color="text-bg-info" attrs="{'invisible': [('payment_state', '!=', 'partial')]}"/>
                     <widget name="web_ribbon" title="In Payment" attrs="{'invisible': [('payment_state', '!=', 'in_payment')]}"/>
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only"/>

--- a/addons/hr_holidays/static/src/scss/time_off.scss
+++ b/addons/hr_holidays/static/src/scss/time_off.scss
@@ -1,14 +1,8 @@
 .o_hr_leave_form {
     .o_form_sheet {
-        padding: 0!important;
         overflow: hidden;
-        .ribbon-top-right {
-            top: 16px;
-            right: -8px;
-        }
     }
     .o_hr_leave_content {
-        margin: 0;
         .o_group {
             margin: 0;
         }

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -55,7 +55,7 @@
                             </div>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <h1><field name="name"/></h1>
                     </div>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -241,7 +241,7 @@
                 <field name="tz_mismatch" invisible="1"/>
                 <field name="holiday_type" invisible="1"/>
                 <field name="leave_type_request_unit" invisible="1"/>
-                <div class="o_hr_leave_content row">
+                <div class="o_hr_leave_content row my-n4 me-n4">
                     <div class="o_hr_leave_column col_left col-md-6 col-12">
                         <div name="title" class="o_hr_leave_title" invisible="1">
                             <field name="employee_id" readonly="1" force_save="1" invisible="1"/>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -225,7 +225,7 @@
                 <field name="state" widget="statusbar" statusbar_visible="confirm,validate" attrs="{'invisible': [('active', '=', False)]}"/>
             </header>
             <sheet>
-                <widget name="web_ribbon" title="Canceled" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                <widget name="web_ribbon" title="Canceled" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                 <div class="alert alert-info" role="alert" attrs="{'invisible': ['|', ('request_unit_hours', '=', False), '|', ('tz_mismatch', '=', False), ('holiday_type', '=', 'category')]}">
                     <span attrs="{'invisible': [('holiday_type', '!=', 'employee')]}">
                         The employee has a different timezone than yours! Here dates and times are displayed in the employee's timezone

--- a/addons/hr_recruitment/static/src/scss/hr_job.scss
+++ b/addons/hr_recruitment/static/src/scss/hr_job.scss
@@ -7,27 +7,6 @@
             }
         }
 
-        .ribbon {
-            &::before, &::after {
-                display: none;
-            }
-
-            span {
-                padding: 5px;
-                font-size: small;
-                z-index: unset;
-                height: auto;
-            }
-        }
-        .ribbon-top-right {
-            margin-top: -$o-kanban-dashboard-vpadding;
-
-            span {
-                left: 0px;
-                right: 30px;
-            }
-        }
-
         .text_top_padding{
             padding-top: 0.375rem;
         }
@@ -57,31 +36,6 @@
 
             .o_field_boolean_favorite {
                 display: inline;
-            }
-        }
-    }
-}
-
-.o_kanban_applicant {
-    .o_kanban_renderer {
-        .ribbon {
-            &::before, &::after {
-                display: none;
-            }
-
-            span {
-                padding: 5px;
-                font-size: x-small;
-                z-index: unset;
-                height: auto;
-            }
-        }
-        .ribbon-top-right {
-            margin-top: -$o-kanban-dashboard-vpadding;
-
-            span {
-                top: 10px;
-                left: 20px;
             }
         }
     }

--- a/addons/hr_recruitment/views/hr_applicant_refuse_reason_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_refuse_reason_views.xml
@@ -7,7 +7,7 @@
             <field name="arch" type="xml">
                 <form string="Refuse Reason">
                     <sheet>
-                        <widget name="web_ribbon" text="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" text="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title">
                             <div class="oe_edit_only">
                                 <label for="name"/>

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -97,8 +97,8 @@
                         </div>
                     </button>
                 </div>
-                <widget name="web_ribbon" title="Refused" bg_color="bg-danger" attrs="{'invisible': [('application_status', '!=', 'refused')]}"/>
-                <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('application_status', '!=', 'archived')]}"/>
+                <widget name="web_ribbon" title="Refused" bg_color="text-bg-danger" attrs="{'invisible': [('application_status', '!=', 'refused')]}"/>
+                <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('application_status', '!=', 'archived')]}"/>
                 <widget name="web_ribbon" title="Hired" attrs="{'invisible': [('application_status', '!=', 'hired')]}" />
                 <field name="active" invisible="1"/>
                 <field name="legend_normal" invisible="1"/>
@@ -332,7 +332,7 @@
                         <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click oe_applicant_kanban oe_semantic_html_override">
                             <field name="date_closed" invisible="1"/>
                             <div class="ribbon ribbon-top-right pe-none" attrs="{'invisible': [('date_closed', '=', False)]}">
-                                <span class="bg-success">Hired</span>
+                                <span class="text-bg-success">Hired</span>
                             </div>
                             <span class="badge rounded-pill text-bg-danger float-end me-4" attrs="{'invisible': [('application_status', '!=', 'refused')]}">Refused</span>
                             <span class="badge rounded-pill text-bg-secondary float-end me-4" attrs="{'invisible': [('application_status', '!=', 'archived')]}">Archived</span>

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -331,7 +331,7 @@
                     <t t-name="kanban-box">
                         <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click oe_applicant_kanban oe_semantic_html_override">
                             <field name="date_closed" invisible="1"/>
-                            <div class="ribbon ribbon-top-right pe-none" attrs="{'invisible': [('date_closed', '=', False)]}">
+                            <div class="ribbon ribbon-top-right" attrs="{'invisible': [('date_closed', '=', False)]}">
                                 <span class="text-bg-success">Hired</span>
                             </div>
                             <span class="badge rounded-pill text-bg-danger float-end me-4" attrs="{'invisible': [('application_status', '!=', 'refused')]}">Refused</span>

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -169,7 +169,7 @@
         <field name="arch" type="xml">
             <form string="Work Entry Type" >
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <h1>
                             <field name="name" placeholder="Work Entry Type Name"/>

--- a/addons/im_livechat/views/chatbot_script_views.xml
+++ b/addons/im_livechat/views/chatbot_script_views.xml
@@ -26,7 +26,7 @@
                         </button>
                     </div>
                     <field name="active" invisible="1"/>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="image_1920" widget="image" class="oe_avatar" options="{'preview_image': 'image_128'}"/>
                     <div class="oe_title">
                         <label for="title" string="Chatbot Name"/>

--- a/addons/loyalty/views/loyalty_program_views.xml
+++ b/addons/loyalty/views/loyalty_program_views.xml
@@ -16,7 +16,7 @@
                         attrs="{'invisible': [('program_type', '!=', 'ewallet')]}" context="{'default_mode': 'selected'}"/>
                 </header>
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_button_box" name="button_box">
                         <button class="oe_stat_button" type="object" name="action_open_loyalty_cards" icon="fa-tags">
                             <div class="o_form_field o_stat_info">

--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -70,7 +70,7 @@
                 <field name="company_id" invisible="1"/>
                 <field name="currency_id" invisible="1"/>
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="image_1920" widget="image" class="oe_avatar" options="{'preview_image': 'image_128'}"/>
                     <div class="oe_title">
                         <label for="name" class="oe-edit-only"/>

--- a/addons/lunch/views/lunch_supplier_views.xml
+++ b/addons/lunch/views/lunch_supplier_views.xml
@@ -18,7 +18,7 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <label for="name" string="Vendor"/>
                         <h1><field name="name" required="1" placeholder="e.g. The Pizzeria Inn"/></h1>

--- a/addons/mail/static/src/scss/kanban_view.scss
+++ b/addons/mail/static/src/scss/kanban_view.scss
@@ -4,26 +4,6 @@ $o-kanban-attachement-image-size: 80px;
     .o_module_desc_short {
         max-width: 90%;
     }
-    .ribbon {
-        &::before, &::after {
-            display: none;
-        }
-
-        span {
-            padding: 5px;
-            font-size: x-small;
-            z-index: unset;
-            height: auto;
-        }
-    }
-    .ribbon-top-right {
-        margin-top: 54px;
-
-        span {
-            top: 15px;
-            left: 10px;
-        }
-    }
 }
 
 .o_kanban_renderer {

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -22,7 +22,7 @@
                         <t t-name="kanban-box">
                             <div class="o_discuss_channel_kanban oe_module_vignette oe_kanban_global_click d-flex align-items-center">
                                 <div class="ribbon ribbon-top-right o_small" attrs="{'invisible': [('active', '=', True)]}">
-                                    <span class="bg-danger">Archived</span>
+                                    <span class="text-bg-danger">Archived</span>
                                 </div>
                                 <img t-att-src="kanban_image('discuss.channel', 'avatar_128', record.id.raw_value)" class="oe_module_icon" alt="Channel"/>
                                 <div class="oe_module_desc">
@@ -50,7 +50,7 @@
                         <div class="oe_button_box" name="button_box"/>
                         <field name="avatar_128" invisible="1"/>
                         <field name="image_128" widget="image" class="oe_avatar" options="{'size': [90, 90], 'preview_image':'avatar_128'}"/>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title">
                             <label for="name" string="Group Name"/>
                             <h1>

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -20,18 +20,20 @@
                             </div>
                         </t>
                         <t t-name="kanban-box">
-                            <div class="o_discuss_channel_kanban oe_module_vignette oe_kanban_global_click d-flex align-items-center">
+                            <div class="o_discuss_channel_kanban oe_module_vignette oe_kanban_global_click">
                                 <div class="ribbon ribbon-top-right o_small" attrs="{'invisible': [('active', '=', True)]}">
                                     <span class="text-bg-danger">Archived</span>
                                 </div>
-                                <img t-att-src="kanban_image('discuss.channel', 'avatar_128', record.id.raw_value)" class="oe_module_icon" alt="Channel"/>
-                                <div class="oe_module_desc">
-                                    <h4 class="o_kanban_record_title">#<field name="name"/></h4>
-                                    <p class="oe_module_name" t-att-class="!record.active.raw_value ? 'o_module_desc_short': ''">
-                                        <field name="description"/>
-                                    </p>
-                                    <button type="object" attrs="{'invisible':['|', ('is_member','=',True), ('group_ids', '!=', [])]}" class="btn btn-primary float-end" name="channel_join">Join</button>
-                                    <button type="object" attrs="{'invisible':['|', ('is_member','=',False), ('group_ids', '!=', [])]}" class="btn btn-secondary float-end" name="action_unfollow">Leave</button>
+                                <div class="d-flex align-items-center">
+                                    <img t-att-src="kanban_image('discuss.channel', 'avatar_128', record.id.raw_value)" class="oe_module_icon" alt="Channel"/>
+                                    <div class="oe_module_desc">
+                                        <h4 class="o_kanban_record_title">#<field name="name"/></h4>
+                                        <p class="oe_module_name" t-att-class="!record.active.raw_value ? 'o_module_desc_short': ''">
+                                            <field name="description"/>
+                                        </p>
+                                        <button type="object" attrs="{'invisible':['|', ('is_member','=',True), ('group_ids', '!=', [])]}" class="btn btn-primary float-end" name="channel_join">Join</button>
+                                        <button type="object" attrs="{'invisible':['|', ('is_member','=',False), ('group_ids', '!=', [])]}" class="btn btn-secondary float-end" name="action_unfollow">Leave</button>
+                                    </div>
                                 </div>
                             </div>
                         </t>

--- a/addons/mail/views/fetchmail_views.xml
+++ b/addons/mail/views/fetchmail_views.xml
@@ -30,7 +30,7 @@
                     </header>
                     <sheet>
                     <field name="active" invisible="1"/>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger"
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger"
                         attrs="{'invisible': [('active', '=', True)]}"/>
                      <group>
                         <group>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <form string="Activities">
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only"/>
                         <h1><field name="name" placeholder="e.g. Schedule a meeting"/></h1>

--- a/addons/mail/views/mail_blacklist_views.xml
+++ b/addons/mail/views/mail_blacklist_views.xml
@@ -25,7 +25,7 @@
                         attrs="{'invisible': ['|', ('active', '=', True), ('email', '=', False)]}"/>
                 </header>
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <group>
                         <group>
                             <field name="email"/>

--- a/addons/mail_group/views/mail_group_message_views.xml
+++ b/addons/mail_group/views/mail_group_message_views.xml
@@ -63,9 +63,9 @@
                         attrs="{'invisible': ['|', ('moderation_status', '!=', 'pending_moderation'), ('is_group_moderated', '=', True)]}"/>
                 </header>
                 <sheet>
-                    <widget name="web_ribbon" title="Rejected" bg_color="bg-danger"
+                    <widget name="web_ribbon" title="Rejected" bg_color="text-bg-danger"
                         attrs="{'invisible': [('moderation_status', '!=', 'rejected')]}"/>
-                    <widget name="web_ribbon" title="Accepted" bg_color="bg-success"
+                    <widget name="web_ribbon" title="Accepted" bg_color="text-bg-success"
                         attrs="{'invisible': [('moderation_status', '!=', 'accepted')]}"/>
                     <group>
                         <field name="mail_message_id" invisible="1"/>

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -342,7 +342,7 @@
                             <field string="Maintenance" name="maintenance_count" widget="statinfo"/>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <label for="name"/>
                         <h1><field name="name" string="Name" placeholder="e.g. LED Monitor"/></h1>
@@ -748,7 +748,7 @@
         <field name="arch" type="xml">
             <form string="Maintenance Team">
                 <sheet>
-                <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                 <div class="oe_title">
                     <label for="name" string="Team Name"/>
                     <h1>

--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -62,7 +62,7 @@
                                 <field name="contact_pct_blacklisted" widget="statinfo" string="% Blacklist"/>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <label for="name"/>
                         <h1>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -166,7 +166,7 @@
                                 <field name="bounced_ratio" string="Bounced" widget="percentpie"/>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <group class="o_mass_mailing_mailing_group">
                             <field name="active" invisible="1"/>
                             <field name="mailing_type" widget="radio" options="{'horizontal': true}" invisible="1"

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -51,7 +51,7 @@
                                 </div>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <group>
                         <group>
                             <field name="active" invisible="1"/>

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -86,7 +86,7 @@
             <field name="arch" type="xml">
                 <form string="Routing Work Centers">
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <group>
                             <group name="description">
                                 <field name="active" invisible="1"/>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -334,7 +334,7 @@
                                 </div>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <group>
                             <group>
                                 <field name="active" invisible="1"/>

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -52,8 +52,8 @@
                     </div>
                     <field name="image_128" widget="image" class="oe_avatar"
                            attrs="{'readonly': [('module_state', '!=', 'installed')]}"/>
-                    <widget name="web_ribbon" title="Disabled" bg_color="bg-danger" attrs="{'invisible': ['|', ('module_state', '!=', 'installed'), ('state', '!=', 'disabled')]}"/>
-                    <widget name="web_ribbon" title="Test Mode" bg_color="bg-warning" attrs="{'invisible': ['|', ('module_state', '!=', 'installed'), ('state', '!=', 'test')]}"/>
+                    <widget name="web_ribbon" title="Disabled" bg_color="text-bg-danger" attrs="{'invisible': ['|', ('module_state', '!=', 'installed'), ('state', '!=', 'disabled')]}"/>
+                    <widget name="web_ribbon" title="Test Mode" bg_color="text-bg-warning" attrs="{'invisible': ['|', ('module_state', '!=', 'installed'), ('state', '!=', 'test')]}"/>
                     <div class="oe_title">
                         <h1><field name="name" placeholder="Name"/></h1>
                         <div attrs="{'invisible': ['|', ('module_state', '=', 'installed'), ('module_id', '=', False)]}">

--- a/addons/payment/views/payment_token_views.xml
+++ b/addons/payment/views/payment_token_views.xml
@@ -14,7 +14,7 @@
                                 type="action" icon="fa-money" string="Payments">
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <group>
                         <group name="general_information">
                             <field name="payment_details"/>

--- a/addons/phone_validation/views/phone_blacklist_views.xml
+++ b/addons/phone_validation/views/phone_blacklist_views.xml
@@ -25,7 +25,7 @@
                         attrs="{'invisible': ['|', ('active', '=', True), ('number', '=', False)]}"/>
                 </header>
                 <sheet>
-                <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <group>
                         <group>
                             <field name="number"/>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <form string="Point of Sale Configuration">
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="active" invisible="1"/>
                     <field name="company_has_template" invisible="1"/>
                     <field name="has_active_session" invisible="1"/>

--- a/addons/point_of_sale/views/pos_payment_method_views.xml
+++ b/addons/point_of_sale/views/pos_payment_method_views.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <form string="Payment Methods">
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="active" invisible="1"/>
                     <field name="type" invisible="1" />
                     <div class="oe_title">

--- a/addons/pos_restaurant/views/pos_restaurant_views.xml
+++ b/addons/pos_restaurant/views/pos_restaurant_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <form string="Restaurant Floor">
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name="active" invisible="1"/>
                         <group col="4">
                             <field name="name" />

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -59,7 +59,7 @@
         <field name="arch" type="xml">
             <form string="Products Price List">
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <h1><field name="name" placeholder="e.g. USD Retailers"/></h1>
                     </div>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -36,7 +36,7 @@
                                </div>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="id" invisible="True"/>
                     <field name="image_1920" widget="image" class="oe_avatar" options="{'preview_image': 'image_128'}"/>
                     <div class="oe_title">
@@ -235,7 +235,7 @@
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box"/>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name="active" invisible="1"/>
                         <field name="id" invisible="1"/>
                         <field name="company_id" invisible="1"/>

--- a/addons/project/views/project_project_stage_views.xml
+++ b/addons/project/views/project_project_stage_views.xml
@@ -33,7 +33,7 @@
         <field name="arch" type="xml">
             <form delete="0">
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <h1><field name="name" placeholder="New"/></h1>
                     <group>
                         <group>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -51,7 +51,7 @@
                             </div>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <h1 class="d-flex flex-row">
                             <field name="is_favorite" nolabel="1" widget="boolean_favorite" class="me-2"/>

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -150,7 +150,7 @@
                             </div>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title pe-0">
                         <h1 class="d-flex flex-row justify-content-between">
                             <field name="priority" widget="priority" class="me-3"/>

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -21,7 +21,7 @@
                 <form string="Task Stage" delete="0">
                     <field name="active" invisible="1" />
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}" />
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}" />
                         <group>
                             <group>
                                 <field name="name"/>
@@ -51,7 +51,7 @@
                 <form string="Task Stage" delete="0">
                     <field name="active" invisible="1" />
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}" />
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}" />
                         <group>
                             <group>
                                 <field name="name"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -307,7 +307,7 @@
                         <!-- Dummy tag used to organize buttons -->
                         <span id="end_button_box" invisible="1"/>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title pe-0">
                         <h1 class="d-flex justify-content-between align-items-center">
                             <div class="d-flex w-100">

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -44,7 +44,7 @@
         <field name="arch" type="xml">
             <form string="Purchase Agreement Types">
             <sheet>
-                <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                 <group>
                     <group string="Agreement Type">
                         <field name="name"/>

--- a/addons/resource/views/resource_calendar_views.xml
+++ b/addons/resource/views/resource_calendar_views.xml
@@ -24,7 +24,7 @@
                     <button name="switch_calendar_type" attrs="{'invisible':[('two_weeks_calendar', '=', False)]}" string="Switch to 1 week calendar" type="object" confirm="Are you sure you want to switch this calendar to 1 week calendar? All entries will be lost"/>
                 </header>
                 <sheet string="Working Time">
-                    <widget name="web_ribbon" text="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_button_box" name="button_box">
                         <button name="%(resource_calendar_leaves_action_from_calendar)d" type="action"
                                 icon="fa-plane"

--- a/addons/resource/views/resource_resource_views.xml
+++ b/addons/resource/views/resource_resource_views.xml
@@ -34,7 +34,7 @@
             <sheet>
                 <field name="active" invisible="1" />
                 <field name="company_id" invisible="1"/>
-                <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                 <group>
                     <group name="user_details">
                         <field name="name"/>

--- a/addons/sale_management/views/sale_order_template_views.xml
+++ b/addons/sale_management/views/sale_order_template_views.xml
@@ -21,7 +21,7 @@
             <form string="Quotation Template">
                 <sheet>
                     <div name="button_box" class="oe_button_box"/>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title" name="sale_order_template_title">
                         <label for="name" id="sale_order_template_title"/>
                         <h1>

--- a/addons/sales_team/static/src/scss/crm_team_views.scss
+++ b/addons/sales_team/static/src/scss/crm_team_views.scss
@@ -14,22 +14,6 @@
         }
     }
     .ribbon {
-        &::before, &::after {
-            display: none;
-        }
-
-        span {
-            padding: 5px;
-            font-size: small;
-            height: auto;
-        }
-    }
-    .ribbon-top-right {
-        margin-top: -$o-kanban-dashboard-vpadding;
-
-        span {
-            left: 0px;
-            right: 30px;
-        }
+        --Ribbon-wrapper-width: 6rem;
     }
 }

--- a/addons/sales_team/views/crm_team_member_views.xml
+++ b/addons/sales_team/views/crm_team_member_views.xml
@@ -56,7 +56,7 @@
                     <t t-name="kanban-box">
                         <div class="oe_kanban_card oe_kanban_global_click">
                             <div class="ribbon ribbon-top-right" attrs="{'invisible': [('active', '=', True)]}">
-                                <span class="bg-danger">Archived</span>
+                                <span class="text-bg-danger">Archived</span>
                             </div>
                             <div class="o_kanban_card_content d-flex">
                                 <div>
@@ -105,7 +105,7 @@
                         attrs="{'invisible': [('member_warning', '=', False)]}">
                         <field name="member_warning"/>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="image_1920" widget='image' class="oe_avatar"
                         attrs="{'invisible': [('user_id', '=', False)]}"
                         options='{"preview_image": "image_128"}'/>

--- a/addons/sales_team/views/crm_team_member_views.xml
+++ b/addons/sales_team/views/crm_team_member_views.xml
@@ -56,7 +56,7 @@
                     <t t-name="kanban-box">
                         <div class="oe_kanban_card oe_kanban_global_click">
                             <div class="ribbon ribbon-top-right" attrs="{'invisible': [('active', '=', True)]}">
-                                <span class="bg-odoo">Archived</span>
+                                <span class="bg-danger">Archived</span>
                             </div>
                             <div class="o_kanban_card_content d-flex">
                                 <div>

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -29,7 +29,7 @@
                 </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box"/>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <label for="name" string="Sales Team"/>
                         <h1>

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -26,7 +26,7 @@
                                 class="oe_stat_button"
                                 icon="fa-cubes" name="%(location_open_quants)d" type="action"/>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <label for="name"/>
                     <h1><field name="name" placeholder="e.g. Spare Stock"/></h1>
                     <label for="location_id"/>
@@ -179,7 +179,7 @@
                 <form string="Route">
                     <field name="company_id" invisible="1"/>
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title">
                             <label for="name"/>
                             <h1><field name="name" placeholder="e.g. Two-steps reception"/></h1>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -134,7 +134,7 @@
                     <a style="cursor: pointer" class="alert-link o_form_uri" type="action" name="%(action_procurement_compute)d">Run the scheduler</a> manually to trigger the reordering rules right now.
                 </div>
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <h1>
                             <field name="name"/>

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -75,7 +75,7 @@
         <field name="arch" type="xml">
             <form string="Operation Types">
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <label for="name"/>
                     <h1><field name="name" placeholder="e.g. Receptions"/></h1>
                     <group name="first">

--- a/addons/stock/views/stock_rule_views.xml
+++ b/addons/stock/views/stock_rule_views.xml
@@ -61,7 +61,7 @@
             <field name="arch" type="xml">
                 <form string="Rules">
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title">
                             <label for="name"/>
                             <h1><field name="name"/></h1>

--- a/addons/stock/views/stock_warehouse_views.xml
+++ b/addons/stock/views/stock_warehouse_views.xml
@@ -18,7 +18,7 @@
                                     </div>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <label for="name"/>
                         <h1><field name="name" placeholder="e.g. Central Warehouse"/></h1>
                         <group>

--- a/addons/survey/static/src/scss/survey_survey_views.scss
+++ b/addons/survey/static/src/scss/survey_survey_views.scss
@@ -31,7 +31,7 @@
             width: 100%;
             margin: 0px;
         }
-        
+
         .o_survey_kanban_card {
             border-top: 0px !important;
         }
@@ -81,54 +81,10 @@
     // Ungrouped specific
     .o_survey_kanban_card_ungrouped {
         .ribbon {
-            // Desktop: finishes on next kanban card line
-            height: 77px;
-            width: 130px;
+            --Ribbon-wrapper-width: 6rem;
 
-            // Mobile: is in a corner, takes more place
             @include media-breakpoint-down(md) {
-                height: 100px;
-                width: 100px;
-            }
-
-            &-top-right {
-                margin-top: -$o-kanban-inside-vgutter;
-                right: 0;
-
-                & span {
-                    left: -8px;
-                    top: 24px;
-                }
-            }
-
-            & span {
-                font-size: 1rem;
-                width: 150px;
-                height: 32px;
-            }
-        }
-    }
-    // Grouped specific
-    .o_survey_kanban_card_grouped {
-        .ribbon {
-            height: 90px;
-            width: 98px;
-
-            &-top-right {
-                margin-top: -$o-kanban-inside-vgutter;
-                right: 0;
-
-                & span {
-                    left: -8px;
-                    top: 16px;
-                }
-            }
-
-            & span {
-                font-size: 1rem;
-                width: 150px;
-                height: 32px;
-                padding: 0 8px;
+                --Ribbon-wrapper-width: 6.5rem;
             }
         }
     }
@@ -140,7 +96,7 @@
     background-color: var(--SurveyForm__section-background-color, #DDD);
     border-top: 1px solid #BBB;
     border-bottom: 1px solid #BBB;
-    
+
     > td {
         background: transparent;
     }

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -241,6 +241,9 @@
                                       o_survey_kanban_card #{record.certification.raw_value ? 'o_survey_kanban_card_certification' : ''}">
                         <!-- displayed in ungrouped mode -->
                         <div class="o_survey_kanban_card_ungrouped row mx-0">
+                            <widget name="web_ribbon" title="Archived"
+                                bg_color="text-bg-danger"
+                                attrs="{'invisible': [('active', '=', True)]}"/>
                             <div class="col-lg-2 col-sm-8 py-0 my-2 my-lg-0 col-12">
                                 <div class="d-flex flex-grow-1 flex-column my-0 my-lg-2">
                                     <span class="fw-bold"><field name="title"/></span>
@@ -324,9 +327,6 @@
                                     End Live Session
                                 </button>
                             </div>
-                            <widget name="web_ribbon" title="Archived"
-                                bg_color="text-bg-danger"
-                                attrs="{'invisible': [('active', '=', True)]}"/>
                         </div>
                         <!-- displayed in grouped mode -->
                         <div class="o_survey_kanban_card_grouped">
@@ -356,7 +356,7 @@
                                                 <a name="action_survey_user_input_certified" type="object" class="d-flex flex-column align-items-center">
                                                     <span class="fw-bold"> <t t-esc="Math.round(record.success_ratio.raw_value)"></t> %</span>
                                                     <span class="text-muted" >Success</span>
-                                                </a> 
+                                                </a>
                                             </div>
                                         </div>
                                     </div>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -47,7 +47,7 @@
                             <field string="Participations" name="answer_done_count" widget="statinfo"/>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="background_image" widget="image" class="oe_avatar"/>
                     <field name="survey_type" widget="radio" options="{'horizontal': True}"/>
                     <div class="oe_title" style="width: 100%;">
@@ -325,13 +325,13 @@
                                 </button>
                             </div>
                             <widget name="web_ribbon" title="Archived"
-                                bg_color="bg-danger"
+                                bg_color="text-bg-danger"
                                 attrs="{'invisible': [('active', '=', True)]}"/>
                         </div>
                         <!-- displayed in grouped mode -->
                         <div class="o_survey_kanban_card_grouped">
                             <widget name="web_ribbon" title="Archived"
-                                bg_color="bg-danger"
+                                bg_color="text-bg-danger"
                                 attrs="{'invisible': [('active', '=', True)]}"/>
                             <div class="o_kanban_record_top">
                                 <h4 class="o_kanban_record_title p-0 mb4"><field name="title" /></h4>

--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -53,9 +53,9 @@
                         </button>
                     </div>
                     <field name="test_entry" invisible="1"/>
-                    <widget name="web_ribbon" title="Test Entry" bg_color="bg-info"
+                    <widget name="web_ribbon" title="Test Entry" bg_color="text-bg-info"
                         attrs="{'invisible': [('test_entry', '!=', True)]}"/>
-                    <widget name="web_ribbon" title="Failed" bg_color="bg-danger"
+                    <widget name="web_ribbon" title="Failed" bg_color="text-bg-danger"
                         attrs="{'invisible': ['|', '|', ('test_entry', '=', True), ('scoring_type', '=', 'no_scoring'), ('scoring_success', '=', True)]}"/>
                     <widget name="web_ribbon" title="Passed"
                         attrs="{'invisible': ['|', '|', ('test_entry', '=', True), ('scoring_type', '=', 'no_scoring'), ('scoring_success', '=', False)]}"/>

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -36,7 +36,7 @@
                 <sheet>
                     <div class="oe_button_box d-flex justify-content-end" name="button_box">
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <group id="top-group">
                         <field name="active" invisible="1"/>
                         <field class="text-break" name="title" string="Campaign Name" placeholder="e.g. Black Friday"/>

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -36,6 +36,17 @@
     --KanbanColumn__highlight-border: #{$o-action};
 
     --o-view-nocontent-zindex: 1;
+
+    // ----------------------------------------------------------------------------
+    // Inner components contextual adaptations
+
+    --Ribbon-font-size: #{$font-size-sm};
+    --Ribbon-gap-top: calc(var(--KanbanRecord-padding-v) * -1 - #{$border-width});
+    --Ribbon-gap-right: 0;
+    --Ribbon-wrapper-width: 6.5rem;
+    --Ribbon-height:  calc(var(--Ribbon-font-size) * 2);
+    --Ribbon-z-index: 0;
+
     // ----------------------------------------------------------------------------
 
     border-top: $border-width solid var(--Kanban-background);

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.js
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.js
@@ -28,7 +28,7 @@ class RibbonWidget extends Component {
     };
     static defaultProps = {
         title: "",
-        bgClass: "bg-success",
+        bgClass: "text-bg-success",
     };
 
     get classes() {

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.scss
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.scss
@@ -1,50 +1,57 @@
 .ribbon {
-    width: 150px;
-    height: 150px;
+    --Ribbon-wrapper-width-default: 10rem;
+    --Ribbon-wrapper-height: var(--Ribbon-wrapper-width, var(--Ribbon-wrapper-width-default));
+
+    width: var(--Ribbon-wrapper-width, var(--Ribbon-wrapper-width-default));
+    height: var(--Ribbon-wrapper-height);
     overflow: hidden;
     position: absolute;
 
     & span {
-        z-index: 1;
+        --Ribbon-font-size-default: #{$font-size-lg};
+        --Ribbon-height-default: calc(var(--Ribbon-font-size, var(--Ribbon-font-size-default)) * 2.5);
+        --Ribbon-shadow-distance: .25rem;
+        --Ribbon-shadow-blur: .5rem;
+        --Ribbon-z-index: 1;
+
+        z-index: var( --Ribbon-z-index);
         position: absolute;
-        display: grid;
-        align-items: center;
-        width: 225px;
-        height: 48px;
-        padding: 0 44px;
-        box-shadow: 0 5px 10px rgba(0, 0, 0, .1);
-        color: #fff;
-        font: 700 18px/1 'Lato', sans-serif;
+        width: 141.421%; //Square root of 2 to get the diagonal of the parent
+        height: var(--Ribbon-height, var(--Ribbon-height-default));
+        box-shadow: 0 var(--Ribbon-shadow-distance) var(--Ribbon-shadow-blur) rgba(0, 0, 0, .1);
+        color: $white;
+        font-size: var(--Ribbon-font-size, var(--Ribbon-font-size-default));
+        line-height: var(--Ribbon-height, var(--Ribbon-height-default));
+        font-weight: $font-weight-bolder;
+        font-family: 'Lato', sans-serif;
         text-shadow: 0 1px 1px rgba(0, 0, 0, .2);
         text-transform: uppercase;
         text-align: center;
         overflow: hidden;
         user-select: none;
+        transform-origin: left bottom;
+        pointer-events: none;
         &.o_small {
-            font-size: 12px;
+            font-size: $font-size-sm
         }
         &.o_medium {
-            font-size: 15px;
+            font-size: $font-size-base;
         }
     }
 
     &-top-right {
-        margin-top: -$o-sheet-vpadding;
-        right: 0;
+        --Ribbon-gap-top-default: calc(var(--formView-sheet-padding-y, 0) * -1 - #{$border-width});
+        --Ribbon-gap-right-default: -#{$border-width};
 
-        &::before {
-            top: 0;
-            left: 0;
-        }
-
-        &::after {
-            bottom: 0;
-            right: 0;
-        }
+        margin-top: var(--Ribbon-gap-top, var(--Ribbon-gap-top-default));
+        right: var(--Ribbon-gap-right, var(--Ribbon-gap-right-default));
 
         & span {
-            left: -15px;
-            top: 30px;
+            --Ribbon-top-position-default: calc((var(--Ribbon-height-default) * -1));
+            --Ribbon-left-position-default: calc(var(--Ribbon-shadow-distance) + var(--Ribbon-shadow-blur));
+
+            left: var(--Ribbon-left-position, var(--Ribbon-left-position-default));
+            top: var(--Ribbon-top-position, var(--Ribbon-top-position-default));
             transform: rotate(45deg);
         }
     }

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.scss
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.scss
@@ -4,14 +4,6 @@
     overflow: hidden;
     position: absolute;
 
-    &::before, &::after {
-        position: absolute;
-        z-index: -1;
-        content: '';
-        display: block;
-        border: 5px solid #2980b9;
-    }
-
     & span {
         z-index: 1;
         position: absolute;
@@ -39,11 +31,6 @@
     &-top-right {
         margin-top: -$o-sheet-vpadding;
         right: 0;
-
-        &::before, &::after {
-            border-top-color: black;
-            border-right-color: black;
-        }
 
         &::before {
             top: 0;

--- a/addons/website_blog/views/website_blog_views.xml
+++ b/addons/website_blog/views/website_blog_views.xml
@@ -19,7 +19,7 @@
             <field name="arch" type="xml">
                 <form string="Blog">
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="name"/>

--- a/addons/website_blog/views/website_pages_views.xml
+++ b/addons/website_blog/views/website_pages_views.xml
@@ -10,7 +10,7 @@
                 <div class="oe_button_box" name="button_box" attrs="{'invisible': [('active', '=', False)]}">
                     <field name="is_published" widget="website_redirect_button"/>
                 </div>
-                <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                 <group name="blog_details">
                     <field name="blog_id"/>
                     <field name="active" invisible="1"/>

--- a/addons/website_event_exhibitor/static/src/scss/event_templates_sponsor.scss
+++ b/addons/website_event_exhibitor/static/src/scss/event_templates_sponsor.scss
@@ -57,34 +57,6 @@
     margin: 0 -1px -1px 0;
     cursor: pointer;
 
-    .ribbon-wrapper {
-        width: 50px;
-        height: 50px;
-    }
-
-    .ribbon {
-        font: bold 10px Sans-Serif;
-        padding: 2px 0;
-        top: 10px;
-        width: 70px;
-        background-image: none; // not needed if colors for ribbons (Gold,Silver,Bronze) is removed in website_event_track.css
-
-        &.ribbon_Gold {
-            background-color: #e3aa24;
-            color:$white;
-        }
-
-        &.ribbon_Silver {
-            background-color: #adb5bd;
-            color: $white;
-        }
-
-        &.ribbon_Bronze {
-            background-color: #c7632a;
-            color: $white;
-        }
-    }
-
     &:before {
         content: "";
         display: block;

--- a/addons/website_event_exhibitor/views/event_sponsor_views.xml
+++ b/addons/website_event_exhibitor/views/event_sponsor_views.xml
@@ -77,7 +77,7 @@
                         <field name="is_published" widget="website_redirect_button"
                             attrs="{'invisible': [('exhibitor_type', '=', 'sponsor')]}"/>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="active" invisible="1"/>
                     <field name="image_512" widget="image" class="oe_avatar"/>
                     <div class="oe_title">

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -156,7 +156,7 @@
                     <field name="legend_blocked" invisible="1"/>
                     <field name="legend_normal" invisible="1"/>
                     <field name="legend_done" invisible="1"/>
-                    <widget name="web_ribbon" text="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="d-flex gap-4 mb-3">
                         <div class="flex-grow-1">
                             <label for="name"/>

--- a/addons/website_forum/views/forum_forum_views.xml
+++ b/addons/website_forum/views/forum_forum_views.xml
@@ -49,7 +49,7 @@
                             </button>
                         </div>
                         <field name="active" invisible="1"/>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name="image_1920" widget="image" options="{'preview_image': 'image_128'}" class="oe_avatar"/>
                         <div class="oe_title">
                             <label for="name"/>

--- a/addons/website_forum/views/forum_post_views.xml
+++ b/addons/website_forum/views/forum_post_views.xml
@@ -14,7 +14,7 @@
                         </div>
                     </button>
                 </div>
-                <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                 <label for="name"/>
                 <h1>
                     <field name="name" placeholder="e.g. When should I plant my tomatoes?"/>

--- a/addons/website_hr_recruitment/views/hr_job_views.xml
+++ b/addons/website_hr_recruitment/views/hr_job_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//div[hasclass('o_kanban_card_header')]" position="before">
                 <field name="website_published" invisible="1"/>
                 <div class="ribbon ribbon-top-right" attrs="{'invisible': [('website_published', '=', False)]}">
-                    <span class="bg-success">Published</span>
+                    <span class="text-bg-success">Published</span>
                 </div>
             </xpath>
             <xpath expr="//div[@name='kanban_boxes']" position="attributes">

--- a/addons/website_hr_recruitment/views/hr_job_views.xml
+++ b/addons/website_hr_recruitment/views/hr_job_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//div[hasclass('o_kanban_card_header')]" position="before">
                 <field name="website_published" invisible="1"/>
                 <div class="ribbon ribbon-top-right" attrs="{'invisible': [('website_published', '=', False)]}">
-                    <span class="bg-odoo">Published</span>
+                    <span class="bg-success">Published</span>
                 </div>
             </xpath>
             <xpath expr="//div[@name='kanban_boxes']" position="attributes">

--- a/addons/website_slides/static/src/scss/slide_views.scss
+++ b/addons/website_slides/static/src/scss/slide_views.scss
@@ -17,27 +17,3 @@ table.o_section_list_view tr.o_data_row.o_is_section {
     border-top: 1px solid #BBB;
     border-bottom: 1px solid #BBB;
 }
-
-// Ribbon specific style for channel and attendee kanban
-.o_slide_channel_kanban .o_kanban_renderer {
-    .ribbon {
-        &::before, &::after {
-            display: none;
-        }
-
-        span {
-            padding: 5px;
-            font-size: small;
-            z-index: unset;
-            height: auto;
-        }
-    }
-    .ribbon-top-right {
-        margin-top: -$o-kanban-dashboard-vpadding;
-
-        span {
-            left: 0px;
-            right: 30px;
-        }
-    }
-}

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -268,7 +268,7 @@
                                 <div class="ribbon ribbon-top-right"
                                     attrs="{'invisible': ['|', ('website_published', '!=', True), ('active', '=', False)]}">
                                     <field name="website_published" invisible="1"/>
-                                    <span class="bg-odoo">Published</span>
+                                    <span class="bg-success">Published</span>
                                 </div>
                                 <div class="o_kanban_card_header">
                                     <div class="o_kanban_card_header_title mb16">

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -56,7 +56,7 @@
                             </button>
                             <field name="is_published" widget="website_redirect_button"/>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name="image_1920" widget="image" class="oe_avatar" options="{'preview_image': 'image_128'}"/>
                         <div class="oe_title">
                             <label for="name" string="Course Title"/>
@@ -263,12 +263,12 @@
                                 <div class="ribbon ribbon-top-right"
                                     attrs="{'invisible': [('active', '=', True)]}">
                                     <field name="active" invisible="1"/>
-                                    <span class="bg-danger">Archived</span>
+                                    <span class="text-bg-danger">Archived</span>
                                 </div>
                                 <div class="ribbon ribbon-top-right"
                                     attrs="{'invisible': ['|', ('website_published', '!=', True), ('active', '=', False)]}">
                                     <field name="website_published" invisible="1"/>
-                                    <span class="bg-success">Published</span>
+                                    <span class="text-bg-success">Published</span>
                                 </div>
                                 <div class="o_kanban_card_header">
                                     <div class="o_kanban_card_header_title mb16">

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -85,7 +85,7 @@
                             <field name="is_published" class="ms-1" widget="website_redirect_button"
                                    attrs="{'invisible': ['|',('is_category', '=', True), ('channel_id', '=', False)]}"/>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name="image_1920" widget="image" class="oe_avatar" options='{"preview_image": "image_256"}'
                             attrs="{'invisible': [('is_category', '=', True)]}"/>
                         <div class="oe_title pe-xl-0">

--- a/odoo/addons/base/static/src/scss/res_partner.scss
+++ b/odoo/addons/base/static/src/scss/res_partner.scss
@@ -1,26 +1,4 @@
 .o_kanban_view .o_res_partner_kanban {
-
-    .ribbon {
-        &::before, &::after {
-            display: none;
-        }
-
-        span {
-            padding: 5px;
-            font-size: x-small;
-            z-index: unset;
-            height: auto;
-        }
-    }
-    .ribbon-top-right {
-        margin-top: -$o-kanban-dashboard-vpadding;
-
-        span {
-            top: 15px;
-            left: 10px;
-        }
-    }
-
     .oe_kanban_action_a:hover > .badge {
         background-color: $o-brand-primary;
         color: white;

--- a/odoo/addons/base/views/ir_mail_server_views.xml
+++ b/odoo/addons/base/views/ir_mail_server_views.xml
@@ -10,7 +10,7 @@
                             name="test_smtp_connection" class="btn-primary"/>
                     </header>
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger"
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger"
                             attrs="{'invisible': [('active', '=', True)]}"/>
                         <group>
                             <group>

--- a/odoo/addons/base/views/res_bank_views.xml
+++ b/odoo/addons/base/views/res_bank_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <form string="Bank">
                     <sheet>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <group name="bank_details" col="4">
                             <field name="name"/>
                             <field name="bic"/>
@@ -81,7 +81,7 @@
             <field name="arch" type="xml">
                 <form string="Bank account" name="bank_account_form">
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <group>
                         <group>
                             <field name="sequence" invisible="1"/>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -174,7 +174,7 @@
                 </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box"/>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="avatar_128" invisible="1"/>
                     <field name="image_1920" widget='image' class="oe_avatar" options='{"preview_image": "avatar_128"}'/>
                     <div class="oe_title mb24">
@@ -500,7 +500,7 @@
                                     </div>
                                 </t>
                                 <div class="ribbon ribbon-top-right" attrs="{'invisible': [('active', '=', True)]}">
-                                    <span class="bg-danger">Archived</span>
+                                    <span class="text-bg-danger">Archived</span>
                                 </div>
                                 <div class="oe_kanban_details d-flex flex-column justify-content-between">
                                     <div>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -209,7 +209,7 @@
                                 <field string="Record Rules" name="rules_count" widget="statinfo"/>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name="active_partner" required="0" readonly="1" invisible="1"/>
                         <div class="alert alert-info text-center o_form_header"
                             attrs="{'invisible': [

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -876,7 +876,7 @@ stepUtils.mobileModifier(stepUtils.autoExpandMoreButtons('.o_control_panel .o_br
 }, {
     edition: "community",
     content: "wait for payment registration to succeed",
-    trigger: "span.bg-success:contains('Paid')",
+    trigger: "span.text-bg-success:contains('Paid')",
     auto: true,
     run() {}
 },{


### PR DESCRIPTION
This PR fixes these issues concerning ribbons: 

- Misaligned banner widgets (Won, Archived, etc)  https://tinyurl.com/26h9wurp
- Published banner in kanban is borken  https://tinyurl.com/2yz3c4ue
- FRGI: banner not visible in eLearning https://www.awesomescreenshot.com/image/39482076?key=1665776a3b868c5a85bbb95a8d45e8c0
- LNA: There is a glitched pixel next to the archived ribbon https://tinyurl.com/2z7f54s5

In order for the text color to be more readable in dark-mode on these ribbons, the `bg-[color]` classes have been replaced by `text-bg-[color]` classes.

task-2818586

Related to enterprise PR: https://github.com/odoo-dev/enterprise/pull/547
