### PR TITLE
[IMP] web: fix calendar year view min-width

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -413,7 +413,6 @@
 
                 @include media-breakpoint-down(md) {
                     width: 50%;
-                    min-width: 12rem;
                 }
 
                 > .fc-month {


### PR DESCRIPTION
This PR is related to this issue in the pad :

**[aju] https://i.imgur.com/LpyKJFU.png calendar view > year scale on mobile > I guess the calendar could take the whole width of the screen 🤔**

== ISSUE ==

When you access the calendar view inside a module and access the year
view, there is only one month per row, which is due to the base `rem`unit value change.

In fact, we introduce a new value for the `rem` unit with Milk, which is 16px.

On Master, 1rem is actually 12px, so 4px less.

Since the `min-width` of the `.fc-month-container` is defined using rem, we have :

`min-width: 144px` on Master.
`min-width: 192px` on Milk.

This huge difference cause the months to occupy more space than needed.

== After this commit ==

The `min-width` of the month container is removed so we have one single
month per row on small devices. This makes the calendar more accessible
and easier to navigate through for users.

task-2818586