### PR TITLE
[IMP] web, *: fix layout issues for Milk - Part 4

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -4,7 +4,7 @@
     <t t-name="web.ControlPanel" owl="1">
         <div class="o_control_panel d-flex flex-column gap-3 gap-lg-1 px-3 pt-2 pb-3" t-ref="root">
             <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-3 flex-grow-1">
-                <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0">
+                <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0 h-100">
                     <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-ref="mainButtons">
                         <div class="btn-group d-xl-none o_control_panel_collapsed_create">
                             <t t-slot="control-panel-create-button"/>

--- a/addons/web/static/src/views/kanban/kanban_column_progressbar.scss
+++ b/addons/web/static/src/views/kanban/kanban_column_progressbar.scss
@@ -42,5 +42,6 @@
         @include o-kanban-css-filter(danger, map-get($theme-colors, "danger"));
         @include o-kanban-css-filter(muted, map-get($theme-colors, "dark"));
         @include o-kanban-css-filter(info, map-get($theme-colors, "info"));
+        @include o-kanban-css-filter(purple, purple);
     }
 }

--- a/addons/web/static/src/views/view_button/view_button.js
+++ b/addons/web/static/src/views/view_button/view_button.js
@@ -25,7 +25,7 @@ function iconFromString(iconString) {
     const icon = {};
     if (iconString.startsWith("fa-")) {
         icon.tag = "i";
-        icon.class = `o_button_icon fa me-1 ${iconString}`;
+        icon.class = `o_button_icon fa ${iconString}`;
     } else {
         icon.tag = "img";
         icon.src = iconString;

--- a/addons/web/static/src/views/view_button/view_button.xml
+++ b/addons/web/static/src/views/view_button/view_button.xml
@@ -18,7 +18,7 @@
         t-att-tabindex="props.tabindex"
         t-on-click.stop="onClick"
     >
-      <t t-if="icon" t-tag="icon.tag" t-att-class="icon.class" t-att-src="icon.src"/>
+      <t t-if="icon" t-tag="icon.tag" t-att-class="icon.class + (props.string ? ' me-1' : '')" t-att-src="icon.src"/>
       <t t-slot="contents"><span t-if="props.string" t-esc="props.string"/></t>
     </t>
   </t>


### PR DESCRIPTION
4b3b21acb391ce834fc84bfd1a54dcc9cc758107:
- Fix of a fix made here : https://github.com/odoo-dev/odoo/pull/2458 (commit afc0a9e) : it added a right margin every time, on the icon but when there's no string in the button, we don't need this margin.

d9766fdbbc40ed053a1081579b1e9a59e2e87b9a:
- Sometimes the left part of the CP doesn't have primary or secondary buttons (eg. Timesheets) and it creates a vertical alignment issue. This commit fix that.

a08ac4a0d59e4c39d6f53edb882d591063dfe6b3:
- https://watch.screencastify.com/v/VSCqiY3vsRWwME3fs1xS project kanban view > click on the progress bar to filter projects > the column is not highlighted for every color

Requires:
- https://github.com/odoo-dev/enterprise/pull/550