### PR TITLE
[IMP] web: fix stat buttons layout

### DIFF
--- a/addons/web/static/src/views/form/button_box/button_box.scss
+++ b/addons/web/static/src/views/form/button_box/button_box.scss
@@ -23,6 +23,8 @@
     }
 
     %-stat-button-value {
+        display: flex;
+        gap: map-get($spacers, 1);
         order: 2;
         font-weight: $font-weight-bold;
         color: $o-brand-primary;


### PR DESCRIPTION
== ISSUE ==

The layout of some stat buttons is broken. Children elements wrap themselves on three lines causing layout issue and weird sized buttons.

== After this commit ==

Setting up the `display` property of all the `.o_stat_value` elements inside `.oe_stat_button` wraps the content correctly.

We also set up a gap property to manage the spacing between the value and the unit.

task-2818586