### PR TITLE
Master milk studio dbo

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -377,6 +377,9 @@ export class ListController extends Component {
 
     get display() {
         const { controlPanel } = this.props.display;
+        if (!controlPanel) {
+            return this.props.display;
+        }
         return {
             ...this.props.display,
             controlPanel: {


### PR DESCRIPTION
The control panel 'display' prop provided to the list controller can sometimes be falsy instead of being an object - in that case (mainly studio), the cp should not be displayed at all. The display getter did not return a structure that allowed this to behave properly.