### PR TITLE
[IMP] *: status buttons fix

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -33,8 +33,12 @@
                     <sheet>
                         <div name="button_box" class="oe_button_box">
                             <button class="oe_stat_button" type="action"
-                                    name="%(action_account_moves_all_a)d" icon="fa-book" string="Journal Entries"
-                                    context="{'search_default_journal_id':active_id}"/>
+                                    name="%(action_account_moves_all_a)d" icon="fa-book"
+                                    context="{'search_default_journal_id':active_id}">
+                                    <div class="o_stat_info">
+                                        <span class="o_stat_text">Journal Entries</span>
+                                    </div>
+                            </button>
                         </div>
                         <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title">

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -683,22 +683,28 @@
                                     class="oe_stat_button"
                                     icon="fa-bars"
                                     type="object"
-                                    attrs="{'invisible': ['|', '|', ('move_type', '!=', 'entry'), ('id', '=', False), ('payment_id', '=', False)]}"
-                                    string="1 Payment">
+                                    attrs="{'invisible': ['|', '|', ('move_type', '!=', 'entry'), ('id', '=', False), ('payment_id', '=', False)]}">
+                                    <div class="o_stat_info">
+                                        <span class="o_stat_text">1 Payment</span>
+                                    </div>
                             </button>
                             <button name="open_reconcile_view"
                                     class="oe_stat_button"
                                     icon="fa-bars"
                                     type="object"
-                                    attrs="{'invisible': ['|', '|', ('move_type', '!=', 'entry'), ('id', '=', False), ('has_reconciled_entries', '=', False)]}"
-                                    string="Reconciled Items">
+                                    attrs="{'invisible': ['|', '|', ('move_type', '!=', 'entry'), ('id', '=', False), ('has_reconciled_entries', '=', False)]}">
+                                    <div class="o_stat_info">
+                                        <span class="o_stat_text">Reconciled Items</span>
+                                    </div>
                             </button>
                             <button name="open_created_caba_entries"
                                     class="oe_stat_button"
                                     icon="fa-usd"
                                     type="object"
-                                    attrs="{'invisible': [('tax_cash_basis_created_move_ids', '=', [])]}"
-                                    string="Cash Basis Entries">
+                                    attrs="{'invisible': [('tax_cash_basis_created_move_ids', '=', [])]}">
+                                    <div class="o_stat_info">
+                                        <span class="o_stat_text">Cash Basis Entries</span>
+                                    </div>
                             </button>
                         </div>
 

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -225,7 +225,7 @@
                                     attrs="{'invisible': [('reconciled_statement_lines_count','=', 0)]}">
                                 <div class="o_form_field o_stat_info">
                                     <field name="reconciled_statement_lines_count"/>
-                                    <span> Transaction</span>
+                                    <span class="o_stat_text">Transaction</span>
                                 </div>
                             </button>
 

--- a/addons/account_payment/views/account_move_views.xml
+++ b/addons/account_payment/views/account_move_views.xml
@@ -28,8 +28,11 @@
                 <field name="transaction_ids" invisible="1" />
                 <button name="action_view_payment_transactions" type="object"
                         class="oe_stat_button" icon="fa-money"
-                        string="Payment Transaction"
-                        attrs="{'invisible': [('transaction_ids', '=', [])]}" />
+                        attrs="{'invisible': [('transaction_ids', '=', [])]}">
+                        <div class="o_stat_info">
+                            <span class="o_stat_text">Payment Transaction</span>
+                        </div>
+                </button>
             </xpath>
         </field>
     </record>

--- a/addons/base_address_extended/views/res_country_view.xml
+++ b/addons/base_address_extended/views/res_country_view.xml
@@ -10,8 +10,10 @@
                     class="oe_stat_button"
                     icon="fa-globe"
                     type="action"
-                    context="{'default_country_id': active_id, 'search_default_country_id': active_id}"
-                    string="Cities">
+                    context="{'default_country_id': active_id, 'search_default_country_id': active_id}">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Cities</span>
+                    </div>
                 </button>
             </xpath>
             <xpath expr="//field[@name='phone_code']" position="after">

--- a/addons/delivery/views/delivery_carrier_views.xml
+++ b/addons/delivery/views/delivery_carrier_views.xml
@@ -53,7 +53,7 @@
                                 class="oe_stat_button"
                                 type="object" icon="fa-stop">
                             <div class="o_stat_info o_field_widget">
-                                <span class="o_warning_text">Test</span>
+                                <span class="o_stat_text o_warning_text fw-bold">Test</span>
                                 <span class="o_stat_text">Environment</span>
                             </div>
                         </button>
@@ -62,7 +62,7 @@
                                 class="oe_stat_button"
                                 type="object" icon="fa-code">
                             <div class="o_stat_info o_field_widget">
-                                <span class="text-danger">No debug</span>
+                                <span class="o_stat_text text-danger">No debug</span>
                             </div>
                         </button>
                         <button name="toggle_debug"

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -13,9 +13,11 @@
                     <div class="oe_button_box" name="button_box" groups="base.group_user">
                         <button name="%(event.event_registration_action_stats_from_event)d"
                                 type="action" class="oe_stat_button" icon="fa-line-chart">
-                            <span class="o_stat_text">
-                                Registration statistics
-                            </span>
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">
+                                    Registration statistics
+                                </span>
+                            </div>
                         </button>
                         <button name="%(event.act_event_registration_from_event)d"
                                 type="action"

--- a/addons/event_booth_sale/views/event_booth_views.xml
+++ b/addons/event_booth_sale/views/event_booth_views.xml
@@ -10,7 +10,10 @@
             <div name="button_box" position="inside">
                 <button name="action_view_sale_order" type="object" class="oe_stat_button"
                         icon="fa-usd" groups="sales_team.group_sale_salesman"
-                        string="Sale Order" attrs="{'invisible': [('sale_order_id', '=', False)]}">
+                        attrs="{'invisible': [('sale_order_id', '=', False)]}">
+                        <div class="o_stat_info">
+                            <span class="o_stat_text">Sale Order</span>
+                        </div>
                 </button>
             </div>
             <div name="button_box" position="after">

--- a/addons/event_sale/views/event_registration_views.xml
+++ b/addons/event_sale/views/event_registration_views.xml
@@ -37,9 +37,12 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button name="action_view_sale_order" type="object"
-                        class="oe_stat_button" icon="fa-usd" string="Sale Order"
+                        class="oe_stat_button" icon="fa-usd"
                         groups="sales_team.group_sale_salesman"
                         attrs="{'invisible': [('sale_order_id', '=', False)]}">
+                        <div class="o_stat_info">
+                            <span class="o_stat_text">Sale Order</span>
+                        </div>
                 </button>
             </xpath>
             <xpath expr="//group" position="before">

--- a/addons/gamification/views/gamification_challenge_views.xml
+++ b/addons/gamification/views/gamification_challenge_views.xml
@@ -39,8 +39,7 @@
                                 icon="fa-gift"
                                 attrs="{'invisible': [('state','=','draft')]}">
                             <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_text">Related</span>
-                                <span class="o_stat_text">Goals</span>
+                                <span class="o_stat_text">Related Goals</span>
                             </div>
                         </button>
                     </div>

--- a/addons/hr_expense/views/account_move_views.xml
+++ b/addons/hr_expense/views/account_move_views.xml
@@ -10,10 +10,13 @@
                     <field name="expense_sheet_id" invisible="1"/>
                     <button name="action_open_expense_report"
                             class="oe_stat_button"
-                            string="Expense Report"
                             icon="fa-file-text-o"
                             type="object"
-                            attrs="{'invisible': [('expense_sheet_id', '=', [])]}"/>
+                            attrs="{'invisible': [('expense_sheet_id', '=', [])]}">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Expense Report</span>
+                            </div>
+                    </button>
                 </xpath>
             </field>
         </record>

--- a/addons/hr_expense/views/account_payment_views.xml
+++ b/addons/hr_expense/views/account_payment_views.xml
@@ -10,10 +10,13 @@
                     <field name="expense_sheet_id" invisible="1"/>
                     <button name="action_open_expense_report"
                             class="oe_stat_button"
-                            string="Expense Report"
                             icon="fa-file-text-o"
                             type="object"
-                            attrs="{'invisible': [('expense_sheet_id', '=', [])]}"/>
+                            attrs="{'invisible': [('expense_sheet_id', '=', [])]}">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Expense Report</span>
+                            </div>
+                    </button>
                 </xpath>
             </field>
         </record>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -727,7 +727,9 @@
                             type="object"
                             attrs="{'invisible': ['|', ('state', 'not in', ['post', 'done']), ('account_move_id', '=', False)]}"
                             groups="account.group_account_invoice">
-                            Journal Entry
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Journal Entry</span>
+                            </div>
                         </button>
                         <button name="action_open_expense_view"
                             class="oe_stat_button"

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -92,8 +92,8 @@
                     </button>
                     <button name="action_makeMeeting" class="oe_stat_button" icon="fa-calendar" type="object" attrs="{'invisible': [('id', '=', False)]}">
                         <div class="o_field_widget o_stat_info">
-                            <span class="o_stat_value"><field name="meeting_display_text" /></span>
-                            <span class="o_stat_text"><field name="meeting_display_date" readonly="1"/></span>
+                            <span class="o_stat_text"><field name="meeting_display_text" /></span>
+                            <span class="o_stat_value"><field name="meeting_display_date" readonly="1"/></span>
                         </div>
                     </button>
                 </div>

--- a/addons/hr_work_entry/views/hr_employee_views.xml
+++ b/addons/hr_work_entry/views/hr_employee_views.xml
@@ -9,7 +9,12 @@
             <div name="button_box" position="inside">
                 <field name="has_work_entries" invisible="1"/>
                 <button attrs="{'invisible': [('has_work_entries', '=', False)]}" type="object" class="oe_stat_button" id="open_work_entries"
-                    icon="fa-calendar" name="action_open_work_entries" string="Work Entries">
+                    icon="fa-calendar" name="action_open_work_entries">
+                    <div class="o_stat_info">
+                            <span class="o_stat_text">
+                            Work Entries
+                            </span>
+                        </div>
                 </button>
             </div>
         </field>

--- a/addons/link_tracker/views/link_tracker_views.xml
+++ b/addons/link_tracker/views/link_tracker_views.xml
@@ -30,7 +30,11 @@
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <button type="object" icon="fa-sign-out" name="action_visit_page"
-                                string="Visit Page" class="oe_stat_button"/>
+                                string="Visit Page" class="oe_stat_button">
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_text">Visit Page</span>
+                                </div>
+                            </button>
 
                             <button type="object" class="oe_stat_button" name="action_view_statistics" icon="fa-bar-chart-o">
                                 <field name="count" string="Clicks" widget="statinfo"/>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -99,9 +99,13 @@
             <form string="Log an Activity" create="false">
                 <sheet string="Activity">
                     <div class="oe_button_box" name="button_box" invisible="1">
-                        <button name="action_open_document" string="Open Document"
+                        <button name="action_open_document"
                                 type="object" class="oe_link" icon="fa-file-text-o"
-                                attrs="{'invisible': ['|', ('res_model', '=', False), ('res_id', '=', 0)]}"/>
+                                attrs="{'invisible': ['|', ('res_model', '=', False), ('res_id', '=', 0)]}">
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_text">Open Document</span>
+                                </div>
+                        </button>
                     </div>
                     <group invisible="1">
                         <field name="activity_category" invisible="1" />

--- a/addons/mail/views/mail_alias_views.xml
+++ b/addons/mail/views/mail_alias_views.xml
@@ -18,9 +18,13 @@
                             <button name="open_document" string="Open Document"
                                     type="object" class="oe_link" icon="fa-sitemap"
                                     attrs="{'invisible': ['|', ('alias_model_id', '=', False), ('alias_force_thread_id', '=', 0)]}"/>
-                            <button name="open_parent_document" string="Open Parent Document"
+                            <button name="open_parent_document"
                                     type="object" class="oe_link" icon="fa-sitemap"
-                                    attrs="{'invisible': ['|', ('alias_parent_model_id', '=', False), ('alias_parent_thread_id', '=', 0)]}"/>
+                                    attrs="{'invisible': ['|', ('alias_parent_model_id', '=', False), ('alias_parent_thread_id', '=', 0)]}">
+                                    <div class="o_field_widget o_stat_info">
+                                        <span class="o_stat_text">Open Parent Document</span>
+                                    </div>
+                            </button>
                         </div>
                         <div class="d-flex">
                             <h2 class="flex-grow-1"><field name="alias_name" class="oe_inline"/>@<field name="alias_domain" class="oe_inline"/></h2>

--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -16,9 +16,13 @@
                         <field name="model" invisible="1"/>
                         <field name="res_id" invisible="1"/>
                         <div class="oe_button_box" name="button_box">
-                            <button name="action_open_document" string="Open Document"
+                            <button name="action_open_document"
                                     type="object" class="oe_link" icon="fa-file-text-o"
-                                    attrs="{'invisible': ['|', ('model', '=', False), ('res_id', '=', 0)]}"/>
+                                    attrs="{'invisible': ['|', ('model', '=', False), ('res_id', '=', 0)]}">
+                                    <div class="o_field_widget o_stat_info">
+                                        <span class="o_stat_text">Open Document</span>
+                                    </div>
+                            </button>
                         </div>
                         <field name="mail_message_id_int" required="0" invisible="1"/>
                         <label for="subject" class="oe_edit_only"/>

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -26,9 +26,13 @@
                 <form string="Message" duplicate="0">
                     <sheet>
                         <div class="oe_button_box" name="button_box">
-                            <button name="action_open_document" string="Open Document"
+                            <button name="action_open_document"
                                 type="object" class="oe_link" icon="fa-file-text-o"
-                                attrs="{'invisible': ['|', ('model', '=', False), ('res_id', '=', 0)]}"/>
+                                attrs="{'invisible': ['|', ('model', '=', False), ('res_id', '=', 0)]}">
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_text">Open Document</span>
+                                </div>
+                            </button>
                         </div>
                         <group>
                             <group>

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -36,8 +36,12 @@
                                     <span class="o_stat_text">Context Action</span>
                                 </div>
                             </button>
-                            <button class="oe_stat_button" name="%(mail_template_preview_action)d" icon="fa-search-plus" string="Preview"
-                                    type="action" target="new"/>
+                            <button class="oe_stat_button" name="%(mail_template_preview_action)d" icon="fa-search-plus"
+                                    type="action" target="new">
+                                    <div class="o_field_widget o_stat_info">
+                                        <span class="o_stat_text">Preview</span>
+                                    </div>
+                            </button>
                         </div>
                         <div class="oe_title">
                             <label for="name"/>

--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -51,39 +51,15 @@
                         </button>
                         <button name="action_view_contacts_bouncing"
                                 type="object" icon="fa-exchange" class="oe_stat_button">
-                            <div class="o_field_widget o_stat_info">
-                                <div class="oe_inline">
-                                    <span class="o_stat_value">
-                                        <field name="contact_pct_bounce" widget="statinfo" nolabel="1"/>
-                                    </span>
-                                    <span class="o_stat_value">%</span>
-                                </div>
-                                <span class="o_stat_text">Bounce</span>
-                            </div>
+                                <field name="contact_pct_bounce" widget="statinfo" string="% Bounce"/>
                         </button>
                         <button name="action_view_contacts_opt_out"
                                 type="object" icon="fa-bell-slash-o" class="oe_stat_button">
-                            <div class="o_field_widget o_stat_info">
-                                <div class="oe_inline">
-                                    <span class="o_stat_value">
-                                        <field name="contact_pct_opt_out" widget="statinfo" nolabel="1"/>
-                                    </span>
-                                    <span class="o_stat_value">%</span>
-                                </div>
-                                <span class="o_stat_text">Opt-out</span>
-                            </div>
+                                <field name="contact_pct_opt_out" widget="statinfo" string="% Opt-out"/>
                         </button>
                         <button name="action_view_contacts_blacklisted"
                                 type="object" icon="fa-ban" class="oe_stat_button">
-                            <div class="o_field_widget o_stat_info">
-                                <div class="oe_inline">
-                                    <span class="o_stat_value">
-                                        <field name="contact_pct_blacklisted" widget="statinfo" nolabel="1"/>
-                                    </span>
-                                    <span class="o_stat_value">%</span>
-                                </div>
-                                <span class="o_stat_text">Blacklist</span>
-                            </div>
+                                <field name="contact_pct_blacklisted" widget="statinfo" string="% Blacklist"/>
                         </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>

--- a/addons/mass_mailing/views/mailing_trace_views.xml
+++ b/addons/mass_mailing/views/mailing_trace_views.xml
@@ -80,7 +80,9 @@
                     <div class="oe_button_box" name="button_box">
                         <button name="action_view_contact"
                                 type="object" icon="fa-user" class="oe_stat_button">
-                            <span widget="statinfo">Open Recipient</span>
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_text">Open Recipient</span>
+                                </div>
                         </button>
                     </div>
                     <group>

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -45,7 +45,11 @@
                                 </div>
                             </button>
                             <button name="%(action_report_mrp_bom)d" type="action"
-                                class="oe_stat_button" icon="fa-bars" string="Overview"/>
+                                class="oe_stat_button" icon="fa-bars">
+                                <div class="o_stat_info">
+                                    <span class="o_stat_text">Overview</span>
+                                </div>
+                            </button>
                         </div>
                         <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <group>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -185,9 +185,21 @@
                         <button type="object" name="action_view_mo_delivery" class="oe_stat_button" icon="fa-truck"  groups="base.group_user" attrs="{'invisible': [('delivery_count', '=', 0)]}">
                             <field name="delivery_count" widget="statinfo" string="Transfers"/>
                         </button>
-                        <button name="%(stock.action_stock_report)d" icon="oi oi-arrow-up" class="oe_stat_button" string="Traceability" type="action" states="done" groups="stock.group_production_lot"/>
-                        <button name="%(action_mrp_production_moves)d" type="action" string="Product Moves" class="oe_stat_button" icon="fa-exchange" attrs="{'invisible': [('state', 'not in', ('progress', 'done'))]}"/>
-                        <button name="%(action_report_mo_overview)d" type="action" class="oe_stat_button" icon="fa-bars" string="Overview"/>
+                        <button name="%(stock.action_stock_report)d" icon="oi oi-arrow-up" class="oe_stat_button" string="Traceability" type="action" states="done" groups="stock.group_production_lot">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Traceability</span>
+                            </div>
+                        </button>
+                        <button name="%(action_mrp_production_moves)d" type="action" class="oe_stat_button" icon="fa-exchange" attrs="{'invisible': [('state', 'not in', ('progress', 'done'))]}">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Product Moves</span>
+                            </div>
+                        </button>
+                        <button name="%(action_report_mo_overview)d" type="action" class="oe_stat_button" icon="fa-bars">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Overview</span>
+                            </div>
+                        </button>
                     </div>
                     <div class="oe_title">
                         <label class="o_form_label" for="name" string="MO Reference"/>

--- a/addons/mrp/views/mrp_unbuild_views.xml
+++ b/addons/mrp/views/mrp_unbuild_views.xml
@@ -95,7 +95,11 @@
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <button class="oe_stat_button" name="%(action_mrp_unbuild_moves)d"
-                                    string="Product Moves" type="action" icon="fa-exchange" states="done"/>
+                                    type="action" icon="fa-exchange" states="done">
+                                    <div class="o_stat_info">
+                                        <span class="o_stat_text">Product Moves</span>
+                                    </div>
+                            </button>
                         </div>
                         <div class="oe_title">
                             <h1><field name="name" placeholder="Unbuild Order" nolabel="1"/></h1>

--- a/addons/mrp_account/views/mrp_production_views.xml
+++ b/addons/mrp_account/views/mrp_production_views.xml
@@ -20,15 +20,23 @@
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <t groups="stock.group_stock_manager">
-                    <button string="Valuation" type="object"
+                    <button type="object"
                         name="action_view_stock_valuation_layers"
                         class="oe_stat_button" icon="fa-dollar" groups="base.group_no_one"
-                        attrs="{'invisible': [('show_valuation', '=', False)]}" />
+                        attrs="{'invisible': [('show_valuation', '=', False)]}" >
+                        <div class="o_stat_info">
+                            <span class="o_stat_text">Valuation</span>
+                        </div>
+                    </button>
                     <button class="oe_stat_button" type="object"
                         name="action_view_analytic_account"
-                        string="Analytic Account" icon="fa-bar-chart-o"
+                        icon="fa-bar-chart-o"
                         attrs="{'invisible': ['|', ('analytic_account_id', '=', False), ('state', 'in', ['draft', 'cancel'])]}"
-                        groups="analytic.group_analytic_accounting"/>
+                        groups="analytic.group_analytic_accounting">
+                        <div class="o_stat_info">
+                            <span class="o_stat_text">Analytic Account</span>
+                        </div>
+                    </button>
                 </t>
             </xpath>
             <xpath expr="//page[@name='miscellaneous']//field[@name='date_deadline']" position="after">

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -37,7 +37,7 @@
                                 type="object"
                                 icon="fa-globe">
                             <div class="o_stat_info o_field_widget">
-                                <span class="text-success">Published</span>
+                                <span class="o_stat_text text-success">Published</span>
                             </div>
                         </button>
                         <button name="action_toggle_is_published"
@@ -46,7 +46,7 @@
                                 type="object"
                                 icon="fa-eye-slash">
                             <div class="o_stat_info o_field_widget">
-                                <span class="text-danger">Unpublished</span>
+                                <span class="o_stat_text text-danger">Unpublished</span>
                             </div>
                         </button>
                     </div>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -27,10 +27,10 @@
                                     <span class="o_stat_value">
                                         <field name="pricelist_item_count"/>
                                     </span>
-                                    <span attrs="{'invisible': [('pricelist_item_count', '=', 1)]}">
+                                    <span class="o_stat_text" attrs="{'invisible': [('pricelist_item_count', '=', 1)]}">
                                         Extra Prices
                                     </span>
-                                    <span attrs="{'invisible': [('pricelist_item_count', '!=', 1)]}">
+                                    <span class="o_stat_text" attrs="{'invisible': [('pricelist_item_count', '!=', 1)]}">
                                         Extra Price
                                     </span>
                                </div>

--- a/addons/project/static/src/components/project_status_with_color_selection/project_status_with_color_selection_field.xml
+++ b/addons/project/static/src/components/project_status_with_color_selection/project_status_with_color_selection_field.xml
@@ -8,8 +8,8 @@
                     <span t-attf-class="o_status {{ statusColor(currentValue) }} d-inline-block"/>
                 </div>
                 <div class="ps-2">
-                    <div class="" t-out="string" t-att-raw-value="value"/>
-                    <div class="fw-normal" t-if="this.props.statusLabel" t-out="this.props.statusLabel"/>
+                    <div class="o_stat_text" t-if="this.props.statusLabel" t-out="this.props.statusLabel"/>
+                    <div class="o_stat_value" t-out="string" t-att-raw-value="value"/>
                 </div>
             </div>
         </xpath>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -29,8 +29,8 @@
                 <sheet string="Project">
                     <div class="oe_button_box" name="button_box" groups="base.group_user">
                         <button class="oe_stat_button" name="project_update_all_action" type="object" groups="project.group_project_manager">
-                            <div>
-                                <field name="last_update_color" invisible="1"/>
+                            <field name="last_update_color" invisible="1"/>
+                            <div class="o_stat_info">
                                 <field name="last_update_status" readonly="1" widget="status_with_color" status_label="Project Status"/>
                             </div>
                         </button>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -280,11 +280,10 @@
                         <button name="action_open_parent_task" type="object" class="oe_stat_button" icon="fa-tasks" string="Parent Task" attrs="{'invisible': [('parent_id', '=', False)]}"/>
                         <button name="action_recurring_tasks" type="object" attrs="{'invisible': ['|', ('active', '=', False), ('recurrence_id', '=', False)]}" class="oe_stat_button" icon="fa-repeat" groups="project.group_project_recurring_tasks">
                             <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">Recurring Tasks</span>
                                 <span class="o_stat_value">
                                     <field name="recurring_count" widget="statinfo" nolabel="1" />
-                                    Tasks
                                 </span>
-                                <span class="o_stat_text">in Recurrence</span>
                             </div>
                         </button>
                         <button name="%(project_task_action_sub_task)d" type="action" class="oe_stat_button" icon="fa-tasks"

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -51,7 +51,11 @@
                <sheet string="Repairs order">
                     <div class="oe_button_box" name="button_box">
                         <field name="invoice_id" invisible="1"/>
-                        <button name="%(action_repair_move_lines)d" type="action" string="Product Moves" class="oe_stat_button" icon="fa-exchange" attrs="{'invisible': [('state', 'not in', ['done', 'cancel'])]}"/>
+                        <button name="%(action_repair_move_lines)d" type="action" string="Product Moves" class="oe_stat_button" icon="fa-exchange" attrs="{'invisible': [('state', 'not in', ['done', 'cancel'])]}">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Product Moves</span>
+                            </div>
+                        </button>
                         <button name="action_created_invoice"
                             type="object"
                             class="oe_stat_button"

--- a/addons/resource/views/resource_calendar_views.xml
+++ b/addons/resource/views/resource_calendar_views.xml
@@ -27,13 +27,21 @@
                     <widget name="web_ribbon" text="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_button_box" name="button_box">
                         <button name="%(resource_calendar_leaves_action_from_calendar)d" type="action"
-                                string="Time Off" icon="fa-plane"
+                                icon="fa-plane"
                                 class="oe_stat_button"
-                                groups="base.group_no_one"/>
+                                groups="base.group_no_one">
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_text">Time Off</span>
+                                </div>
+                        </button>
                         <button name="%(resource_resource_action_from_calendar)d" type="action"
-                                string="Work Resources" icon="fa-cogs"
+                                icon="fa-cogs"
                                 class="oe_stat_button"
-                                groups="base.group_user"/>
+                                groups="base.group_user">
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_text">Work Resources</span>
+                                </div>
+                        </button>
                     </div>
                     <h1>
                         <field name="name"/>

--- a/addons/sale_project/views/project_sharing_views.xml
+++ b/addons/sale_project/views/project_sharing_views.xml
@@ -12,8 +12,11 @@
                 <field name="allow_billable" invisible="1"/>
                 <button class="oe_stat_button"
                         type="object" name="action_project_sharing_view_so" icon="fa-dollar"
-                        attrs="{'invisible': [('display_sale_order_button', '=', False)]}"
-                        string="Sales Order"/>
+                        attrs="{'invisible': [('display_sale_order_button', '=', False)]}">
+                        <div class="o_stat_info">
+                            <span class="o_stat_text">Sales Order</span>
+                        </div>
+                </button>
             </div>
             <xpath expr="//field[@name='partner_id']" position="attributes">
                 <attribute name="attrs">{'invisible': [('allow_billable', '=', False)]}</attribute>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -78,8 +78,11 @@
                 <button class="oe_stat_button"
                         type="object" name="action_view_so" icon="fa-dollar"
                         attrs="{'invisible': [('sale_order_id', '=', False)]}"
-                        string="Sales Order"
-                        groups="sales_team.group_sale_salesman_all_leads"/>
+                        groups="sales_team.group_sale_salesman_all_leads">
+                        <div class="o_stat_info">
+                            <span class="o_stat_text">Sales Order</span>
+                        </div>
+                </button>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="attributes">
                 <attribute name="options">{'always_reload': True}</attribute>

--- a/addons/sale_timesheet/views/sale_order_views.xml
+++ b/addons/sale_timesheet/views/sale_order_views.xml
@@ -14,13 +14,13 @@
                            icon="fa-clock-o"
                            attrs="{'invisible': [('timesheet_count', '=', 0)]}"
                            groups="hr_timesheet.group_hr_timesheet_user">
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value">
-                                    <field name="timesheet_total_duration" class="mr4" widget="statinfo" nolabel="1"/>
+                           <div class="o_stat_info">
+                               <span class="o_stat_value">
+                                    <field name="timesheet_total_duration" class="mr4"/>
                                     <field name="timesheet_encode_uom_id" options="{'no_open': True}"/>
                                 </span>
                                 <span class="o_stat_text">Recorded</span>
-                            </div>
+                           </div>
                         </button>
                     </xpath>
                 </data>

--- a/addons/sms/views/sms_template_views.xml
+++ b/addons/sms/views/sms_template_views.xml
@@ -35,7 +35,11 @@
                                 <span class="o_stat_text">Context Action</span>
                             </div>
                         </button>
-                        <button class="oe_stat_button" name="%(sms_template_preview_action)d" icon="fa-search-plus" string="Preview" type="action" target="new"/>
+                        <button class="oe_stat_button" name="%(sms_template_preview_action)d" icon="fa-search-plus" type="action" target="new">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">Preview</span>
+                            </div>
+                        </button>
                     </div>
                     <div class="oe_title">
                         <label for="name" string="SMS Template"/>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -288,25 +288,29 @@
                                 attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}"
                                 class="oe_stat_button" icon="fa-exchange"
                                 groups="stock.group_stock_user">
-                                <div class="o_field_widget o_stat_info mr4">
-                                    <span class="o_stat_text">In:</span>
-                                    <span class="o_stat_text">Out:</span>
-                                </div>
-                                <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_value"><field name="nbr_moves_in"/></span>
-                                    <span class="o_stat_value"><field name="nbr_moves_out"/></span>
+                                <div class="d-flex flex-column">
+                                    <div class="o_field_widget o_stat_info align-items-baseline flex-row gap-1 me-1">
+                                        <span class="o_stat_text">In:</span>
+                                        <span class="o_stat_value"><field name="nbr_moves_in"/></span>
+                                    </div>
+                                    <div class="o_field_widget o_stat_info align-items-baseline flex-row gap-1 me-1">
+                                        <span class="o_stat_text">Out:</span>
+                                        <span class="o_stat_value"><field name="nbr_moves_out"/></span>
+                                    </div>
                                 </div>
                             </button>
                             <button name="action_view_orderpoints" type="object"
                                 attrs="{'invisible':['|',('type', 'not in', ['product', 'consu']),('nbr_reordering_rules', '!=', 1)]}"
                                 class="oe_stat_button" icon="fa-refresh">
-                                <div class="o_field_widget o_stat_info mr4">
-                                    <span class="o_stat_text">Min:</span>
-                                    <span class="o_stat_text">Max:</span>
-                                </div>
-                                <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_value"><field name="reordering_min_qty"/></span>
-                                    <span class="o_stat_value"><field name="reordering_max_qty"/></span>
+                                <div class="d-flex flex-column">
+                                    <div class="o_field_widget o_stat_info align-items-baseline flex-row gap-1 me-1">
+                                        <span class="o_stat_text">Min:</span>
+                                        <span class="o_stat_value"><field name="reordering_min_qty"/></span>
+                                    </div>
+                                    <div class="o_field_widget o_stat_info align-items-baseline flex-row gap-1 me-1">
+                                        <span class="o_stat_text">Max:</span>
+                                        <span class="o_stat_value"><field name="reordering_max_qty"/></span>
+                                    </div>
                                 </div>
                             </button>
                             <button type="object"
@@ -395,26 +399,30 @@
                                 attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}"
                                 class="oe_stat_button" icon="fa-exchange"
                                 groups="stock.group_stock_user">
-                                <div class="o_field_widget o_stat_info mr4">
-                                    <span class="o_stat_text">In:</span>
-                                    <span class="o_stat_text">Out:</span>
-                                </div>
-                                <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_value"><field name="nbr_moves_in"/></span>
-                                    <span class="o_stat_value"><field name="nbr_moves_out"/></span>
+                                <div class="d-flex flex-column">
+                                    <div class="o_field_widget o_stat_info align-items-baseline flex-row gap-1 me-1">
+                                        <span class="o_stat_text">In:</span>
+                                        <span class="o_stat_value"><field name="nbr_moves_in"/></span>
+                                    </div>
+                                    <div class="o_field_widget o_stat_info align-items-baseline flex-row gap-1 me-1">
+                                        <span class="o_stat_text">Out:</span>
+                                        <span class="o_stat_value"><field name="nbr_moves_out"/></span>
+                                    </div>
                                 </div>
                             </button>
                             <button type="object"
                                 name="action_view_orderpoints"
                                 attrs="{'invisible':['|',('type', '!=', 'product'),('nbr_reordering_rules', '!=', 1)]}"
                                 class="oe_stat_button" icon="fa-refresh">
-                                <div class="o_field_widget o_stat_info mr4">
-                                    <span class="o_stat_text">Min:</span>
-                                    <span class="o_stat_text">Max:</span>
-                                </div>
-                                <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_value"><field name="reordering_min_qty"/></span>
-                                    <span class="o_stat_value"><field name="reordering_max_qty"/></span>
+                                <div class="d-flex flex-column">
+                                    <div class="o_field_widget o_stat_info align-items-baseline flex-row gap-1 me-1">
+                                        <span class="o_stat_text">Min:</span>
+                                        <span class="o_stat_value"><field name="reordering_min_qty"/></span>
+                                    </div>
+                                    <div class="o_field_widget o_stat_info align-items-baseline flex-row gap-1 me-1">
+                                        <span class="o_stat_text">Max:</span>
+                                        <span class="o_stat_value"><field name="reordering_max_qty"/></span>
+                                    </div>
                                 </div>
                             </button>
                             <button type="object"
@@ -424,24 +432,36 @@
                                 icon="fa-refresh">
                                 <field name="nbr_reordering_rules" widget="statinfo"/>
                             </button>
-                            <button string="Lot/Serial Numbers" type="object"
+                            <button type="object"
                                 name="action_open_product_lot"
                                 attrs="{'invisible': [('tracking', '=', 'none')]}"
-                                class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot"/>
-                            <button string="Putaway Rules" type="object"
+                                class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot">
+                                <div class="o_stat_info">
+                                    <span class="o_stat_text">Lot/Serial Numbers</span>
+                                </div>
+                            </button>
+                            <button type="object"
                                 name="action_view_related_putaway_rules"
                                 class="oe_stat_button" icon="fa-random" groups="stock.group_stock_multi_locations"
                                 attrs="{'invisible': [('type', '=', 'service')]}"
                                 context="{
                                     'invisible_handle': True,
                                     'single_product': product_variant_count == 1,
-                                }"/>
-                            <button type="object" string="Storage Capacities"
+                                }">
+                                    <div class="o_stat_info">
+                                        <span class="o_stat_text">Putaway Rules</span>
+                                    </div>
+                             </button>
+                            <button type="object"
                                 name="action_view_storage_category_capacity"
                                 groups="stock.group_stock_storage_categories"
                                 attrs="{'invisible':[('type', '=', 'service')]}"
                                 class="oe_stat_button"
-                                icon="fa-cubes"/>
+                                icon="fa-cubes">
+                                <div class="o_stat_info">
+                                    <span class="o_stat_text">Storage Capacities</span>
+                                </div>
+                            </button>
                         </t>
                     </div>
 

--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -21,8 +21,16 @@
                                 <span class="o_stat_text">Transfers</span>
                             </div>
                         </button>
-                        <button name="action_lot_open_quants" icon="fa-arrows" class="oe_stat_button" string="Location" type="object"/>
-                        <button name="%(action_stock_report)d" icon="oi oi-arrow-up" class="oe_stat_button" string="Traceability" type="action"/>
+                        <button name="action_lot_open_quants" icon="fa-arrows" class="oe_stat_button" type="object">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Location</span>
+                            </div>
+                        </button>
+                        <button name="%(action_stock_report)d" icon="oi oi-arrow-up" class="oe_stat_button" type="action">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Traceability</span>
+                            </div>
+                        </button>
                 </div>
                 <div class="oe_title">
                     <label for="name"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -160,12 +160,20 @@
                         <button name="action_see_packages" string="Packages" type="object"
                             class="oe_stat_button" icon="fa-cubes"
                             attrs="{'invisible': [('has_packages', '=', False)]}"/>
-                        <button name="%(action_stock_report)d" icon="oi oi-arrow-up" class="oe_stat_button" string="Traceability" type="action" attrs="{'invisible': ['|', ('state', '!=', 'done'), ('has_tracking', '=', False)]}" groups="stock.group_production_lot"/>
-                        <button name="action_view_reception_report" string="Allocation" type="object"
+                        <button name="%(action_stock_report)d" icon="oi oi-arrow-up" class="oe_stat_button" type="action" attrs="{'invisible': ['|', ('state', '!=', 'done'), ('has_tracking', '=', False)]}" groups="stock.group_production_lot">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Traceability</span>
+                            </div>
+                        </button>
+                        <button name="action_view_reception_report" type="object"
                             context="{'default_picking_ids': [id]}"
                             class="oe_stat_button" icon="fa-list"
                             attrs="{'invisible': [('show_allocation', '=', False)]}"
-                            groups="stock.group_reception_report"/>
+                            groups="stock.group_reception_report">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Allocation</span>
+                            </div>
+                        </button>
                         <!-- Use the following button to avoid onchange on one2many -->
                         <button name="action_picking_move_tree"
                             class="oe_stat_button"

--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -37,8 +37,12 @@
                                     attrs="{'invisible':[('picking_id','=',False)]}" icon="fa-cogs"/>
                             <field name="picking_id" invisible="1"/>
                             <button class="oe_stat_button" name="action_get_stock_move_lines"
-                                    string="Product Moves" type="object"
-                                    attrs="{'invisible':[('move_id','=',False)]}" icon="fa-exchange"/>
+                                    type="object"
+                                    attrs="{'invisible':[('move_id','=',False)]}" icon="fa-exchange">
+                                    <div class="o_stat_info">
+                                        <span class="o_stat_text">Product Moves</span>
+                                    </div>
+                            </button>
                             <field name="move_id" invisible="1"/>
                         </div>
                         <div class="oe_title">

--- a/addons/stock/views/stock_warehouse_views.xml
+++ b/addons/stock/views/stock_warehouse_views.xml
@@ -12,7 +12,11 @@
                                     string="Routes"
                                     icon="fa-refresh"
                                     class="oe_stat_button"
-                                    type="object"/>
+                                    type="object">
+                                    <div class="o_stat_info">
+                                        <span class="o_stat_text">Routes</span>
+                                    </div>
+                            </button>
                         </div>
                         <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <label for="name"/>

--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -157,10 +157,14 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
-                <button string="Valuation" type="object"
+                <button type="object"
                     name="action_view_stock_valuation_layers"
                     class="oe_stat_button" icon="fa-dollar" groups="base.group_no_one"
-                    attrs="{'invisible': [('state', 'not in', ['done'])]}" />
+                    attrs="{'invisible': [('state', 'not in', ['done'])]}" >
+                    <div class="o_stat_info">
+                        <span class="o_stat_text">Valuation</span>
+                    </div>
+                </button>
             </xpath>
         </field>
     </record>

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -16,10 +16,14 @@
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
-                            <button string="Valuation" type="object"
+                            <button type="object"
                                 name="action_view_stock_valuation_layers"
                                 class="oe_stat_button" icon="fa-dollar" groups="stock.group_stock_manager"
-                                attrs="{'invisible': ['|' , ('state', 'not in', ['done']), ('stock_valuation_layer_ids', '=', [])]}"/>
+                                attrs="{'invisible': ['|' , ('state', 'not in', ['done']), ('stock_valuation_layer_ids', '=', [])]}">
+                                <div class="o_stat_info">
+                                    <span class="o_stat_text">Valuation</span>
+                                </div>
+                            </button>
                         </div>
                         <div class="oe_title">
                             <label for="name" string="Landed Cost"/>

--- a/addons/web/static/src/views/fields/percent_pie/percent_pie_field.xml
+++ b/addons/web/static/src/views/fields/percent_pie/percent_pie_field.xml
@@ -11,7 +11,7 @@
 
         <div class="o_pie_info">
             <span class="o_pie_value" t-esc="props.record.data[props.name] + '%'"/>
-            <span class="o_pie_text ms-1" t-esc="props.string"/>
+            <span class="o_pie_text" t-esc="props.string"/>
         </div>
     </t>
 

--- a/addons/web/static/src/views/form/button_box/button_box.scss
+++ b/addons/web/static/src/views/form/button_box/button_box.scss
@@ -89,6 +89,11 @@
         &:hover .o_stat_info > .o_not_hover {
             display: none !important
         }
+        &.btn-outline-secondary:disabled {
+            opacity: 1;
+            color:inherit;
+
+        }
     }
 
     > * + * {

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -188,12 +188,16 @@
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button class="oe_stat_button o_stat_button_info" disabled="1" attrs="{'invisible': [('is_connected', '=', False)]}">
-                            <i class="fa fa-fw o_button_icon fa-circle text-success"/>
-                            <span>Connected</span>
+                            <i class="fa fa-fw o_button_icon fa-circle text-success" title="Connected"/>
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Connected</span>
+                            </div>
                         </button>
                         <button class="oe_stat_button o_stat_button_info" disabled="1" attrs="{'invisible': [('is_connected', '=', True)]}">
-                            <i class="fa fa-fw o_button_icon fa-circle text-danger"/>
-                            <span>Offline</span>
+                            <i class="fa fa-fw o_button_icon fa-circle text-danger" title="Offline"/>
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Offline</span>
+                            </div>
                         </button>
                         <button id="w_visitor_visit_counter" class="oe_stat_button o_stat_button_info" disabled="1" icon="fa-globe">
                             <field name="visit_count" widget="statinfo" string="Visits"/>

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -13,8 +13,7 @@
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
-                            <button
-                                icon="fa-eye"
+                            <button icon="fa-eye"
                                 class="oe_stat_button"
                                 groups="website_slides.group_website_slides_officer"
                                 attrs="{'invisible': [('total_views', '=', 0)]}">
@@ -25,10 +24,7 @@
                                 icon="fa-files-o"
                                 class="oe_stat_button"
                                 groups="website_slides.group_website_slides_officer">
-                                <span>
-                                    <field name="total_slides" widget="statinfo" nolabel="1"/>
-                                    Published Contents
-                                </span>
+                                <field name="total_slides" widget="statinfo" string="Published Contents"/>
                             </button>
                             <button name="action_redirect_to_completed_members"
                                 type="object"

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -60,15 +60,27 @@
                     <field name="binding_model_id" invisible="1"/>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
-                            <button name="create_action" string="Add in the 'Print' menu" type="object"
+                            <button name="create_action" type="object"
                                     attrs="{'invisible':[('binding_model_id','!=',False)]}" icon="fa-plus-square"
-                                    help="Display an option on related documents to print this report" class="oe_stat_button"/>
-                            <button name="unlink_action" string="Remove from the 'Print' menu" type="object"
+                                    help="Display an option on related documents to print this report" class="oe_stat_button">
+                                    <div class="o_field_widget o_stat_info">
+                                        <span class="o_stat_text">Add to the 'Print' menu</span>
+                                    </div>
+                            </button>
+                            <button name="unlink_action" type="object"
                                     attrs="{'invisible':[('binding_model_id','=',False)]}" icon="fa-minus-square"
-                                    help="Remove the contextual action related to this report" class="oe_stat_button"/>
-                            <button name="associated_view" string="QWeb views" type="object"
+                                    help="Remove the contextual action related to this report" class="oe_stat_button">
+                                    <div class="o_field_widget o_stat_info">
+                                        <span class="o_stat_text">Remove from the 'Print' menu</span>
+                                    </div>
+                            </button>
+                            <button name="associated_view" type="object"
                                     attrs="{'invisible':[('report_type', 'not in', ['qweb-pdf', 'qweb-html', 'qweb-text'])]}" icon='fa-code'
-                                    class="oe_stat_button"/>
+                                    class="oe_stat_button">
+                                    <div class="o_field_widget o_stat_info">
+                                        <span class="o_stat_text">Qweb Views</span>
+                                    </div>
+                            </button>
                         </div>
                         <group>
                             <group>

--- a/odoo/addons/base/views/res_lang_views.xml
+++ b/odoo/addons/base/views/res_lang_views.xml
@@ -41,11 +41,14 @@
                 <form string="Languages">
                     <sheet>
                         <div class="oe_button_box" name="button_box">
-                            <button string="Activate and Translate"
-                                name="%(base.action_view_base_language_install)d"
+                            <button name="%(base.action_view_base_language_install)d"
                                 type="action"
                                 class="oe_stat_button"
-                                icon="fa-refresh" />
+                                icon="fa-refresh">
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_text">Activate and Translate</span>
+                                </div>
+                            </button>
                         </div>
                         <field name="flag_image" widget="image" class="oe_avatar"/>
                         <div class="oe_title">


### PR DESCRIPTION
This PR fixes some of the status buttons issues such as alignment, text color, font size differences and overflowing text.

- [jcs] Some characters in smart buttons are cut (overflow problem?). Go to Employees and open Paul Williams. Tested on Windows/Chrome https://www.awesomescreenshot.com/image/39456590?key=e3fce7a5720742d1746df8b1b01fe58e
- [aju] https://i.imgur.com/XQXA622.png helpdesk.ticket form view > the 'x ticket x open' stat button overflows on mobile 
- [aju] https://nimb.ws/0p9BhK project.task form view > the 'tasks in recurrence' stat button overflows
- [aju] https://nimb.ws/a1nwdq project.project form view > the 'status' stat button label is a bit big compared to the other stat buttons

Another issue this PR fixes is the reduced opacity on "disabled" stat buttons. These buttons show stats but aren't clickable. The default behaviour reduced the opacity and set the text to white.
Now the buttons remain unclickable but are visually the same as all the others.

task-2818586
Related Enterprise PR: https://github.com/odoo-dev/enterprise/pull/556
