### PR TITLE
[IMP] delivery, sale_loyalty: adapt for milk

### DIFF
--- a/addons/delivery/views/sale_order_views.xml
+++ b/addons/delivery/views/sale_order_views.xml
@@ -12,7 +12,7 @@
                 <field name="recompute_delivery_price" invisible="1"/>
             </field>
             <group name="note_group" position="before">
-                <div class="oe_right">
+                <div class="oe_right mb-2">
                     <button
                         string="Add shipping"
                         name="action_open_delivery_wizard"

--- a/addons/sale_loyalty/views/sale_order_views.xml
+++ b/addons/sale_loyalty/views/sale_order_views.xml
@@ -8,7 +8,7 @@
         <field name="priority">10</field>
         <field name="arch" type="xml">
             <group name="note_group" position="before">
-                <div class="oe_right">
+                <div class="oe_right d-flex gap-1 mb-2">
                     <button name="%(sale_loyalty.sale_loyalty_coupon_wizard_action)d" class="btn btn-secondary"
                         string="Coupon Code" type="action" states="draft,sent,sale"/>
                     <button name="action_open_reward_wizard" class="btn btn-secondary"


### PR DESCRIPTION
This commit adapts the spacing between the buttons in the sale_order_views to fit with Milk.

7d76420b5a4eb9a18fcf1edb4b2a9c8beaa08a63:
- Sale form view: missing margin between buttons and bar below https://tinyurl.com/2hx42zho

task-2818586