### PR TITLE
[FIX] web: kanban header fixes

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -32,7 +32,7 @@
 
     --KanbanRecord__dropdown-gap: #{$border-width};
 
-    --KanbanColumn__highlight-background: #{rgba($o-action, 0.05)};
+    --KanbanColumn__highlight-background: #{tint-color($o-action, 90%)};
     --KanbanColumn__highlight-border: #{$o-action};
 
     --o-view-nocontent-zindex: 1;

--- a/addons/web/static/src/views/kanban/kanban_header.xml
+++ b/addons/web/static/src/views/kanban/kanban_header.xml
@@ -6,9 +6,9 @@
             <div class="o_kanban_header_title position-relative d-flex lh-lg" t-on-mouseenter="onTitleMouseEnter" t-on-mouseleave="onTitleMouseLeave">
                 <div t-if="!env.isSmall and group.isFolded" class="o_column_title d-flex align-items-center pt-1 fs-4 lh-1 text-nowrap opacity-50 opacity-100-hover">
                     <t t-esc="groupName"></t>
-                    <span class="badge text-bg-500 rounded-pill lh-1 ms-2" t-esc="group.count"></t>
+                    <span class="badge text-bg-500 rounded-pill lh-1 ms-2" t-esc="group.count"></span>
                 </div>
-                <span t-else=""
+                <span t-if="!env.isSmall and !group.isFolded"
                     t-esc="groupName"
                     class="o_column_title flex-grow-1 d-inline-block mw-100 text-truncate fs-4 fw-bold align-top text-900"
                     />


### PR DESCRIPTION
This PR fixes the issues : 

- [DAFL]: kanban view: drag&drop a card to a crowded column -> cards are not hidden behind the column title https://www.awesomescreenshot.com/image/39617719?key=ff7be0c6e8d7e4e58366e4a09896a52d 
- [MANO] The headers titles in social are not displayed anymore (social.demo.data)  https://tinyurl.com/2lcc4onz 

Enterprise PR: https://github.com/odoo-dev/enterprise/pull/561
task-2818586