### PR TITLE
fixup! [IMP] web, *: directional icons

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -144,7 +144,7 @@
                                     </group>
                                     <group name="group_alias_no_domain" string="Create Invoices upon Emails" attrs="{'invisible': ['|', ('type', 'not in',  ('sale' ,'purchase')), ('alias_domain', '!=', False)]}">
                                         <div class="content-group" colspan="2">
-                                            <a type='action' name='%(action_open_settings)d' class="btn btn-link" role="button"><i class="oi fa-fw o_button_icon oi-arrow-right"/> Configure Email Servers</a>
+                                            <a type='action' name='%(action_open_settings)d' class="btn btn-link" role="button"><i class="oi oi-fw o_button_icon oi-arrow-right"/> Configure Email Servers</a>
                                         </div>
                                     </group>
                                     <group class="oe_edit_only" name="group_alias_edit" string="Create Invoices upon Emails" attrs="{'invisible': ['|', ('type', 'not in',  ('sale' ,'purchase')), ('alias_domain', '=', False)]}">

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -82,7 +82,7 @@
                                         <field name="group_multi_currency" invisible="1"/>
                                     </div>
                                     <div class="mt8">
-                                        <button type="action" name="%(base.action_currency_form)d" string="Currencies" class="btn-link" icon="oi oi-arrow-right"/>
+                                        <button type="action" name="%(base.action_currency_form)d" string="Currencies" class="btn-link" icon="oi-arrow-right"/>
                                     </div>
                                 </div>
                             </setting>
@@ -120,7 +120,7 @@
                             <setting id="smallest_coinage_currency" help="Define the smallest coinage of the currency used to pay by cash">
                                 <field name="group_cash_rounding"/>
                                 <div class="mt8">
-                                    <button name="%(account.rounding_list_action)d" icon="oi oi-arrow-right"
+                                    <button name="%(account.rounding_list_action)d" icon="oi-arrow-right"
                                             type="action" string="Cash Roundings" class="btn-link"
                                             attrs="{'invisible': [('group_cash_rounding', '=', False)]}"/>
                                 </div>
@@ -146,7 +146,7 @@
                                                     placeholder="Insert your terms &amp; conditions here..."/>
                                         </div>
                                         <div class="mt8" attrs="{'invisible': [('terms_type', '!=', 'html')]}">
-                                            <button name="action_update_terms" icon="oi oi-arrow-right" type="object" string="Update Terms" class="btn-link"/>
+                                            <button name="action_update_terms" icon="oi-arrow-right" type="object" string="Update Terms" class="btn-link"/>
                                         </div>
                                         <field name="preview_ready" invisible="1"/>
                                         <div class="mt4 ms-1" attrs="{'invisible': [('preview_ready', '=', False)]}">

--- a/addons/auth_ldap/views/res_config_settings_views.xml
+++ b/addons/auth_ldap/views/res_config_settings_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <setting id="module_auth_ldap" position="inside">
                 <div class="mt8" attrs="{'invisible': [('module_auth_ldap','=',False)]}">
-                   <button type="action" name="%(auth_ldap.action_ldap_installer)d" string="LDAP Server" icon="oi oi-arrow-right" class="btn-link"/>
+                   <button type="action" name="%(auth_ldap.action_ldap_installer)d" string="LDAP Server" icon="oi-arrow-right" class="btn-link"/>
                 </div>
             </setting>
             <div id="auth_ldap_warning" position="replace"/>

--- a/addons/auth_oauth/views/res_config_settings_views.xml
+++ b/addons/auth_oauth/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
                 <div id="msg_module_auth_oauth" position="replace">
                     <div class="content-group" attrs="{'invisible': [('module_auth_oauth','=',False)]}">
                         <div class="mt8">
-                            <button type="action" name="%(auth_oauth.action_oauth_provider)d" string="OAuth Providers" icon="oi oi-arrow-right" class="btn-link"/>
+                            <button type="action" name="%(auth_oauth.action_oauth_provider)d" string="OAuth Providers" icon="oi-arrow-right" class="btn-link"/>
                         </div>
                     </div>
                 </div>
@@ -20,7 +20,7 @@
                                 <label for="auth_oauth_google_client_id" string="Client ID:" class="col-lg-3 o_light_label"/>
                                 <field name="auth_oauth_google_client_id" placeholder="e.g. 1234-xyz.apps.googleusercontent.com"/>
                             </div>
-                            <a href="https://www.odoo.com/documentation/master/applications/general/auth/google.html" target="_blank"><i class="oi fa-fw oi-arrow-right"/>Tutorial</a>
+                            <a href="https://www.odoo.com/documentation/master/applications/general/auth/google.html" target="_blank"><i class="oi oi-fw oi-arrow-right"/>Tutorial</a>
                         </div>
                     </setting>
                 </setting>

--- a/addons/auth_signup/views/res_config_settings_views.xml
+++ b/addons/auth_signup/views/res_config_settings_views.xml
@@ -11,7 +11,7 @@
                         <field name="auth_signup_uninvited" class="o_light_label" widget="radio" options="{'horizontal': true}" required="True"/>
                         <div class="content-group" attrs="{'invisible': [('auth_signup_uninvited','=','b2b')]}">
                             <div class="mt8">
-                                <button type="object" name="action_open_template_user" string="Default Access Rights" icon="oi oi-arrow-right" class="btn-link"/>
+                                <button type="object" name="action_open_template_user" string="Default Access Rights" icon="oi-arrow-right" class="btn-link"/>
                             </div>
                         </div>
                     </setting>

--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -25,7 +25,7 @@
                                     </span>
                                     <a href="https://www.odoo.com/documentation/master/applications/general/users.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                     <br/>
-                                    <button name="%(base.action_res_users)d" icon="oi oi-arrow-right" type="action" string="Manage Users" class="btn-link o_web_settings_access_rights"/>
+                                    <button name="%(base.action_res_users)d" icon="oi-arrow-right" type="action" string="Manage Users" class="btn-link o_web_settings_access_rights"/>
                                 </setting>
                             </block>
                         </div>
@@ -44,10 +44,10 @@
                                         </span>
                                     </div>
                                     <div class="mt8">
-                                        <button name="%(base.action_view_base_language_install)d" icon="oi oi-arrow-right" type="action" string="Add Languages" class="btn-link"/>
+                                        <button name="%(base.action_view_base_language_install)d" icon="oi-arrow-right" type="action" string="Add Languages" class="btn-link"/>
                                     </div>
                                     <div class="mt8" groups="base.group_no_one">
-                                        <button name="%(base.res_lang_act_window)d" icon="oi oi-arrow-right" type="action" string="Manage Languages" class="btn-link"/>
+                                        <button name="%(base.res_lang_act_window)d" icon="oi-arrow-right" type="action" string="Manage Languages" class="btn-link"/>
                                     </div>
                                 </setting>
                             </block>
@@ -61,7 +61,7 @@
                                     <br/>
                                     <field name="company_informations" class="text-muted" style="width: 90%;"/>
                                     <br/>
-                                    <button name="open_company" icon="oi oi-arrow-right" type="object" string="Update Info" class="btn-link"/>
+                                    <button name="open_company" icon="oi-arrow-right" type="object" string="Update Info" class="btn-link"/>
                                 </setting>
                                 <setting id="companies_setting">
                                     <field name='company_count' nolabel="1" class="w-auto ps-1 fw-bold"/>
@@ -73,7 +73,7 @@
                                     </span>
                                     <br/>
                                     <div class="mt8">
-                                        <button name="%(base.action_res_company_form)d" icon="oi oi-arrow-right" type="action" string="Manage Companies" class="btn-link"/>
+                                        <button name="%(base.action_res_company_form)d" icon="oi-arrow-right" type="action" string="Manage Companies" class="btn-link"/>
                                     </div>
                                 </setting>
                                 <setting id="document_layout_setting" string="Document Layout" help="Choose the layout of your documents" company_dependent="1">
@@ -82,11 +82,11 @@
                                             <label for="external_report_layout_id" string="Layout" class="col-3 col-lg-3 o_light_label"/>
                                             <field name="external_report_layout_id" domain="[('type','=', 'qweb')]" class="oe_inline"/>
                                         </div>
-                                            <button name="%(web.action_base_document_layout_configurator)d" string="Configure Document Layout" type="action" class="oe_link" icon="oi oi-arrow-right"/>
+                                            <button name="%(web.action_base_document_layout_configurator)d" string="Configure Document Layout" type="action" class="oe_link" icon="oi-arrow-right"/>
                                             <br groups="base.group_no_one"/>
-                                            <button name="edit_external_header" string="Edit Layout" type="object" class="oe_link" groups="base.group_no_one" icon="oi oi-arrow-right"/>
+                                            <button name="edit_external_header" string="Edit Layout" type="object" class="oe_link" groups="base.group_no_one" icon="oi-arrow-right"/>
                                             <br groups="base.group_no_one"/>
-                                            <button name="%(web.action_report_externalpreview)d" string="Preview Document" type="action" class="oe_link" groups="base.group_no_one" icon="oi oi-arrow-right"/>
+                                            <button name="%(web.action_report_externalpreview)d" string="Preview Document" type="action" class="oe_link" groups="base.group_no_one" icon="oi-arrow-right"/>
                                     </div>
                                 </setting>
                                 <field name="company_id" invisible="1"/>
@@ -114,12 +114,12 @@
                             <field name="user_default_rights"/>
                             <div class="content-group" attrs="{'invisible': [('user_default_rights','=',False)]}">
                                 <div class="mt8">
-                                    <button type="object" name="open_default_user" string="Default Access Rights" icon="oi oi-arrow-right" class="btn-link"/>
+                                    <button type="object" name="open_default_user" string="Default Access Rights" icon="oi-arrow-right" class="btn-link"/>
                                 </div>
                             </div>
                         </setting>
                         <setting string="API Keys" help="API Keys allow your users to access Odoo with external tools when multi-factor authentication is enabled." groups="base.group_system">
-                            <button type="action" name="%(base.action_apikeys_admin)d" string="Manage API Keys" icon="oi oi-arrow-right" class="btn-link"/>
+                            <button type="action" name="%(base.action_apikeys_admin)d" string="Manage API Keys" icon="oi-arrow-right" class="btn-link"/>
                         </setting>
                         <setting string="Import &amp; Export" help="Allow users to import data from CSV/XLS/XLSX/ODS files" documentation="/applications/general/export_import_data.html" groups="base.group_no_one" id="allow_import">
                             <field name="module_base_import" />

--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -169,7 +169,7 @@
                             <div class="oe_edit_only" attrs="{'invisible': [('alias_domain', '=', False)]}">
                                 <field name="alias_name" class="oe_inline"/>@<field name="alias_domain" class="oe_inline" readonly="1"/>
                             </div>
-                            <button icon="oi oi-arrow-right" type="action" name="%(base_setup.action_general_configuration)d" string="Configure a custom domain" class="p-0 btn-link" attrs="{'invisible': [('alias_domain', '!=', False)]}"/>
+                            <button icon="oi-arrow-right" type="action" name="%(base_setup.action_general_configuration)d" string="Configure a custom domain" class="p-0 btn-link" attrs="{'invisible': [('alias_domain', '!=', False)]}"/>
                         </div>
                     </div>
                     <field name="alias_contact"

--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -14,7 +14,7 @@
                             <field name="group_use_recurring_revenues"/>
                             <div attrs="{'invisible': [('group_use_recurring_revenues', '=', False)]}">
                                 <button type="action" name="crm.crm_recurring_plan_action"
-                                        string="Manage Recurring Plans" icon="oi oi-arrow-right" class="oe_link"/>
+                                        string="Manage Recurring Plans" icon="oi-arrow-right" class="oe_link"/>
                             </div>
                         </setting>
                         <setting id="crm_lead" title="Use leads if you need a qualification step before creating an opportunity or a customer. It can be a business card you received, a contact form filled in your website, or a file of unqualified prospects you import, etc. Once qualified, the lead can be converted into a business opportunity and/or a new customer in your address book." help="Add a qualification step before the creation of an opportunity">

--- a/addons/delivery/wizard/res_config_settings_views.xml
+++ b/addons/delivery/wizard/res_config_settings_views.xml
@@ -12,7 +12,7 @@
                         <button name="%(delivery.action_delivery_carrier_form)d"
                                 type="action"
                                 class="btn-link"
-                                icon="oi oi-arrow-right"
+                                icon="oi-arrow-right"
                                 string="Shipping Methods"/>
                     </div>
                  </div>

--- a/addons/digest/views/res_config_settings_views.xml
+++ b/addons/digest/views/res_config_settings_views.xml
@@ -16,7 +16,7 @@
                                     <field name="digest_id" class="oe_inline"/>
                                 </div>
                                 <div class="mt8">
-                                    <button type="action" name="%(digest.digest_digest_action)d" string="Configure Digest Emails" icon="oi oi-arrow-right" class="btn-link"/>
+                                    <button type="action" name="%(digest.digest_digest_action)d" string="Configure Digest Emails" icon="oi-arrow-right" class="btn-link"/>
                                 </div>
                             </div>
                         </setting>

--- a/addons/google_gmail/views/fetchmail_server_views.xml
+++ b/addons/google_gmail/views/fetchmail_server_views.xml
@@ -27,7 +27,7 @@
                         <i class="fa fa-cog" title="Edit Settings"/>
                     </button>
                     <button class="alert alert-warning d-block mt-2 text-start"
-                        icon="oi oi-arrow-right" type="action" role="alert"
+                        icon="oi-arrow-right" type="action" role="alert"
                         name="%(base.res_config_setting_act_window)d"
                         attrs="{'invisible': ['|', ('server_type', '!=', 'gmail'), ('google_gmail_uri', '!=', False)]}">
                         Setup your Gmail API credentials in the general settings to link a Gmail account.

--- a/addons/google_gmail/views/ir_mail_server_views.xml
+++ b/addons/google_gmail/views/ir_mail_server_views.xml
@@ -26,7 +26,7 @@
                         <i class="fa fa-cog" title="Edit Settings"/>
                     </button>
                     <button class="alert alert-warning d-block mt-2 text-start"
-                        icon="oi oi-arrow-right" type="action" role="alert"
+                        icon="oi-arrow-right" type="action" role="alert"
                         name="%(base.res_config_setting_act_window)d"
                         attrs="{'invisible': ['|', ('smtp_authentication', '!=', 'gmail'), ('google_gmail_uri', '!=', False)]}">
                         Setup your Gmail API credentials in the general settings to link a Gmail account.

--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -22,7 +22,7 @@
                                 </div>
                                 <div class="content-group" attrs="{'invisible': ['|', ('hr_expense_use_mailgateway', '=',  False), ('alias_domain', 'not in', ['localhost', '', False])]}">
                                     <div class="mt16">
-                                        <button type="action" name="base_setup.action_general_configuration" icon="oi oi-arrow-right" string="Setup your domain alias" class="btn-link"/>
+                                        <button type="action" name="base_setup.action_general_configuration" icon="oi-arrow-right" string="Setup your domain alias" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>

--- a/addons/hr_recruitment_survey/views/res_config_setting_views.xml
+++ b/addons/hr_recruitment_survey/views/res_config_setting_views.xml
@@ -8,7 +8,7 @@
             <setting id="interview_forms_setting" position="inside">
                 <div class="content-group">
                     <div class="mt8">
-                        <button name="%(survey.action_survey_form)d" icon="oi oi-arrow-right" type="action" string="Interview Survey" class="btn-link"/>
+                        <button name="%(survey.action_survey_form)d" icon="oi-arrow-right" type="action" string="Interview Survey" class="btn-link"/>
                     </div>
                 </div>
             </setting>

--- a/addons/iap/views/res_config_settings.xml
+++ b/addons/iap/views/res_config_settings.xml
@@ -20,7 +20,7 @@ if records:
                 <div id="iap_portal">
                     <block class='iap_portal' name="iap_purchases_setting_container">
                         <setting id="iap_credits_setting" string="Odoo IAP" help ="View your IAP Services and recharge your credits" documentation="/applications/general/in_app_purchase.html">
-                            <button name="%(iap.open_iap_account)d" icon="oi oi-arrow-right" type="action" string="View My Services" class="btn-link"/>
+                            <button name="%(iap.open_iap_account)d" icon="oi-arrow-right" type="action" string="View My Services" class="btn-link"/>
                         </setting>
                     </block>
                 </div>

--- a/addons/im_livechat/views/im_livechat_chatbot_templates.xml
+++ b/addons/im_livechat/views/im_livechat_chatbot_templates.xml
@@ -20,7 +20,7 @@
                             <a t-attf-href="/web#view_type=form&amp;model=chatbot.script&amp;id=#{chatbot_data['chatbot_script_id']}&amp;action=im_livechat.chatbot_script_action">
                                 <span>You are currently testing</span>
                                 <span t-out="chatbot_data['chatbot_name']"/>
-                                <i class="oi fa-fw oi-arrow-right"/>Back to edit mode
+                                <i class="oi oi-fw oi-arrow-right"/>Back to edit mode
                             </a>
                         </div>
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>

--- a/addons/l10n_in/report/audit_trail_report_views.xml
+++ b/addons/l10n_in/report/audit_trail_report_views.xml
@@ -12,7 +12,7 @@
                 <field name="author_id" widget="many2one_avatar"/>
                 <field name="l10n_in_audit_log_account_move_id"/>
                 <field name="l10n_in_audit_log_preview"/>
-                <button name="action_open_document" type="object" icon="oi oi-arrow-right" string="View Related Document" attrs="{'invisible': [('res_id', 'in', (0, False, ''))]}" />
+                <button name="action_open_document" type="object" icon="oi-arrow-right" string="View Related Document" attrs="{'invisible': [('res_id', 'in', (0, False, ''))]}" />
             </tree>
         </field>
     </record>

--- a/addons/l10n_in_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_in_edi/views/res_config_settings_views.xml
@@ -25,7 +25,7 @@
                         </div>
                     </div>
                     <div class='mt8'>
-                        <button name="l10n_in_edi_test" icon="oi oi-arrow-right" type="object" string="Verify Username and Password" class="btn-link"/>
+                        <button name="l10n_in_edi_test" icon="oi-arrow-right" type="object" string="Verify Username and Password" class="btn-link"/>
                     </div>
                 </setting>
             </xpath>

--- a/addons/l10n_in_edi_ewaybill/views/res_config_settings_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/res_config_settings_views.xml
@@ -25,7 +25,7 @@
                         </div>
                     </div>
                     <div class='mt8'>
-                        <button name="l10n_in_edi_ewaybill_test" icon="oi oi-arrow-right" type="object" string="Verify Username and Password" class="btn-link"/>
+                        <button name="l10n_in_edi_ewaybill_test" icon="oi-arrow-right" type="object" string="Verify Username and Password" class="btn-link"/>
                     </div>
                 </setting>
             </xpath>

--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -12,7 +12,7 @@
                         <setting id="activities_setting" string="Activities" help="Configure your activity types">
                             <div class="content-group">
                                 <div class="mt8">
-                                    <button name="%(mail.mail_activity_type_action)d" string="Activity Types" type="action" class="oe_link" icon="oi oi-arrow-right"/>
+                                    <button name="%(mail.mail_activity_type_action)d" string="Activity Types" type="action" class="oe_link" icon="oi-arrow-right"/>
                                 </div>
                             </div>
                         </setting>
@@ -23,12 +23,12 @@
                                     <div class="mt8">
                                         <button type="action"
                                         name="%(action_email_server_tree)d"
-                                        string="Incoming Email Servers" icon="oi oi-arrow-right" class="btn-link"/>
+                                        string="Incoming Email Servers" icon="oi-arrow-right" class="btn-link"/>
                                     </div>
                                     <div class="mt8">
                                         <button type="action"
                                         name="%(base.action_ir_mail_server_list)d"
-                                        string="Outgoing Email Servers" icon="oi oi-arrow-right" class="btn-link"/>
+                                        string="Outgoing Email Servers" icon="oi-arrow-right" class="btn-link"/>
                                     </div>
                                 </div>
                             </div>
@@ -70,7 +70,7 @@
                         <setting string="Custom ICE server list" help="Configure your ICE server list for webRTC">
                             <div class="content-group">
                                 <div class="row col-lg-4">
-                                    <button type="action" name="%(mail.action_ice_servers)d" string="ICE Servers" icon="oi oi-arrow-right" class="btn-link"/>
+                                    <button type="action" name="%(mail.action_ice_servers)d" string="ICE Servers" icon="oi-arrow-right" class="btn-link"/>
                                 </div>
                             </div>
                         </setting>
@@ -89,11 +89,11 @@
                             <span class="d-block w-75 py-2">Button Color</span>
                             <field name="secondary_color" class="d-block w-25 p-0 m-0" widget="color"/>
                         </div>
-                        <button name="open_email_layout" icon="oi oi-arrow-right"
+                        <button name="open_email_layout" icon="oi-arrow-right"
                             type="object" string="Update Mail Layout"
                             groups="base.group_no_one" class="btn-link"/>
                         <br groups="base.group_no_one"/>
-                        <button name="open_mail_templates" icon="oi oi-arrow-right" type="object" string="Review All Templates" class="btn-link"/>
+                        <button name="open_mail_templates" icon="oi-arrow-right" type="object" string="Review All Templates" class="btn-link"/>
                     </setting>
                 </setting>
             </field>

--- a/addons/mail_group/views/mail_group_views.xml
+++ b/addons/mail_group/views/mail_group_views.xml
@@ -116,7 +116,7 @@
                                     <div class="oe_edit_only" attrs="{'invisible': [('alias_domain', '=', False)]}">
                                         <field name="alias_name" class="oe_inline"/>@<field name="alias_domain" class="oe_inline" readonly="1"/>
                                     </div>
-                                    <button icon="oi oi-arrow-right" type="action" name="%(base_setup.action_general_configuration)d" string="Configure a custom domain" class="p-0 btn-link" attrs="{'invisible': [('alias_domain', '!=', False)]}"/>
+                                    <button icon="oi-arrow-right" type="action" name="%(base_setup.action_general_configuration)d" string="Configure a custom domain" class="p-0 btn-link" attrs="{'invisible': [('alias_domain', '!=', False)]}"/>
                                 </div>
                             </div>
                             <field name="description"/>

--- a/addons/mass_mailing/views/res_config_settings_views.xml
+++ b/addons/mass_mailing/views/res_config_settings_views.xml
@@ -20,7 +20,7 @@
                                                 placeholder="Default Server"/>
                                     </div>
                                     <div class="mt8">
-                                        <button type="action" name="base.action_ir_mail_server_list" string="Configure Outgoing Mail Servers" icon="oi oi-arrow-right" class="oe_link"/>
+                                        <button type="action" name="base.action_ir_mail_server_list" string="Configure Outgoing Mail Servers" icon="oi-arrow-right" class="oe_link"/>
                                     </div>
                                 </div>
                             </setting>

--- a/addons/microsoft_outlook/views/fetchmail_server_views.xml
+++ b/addons/microsoft_outlook/views/fetchmail_server_views.xml
@@ -29,7 +29,7 @@
                         <i class="fa fa-cog" title="Edit Settings"/>
                     </button>
                     <button class="alert alert-warning d-block mt-2 text-start"
-                        icon="oi oi-arrow-right" type="action" role="alert"
+                        icon="oi-arrow-right" type="action" role="alert"
                         name="%(base.res_config_setting_act_window)d"
                         attrs="{'invisible': ['|', ('is_microsoft_outlook_configured', '=', True), ('server_type', '!=', 'outlook')]}">
                         Setup your Outlook API credentials in the general settings to link a Outlook account.

--- a/addons/microsoft_outlook/views/ir_mail_server_views.xml
+++ b/addons/microsoft_outlook/views/ir_mail_server_views.xml
@@ -28,7 +28,7 @@
                         <i class="fa fa-cog" title="Edit Settings"/>
                     </button>
                     <button class="alert alert-warning d-block mt-2 text-start"
-                        icon="oi oi-arrow-right" type="action" role="alert"
+                        icon="oi-arrow-right" type="action" role="alert"
                         name="%(base.res_config_setting_act_window)d"
                         attrs="{'invisible': ['|', ('is_microsoft_outlook_configured', '=', True), ('smtp_authentication', '!=', 'outlook')]}">
                         Setup your Outlook API credentials in the general settings to link a Outlook account.

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -176,7 +176,7 @@
                                 <span class="o_stat_text">Unbuilds</span>
                             </div>
                         </button>
-                        <button class="oe_stat_button" name="action_see_move_scrap" type="object" icon="oi oi-arrows-v" attrs="{'invisible': [('scrap_count', '=', 0)]}">
+                        <button class="oe_stat_button" name="action_see_move_scrap" type="object" icon="oi-arrows-v" attrs="{'invisible': [('scrap_count', '=', 0)]}">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value"><field name="scrap_count"/></span>
                                 <span class="o_stat_text">Scraps</span>
@@ -185,7 +185,7 @@
                         <button type="object" name="action_view_mo_delivery" class="oe_stat_button" icon="fa-truck"  groups="base.group_user" attrs="{'invisible': [('delivery_count', '=', 0)]}">
                             <field name="delivery_count" widget="statinfo" string="Transfers"/>
                         </button>
-                        <button name="%(stock.action_stock_report)d" icon="oi oi-arrow-up" class="oe_stat_button" string="Traceability" type="action" states="done" groups="stock.group_production_lot">
+                        <button name="%(stock.action_stock_report)d" icon="oi-arrow-up" class="oe_stat_button" string="Traceability" type="action" states="done" groups="stock.group_production_lot">
                             <div class="o_stat_info">
                                 <span class="o_stat_text">Traceability</span>
                             </div>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -141,7 +141,7 @@
             </header>
             <sheet>
                 <div class="oe_button_box" name="button_box">
-                    <button class="oe_stat_button" name="action_see_move_scrap" type="object" icon="oi oi-arrows-v" attrs="{'invisible': [('scrap_count', '=', 0)]}">
+                    <button class="oe_stat_button" name="action_see_move_scrap" type="object" icon="oi-arrows-v" attrs="{'invisible': [('scrap_count', '=', 0)]}">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value"><field name="scrap_count"/></span>
                             <span class="o_stat_text">Scraps</span>

--- a/addons/mrp/views/res_config_settings_views.xml
+++ b/addons/mrp/views/res_config_settings_views.xml
@@ -16,7 +16,7 @@
                                 <div id="workorder_settings_workcenters" class="content-group" attrs="{'invisible': [('group_mrp_routings','=',False)]}">
                                     <div class="mt8">
                                         <div>
-                                            <button name="%(mrp.mrp_workcenter_action)d" icon="oi oi-arrow-right" type="action" string="Work Centers" class="btn-link"/>
+                                            <button name="%(mrp.mrp_workcenter_action)d" icon="oi-arrow-right" type="action" string="Work Centers" class="btn-link"/>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -70,7 +70,7 @@
                                     <field name="pos_iface_available_categ_ids" widget="many2many_tags" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
                                 </div>
                                 <div class="content-group mt16" attrs="{'invisible': [('pos_limit_categories', '=', False)]}">
-                                    <button name="%(product_pos_category_action)d" icon="oi oi-arrow-right" type="action" string="PoS Product Categories" class="btn-link"/>
+                                    <button name="%(product_pos_category_action)d" icon="oi-arrow-right" type="action" string="PoS Product Categories" class="btn-link"/>
                                 </div>
                             </setting>
                             <setting help="Improve navigation for imprecise industrial touchscreens">
@@ -86,7 +86,7 @@
                                         <field name="pos_trusted_config_ids" widget="many2many_tags" options="{'no_create':'true'}" placeholder="Select PoS to start sharing orders"/>
                                     </div>
                                     <div>
-                                        <button name="%(point_of_sale.action_pos_config_tree)d" icon="oi oi-arrow-right" type="action" string="Point of Sales" class="btn-link"/>
+                                        <button name="%(point_of_sale.action_pos_config_tree)d" icon="oi-arrow-right" type="action" string="Point of Sales" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>
@@ -103,7 +103,7 @@
                                     <field name="sale_tax_id" colspan="4" nolabel="1" domain="[('type_tax_use', 'in', ('sale', 'all')), ('company_id', '=', company_id)]"/>
                                 </div>
                                 <div class="mt8">
-                                    <button name="%(account.action_tax_form)d" icon="oi oi-arrow-right" type="action" string="Taxes" class="btn-link"/>
+                                    <button name="%(account.action_tax_form)d" icon="oi-arrow-right" type="action" string="Taxes" class="btn-link"/>
                                 </div>
                             </setting>
                             <setting groups="account.group_account_readonly">
@@ -126,7 +126,7 @@
                                         <field name="pos_fiscal_position_ids" widget="many2many_tags" options="{'no_create': True}" domain="['|',('company_id', '=', company_id),('company_id', '=', False)]"/>
                                     </div>
                                     <div>
-                                        <button name="%(account.action_account_fiscal_position_form)d" icon="oi oi-arrow-right" type="action" string="Fiscal Positions" class="btn-link"/>
+                                        <button name="%(account.action_account_fiscal_position_form)d" icon="oi-arrow-right" type="action" string="Fiscal Positions" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>
@@ -164,7 +164,7 @@
                                         <field name="pos_pricelist_id" domain="[('id', 'in', pos_allowed_pricelist_ids)]" options="{'no_create': True}"/>
                                     </div>
                                     <div class="mt8">
-                                        <button name="%(product.product_pricelist_action2)d" icon="oi oi-arrow-right" type="action" string="Pricelists" groups="product.group_product_pricelist" class="btn-link"/>
+                                        <button name="%(product.product_pricelist_action2)d" icon="oi-arrow-right" type="action" string="Pricelists" groups="product.group_product_pricelist" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>
@@ -176,7 +176,7 @@
                                 <div class="content-group">
                                     <a attrs="{'invisible': [('pos_iface_tax_included', '!=', 'total')]}"
                                         href="https://www.odoo.com/documentation/master/applications/finance/accounting/taxation/taxes/B2B_B2C.html"
-                                        target="_blank" class="oe-link"><i class="oi fa-fw oi-arrow-right"/>How to manage tax-included prices</a>
+                                        target="_blank" class="oe-link"><i class="oi oi-fw oi-arrow-right"/>How to manage tax-included prices</a>
                                 </div>
                             </setting>
                             <setting help="Allow cashiers to set a discount per line">
@@ -232,7 +232,7 @@
                             <setting id="payment_methods_new" string="Payment Methods" help="Payment methods available">
                                 <field name="pos_payment_method_ids" colspan="4" widget="many2many_tags" attrs="{'readonly': [('pos_has_active_session','=', True)], 'required': [('pos_company_has_template', '=', True)]}" options="{'no_create': True}" />
                                 <div>
-                                    <button name="%(action_payment_methods_tree)d" icon="oi oi-arrow-right" type="action" string="Payment Methods" class="btn-link"/>
+                                    <button name="%(action_payment_methods_tree)d" icon="oi-arrow-right" type="action" string="Payment Methods" class="btn-link"/>
                                 </div>
                             </setting>
                             <setting string="Automatically validate order" help="Automatically validates orders paid with a payment terminal.">
@@ -251,7 +251,7 @@
                                     </div>
                                 </div>
                                 <div class="mt8">
-                                    <button name="%(account.rounding_list_action)d" icon="oi oi-arrow-right"
+                                    <button name="%(account.rounding_list_action)d" icon="oi-arrow-right"
                                             type="action" string="Cash Roundings" class="btn-link"
                                             attrs="{'invisible': [('group_cash_rounding', '=', False)]}"/>
                                 </div>
@@ -341,7 +341,7 @@
                                         <field name="pos_printer_ids" widget="many2many_tags"/>
                                     </div>
                                     <div>
-                                        <button name="%(point_of_sale.action_pos_printer_form)d" icon="oi oi-arrow-right" type="action" string="Printers" class="btn-link"/>
+                                        <button name="%(point_of_sale.action_pos_printer_form)d" icon="oi-arrow-right" type="action" string="Printers" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>

--- a/addons/pos_loyalty/views/res_config_settings_view.xml
+++ b/addons/pos_loyalty/views/res_config_settings_view.xml
@@ -11,10 +11,10 @@
                         <field name="pos_gift_card_settings" colspan="4" nolabel="1" widget="radio"/>
                     </div>
                     <div class="mt8">
-                        <button name="%(loyalty.loyalty_program_discount_loyalty_action)d" icon="oi oi-arrow-right" type="action" string="Discount &amp; Loyalty" class="btn-link"/>
+                        <button name="%(loyalty.loyalty_program_discount_loyalty_action)d" icon="oi-arrow-right" type="action" string="Discount &amp; Loyalty" class="btn-link"/>
                     </div>
                     <div class="mt8">
-                        <button name="%(loyalty.loyalty_program_gift_ewallet_action)d" icon="oi oi-arrow-right" type="action" string="Gift cards &amp; eWallet" class="btn-link"/>
+                        <button name="%(loyalty.loyalty_program_gift_ewallet_action)d" icon="oi-arrow-right" type="action" string="Gift cards &amp; eWallet" class="btn-link"/>
                     </div>
                 </div>
             </xpath>

--- a/addons/pos_mercury/views/pos_config_setting_views.xml
+++ b/addons/pos_mercury/views/pos_config_setting_views.xml
@@ -7,10 +7,10 @@
         <field name="arch" type="xml">
             <div id="btn_use_pos_mercury" position="replace">
                 <div class="mt16">
-                    <button name="%(pos_mercury.action_configuration_form)d" icon="oi oi-arrow-right" type="action" string="Vantiv Accounts" class="btn-link"/>
+                    <button name="%(pos_mercury.action_configuration_form)d" icon="oi-arrow-right" type="action" string="Vantiv Accounts" class="btn-link"/>
                 </div>
                 <div>
-                    <a href="https://www.odoo.com/app/point-of-sale-hardware#part_8" target="_blank"><i class="oi fa-fw oi-arrow-right"/>Buy a card reader</a>
+                    <a href="https://www.odoo.com/app/point-of-sale-hardware#part_8" target="_blank"><i class="oi oi-fw oi-arrow-right"/>Buy a card reader</a>
                 </div>
             </div>
         </field>

--- a/addons/pos_restaurant/views/res_config_settings_views.xml
+++ b/addons/pos_restaurant/views/res_config_settings_views.xml
@@ -16,7 +16,7 @@
                                 <field name="pos_floor_ids" widget="many2many_tags" attrs="{'readonly': [('pos_has_active_session','=', True)]}" />
                             </div>
                             <div>
-                                <button name="%(pos_restaurant.action_restaurant_floor_form)d" icon="oi oi-arrow-right" type="action" string="Floors" class="btn-link"/>
+                                <button name="%(pos_restaurant.action_restaurant_floor_form)d" icon="oi-arrow-right" type="action" string="Floors" class="btn-link"/>
                             </div>
                         </div>
                     </setting>

--- a/addons/pos_self_order/static/src/NavBar/NavBar.xml
+++ b/addons/pos_self_order/static/src/NavBar/NavBar.xml
@@ -5,7 +5,7 @@
             <t t-if="props.previousPage">
                 <button class="btn btn-link text-dark"
                         t-on-click="() => env.navigate(props.previousPage)">
-                    <i class="oi fa-fw oi-chevron-left">
+                    <i class="oi oi-fw oi-chevron-left">
                 </button>
             </t>
             <div class="mx-auto overflow-hidden">

--- a/addons/pos_stripe/views/pos_payment_method_views.xml
+++ b/addons/pos_stripe/views/pos_payment_method_views.xml
@@ -9,7 +9,7 @@
                 <!-- Stripe -->
                 <field name="stripe_serial_number" attrs="{'invisible': [('use_payment_terminal', '!=', 'stripe')], 'required': [('use_payment_terminal', '=', 'stripe')]}"/>
                 <div colspan="2" class="mt16" attrs="{'invisible': [('use_payment_terminal', '!=', 'stripe')], 'required': [('use_payment_terminal', '=', 'stripe')]}">
-                    <button name="action_stripe_key" type="object" icon="oi oi-arrow-right" string="Don't forget to complete Stripe connect before using this payment method." class="btn-link"/>
+                    <button name="action_stripe_key" type="object" icon="oi-arrow-right" string="Don't forget to complete Stripe connect before using this payment method." class="btn-link"/>
                 </div>
             </xpath>
         </field>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -134,7 +134,7 @@
                                                 </div>
                                                 <div class="content-group">
                                                     <div class="mt8">
-                                                        <button name="%(project.open_task_type_form_domain)d" context="{'project_id':id}" icon="oi oi-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link"/>
+                                                        <button name="%(project.open_task_type_form_domain)d" context="{'project_id':id}" icon="oi-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link"/>
                                                     </div>
                                                 </div>
                                             </div>

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -19,7 +19,7 @@
                                 <field name="group_project_stages"/>
                                 <div class="content-group" attrs="{'invisible': [('group_project_stages', '=', False)]}">
                                     <div class="mt8">
-                                        <button name="%(project.project_project_stage_configure)d" icon="oi oi-arrow-right" type="action" string="Configure Stages" class="btn-link"/>
+                                        <button name="%(project.project_project_stage_configure)d" icon="oi-arrow-right" type="action" string="Configure Stages" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>
@@ -40,7 +40,7 @@
                                 <field name="group_project_rating"/>
                                 <div class="content-group" attrs="{'invisible': [('group_project_rating', '=', False)]}">
                                     <div class="mt16">
-                                        <button name="%(project.open_task_type_form)d" context="{'project_id':id}" icon="oi oi-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link"/>
+                                        <button name="%(project.open_task_type_form)d" context="{'project_id':id}" icon="oi-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>

--- a/addons/purchase/views/res_config_settings_views.xml
+++ b/addons/purchase/views/res_config_settings_views.xml
@@ -51,7 +51,7 @@
                             <field name="group_product_variant"/>
                             <div class="content-group" attrs="{'invisible': [('group_product_variant','=',False)]}">
                                 <div class="mt8">
-                                    <button name="%(product.attribute_action)d" icon="oi oi-arrow-right" type="action" string="Attributes" class="btn-link"/>
+                                    <button name="%(product.attribute_action)d" icon="oi-arrow-right" type="action" string="Attributes" class="btn-link"/>
                                 </div>
                             </div>
                         </setting>
@@ -66,7 +66,7 @@
                             <field name="group_uom"/>
                             <div class="content-group">
                                 <div class="mt8" attrs="{'invisible': [('group_uom', '=', False)]}">
-                                    <button name="%(uom.product_uom_categ_form_action)d" icon="oi oi-arrow-right"
+                                    <button name="%(uom.product_uom_categ_form_action)d" icon="oi-arrow-right"
                                             type="action" string="Units Of Measure" class="btn-link"/>
                                 </div>
                             </div>

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -14,7 +14,7 @@
                             <field name="group_product_variant"/>
                             <div class="content-group" attrs="{'invisible': [('group_product_variant','=',False)]}">
                                 <div class="mt8">
-                                    <button name="%(product.attribute_action)d" icon="oi oi-arrow-right" type="action" string="Attributes" class="btn-link"/>
+                                    <button name="%(product.attribute_action)d" icon="oi-arrow-right" type="action" string="Attributes" class="btn-link"/>
                                 </div>
                             </div>
                         </setting>
@@ -25,7 +25,7 @@
                             <field name="group_uom"/>
                             <div class="content-group" attrs="{'invisible': [('group_uom','=',False)]}">
                                 <div class="mt8">
-                                    <button name="%(uom.product_uom_categ_form_action)d" icon="oi oi-arrow-right" type="action" string="Units of Measure" class="btn-link"/>
+                                    <button name="%(uom.product_uom_categ_form_action)d" icon="oi-arrow-right" type="action" string="Units of Measure" class="btn-link"/>
                                 </div>
                             </div>
                         </setting>
@@ -51,7 +51,7 @@
                                     <field name="product_pricelist_setting" widget="radio" class="o_light_label"/>
                                 </div>
                                 <div class="mt8">
-                                    <button name="%(product.product_pricelist_action2)d" icon="oi oi-arrow-right" type="action" string="Pricelists" groups="product.group_product_pricelist" class="btn-link"/>
+                                    <button name="%(product.product_pricelist_action2)d" icon="oi-arrow-right" type="action" string="Pricelists" groups="product.group_product_pricelist" class="btn-link"/>
                                 </div>
                             </div>
                         </setting>
@@ -91,7 +91,7 @@
                                     Request an online payment to confirm orders
                                 </div>
                                 <div class="mt8" attrs="{'invisible': [('portal_confirmation_pay', '=', False)]}">
-                                    <button name='%(payment.action_payment_provider)d' icon="oi oi-arrow-right" type="action" string="Payment Providers" class="btn-link"/>
+                                    <button name='%(payment.action_payment_provider)d' icon="oi-arrow-right" type="action" string="Payment Providers" class="btn-link"/>
                                 </div>
                                 <div class="mt16" title="Days between quotation proposal and expiration. 0 days means automatic expiration is disabled">
                                     <label for="quotation_validity_days"/>

--- a/addons/sale_management/views/res_config_settings_views.xml
+++ b/addons/sale_management/views/res_config_settings_views.xml
@@ -18,7 +18,7 @@
                                groups="base.group_multi_company"/>
                         </div>
                         <div class="mt8">
-                            <button name="%(sale_management.sale_order_template_action)d" icon="oi oi-arrow-right" type="action" string="Quotation Templates" class="btn-link"/>
+                            <button name="%(sale_management.sale_order_template_action)d" icon="oi-arrow-right" type="action" string="Quotation Templates" class="btn-link"/>
                         </div>
                     </div>
                     <div class="mt16 oe_inline"

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.xml
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.xml
@@ -63,7 +63,7 @@
         </table>
         <button t-if="!props.record.data.is_mto" class="text-start btn btn-link"
             type="button" t-on-click="openForecast">
-            <i class="oi fa-fw o_button_icon oi-arrow-right"></i>
+            <i class="oi oi-fw o_button_icon oi-arrow-right"></i>
             View Forecast
         </button>
         </div>

--- a/addons/sale_stock/views/res_config_settings_views.xml
+++ b/addons/sale_stock/views/res_config_settings_views.xml
@@ -11,7 +11,7 @@
                     <field name="group_display_incoterm"/>
                     <div class="content-group" attrs="{'invisible': [('group_display_incoterm','=',False)]}">
                         <div class="mt8">
-                            <button name="%(account.action_incoterms_tree)d" icon="oi oi-arrow-right" type="action" string="Incoterms" class="btn-link"/>
+                            <button name="%(account.action_incoterms_tree)d" icon="oi-arrow-right" type="action" string="Incoterms" class="btn-link"/>
                         </div>
                     </div>
                 </setting>

--- a/addons/sale_timesheet/views/res_config_settings_views.xml
+++ b/addons/sale_timesheet/views/res_config_settings_views.xml
@@ -10,7 +10,7 @@
             <xpath expr="//div[@name='section_leaves']" position="before">
                 <block title="Billing">
                     <setting string="Time Billing" help="Sell services and invoice time spent" id="time_billing_setting">
-                        <button name="%(sale_timesheet.product_template_action_default_services)d" string="Configure your services" type="action" class="btn-link" icon="oi oi-arrow-right"/>
+                        <button name="%(sale_timesheet.product_template_action_default_services)d" string="Configure your services" type="action" class="btn-link" icon="oi-arrow-right"/>
                     </setting>
                     <setting help="Timesheets taken into account when invoicing your time" name="invoice_policy">
                         <field name="invoice_policy" widget="upgrade_boolean"/>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -115,7 +115,7 @@
                         <label for="route_ids" attrs="{'invisible': [('type', '=', 'service')]}"/>
                         <div>
                             <field name="route_ids" class="mb-0" widget="many2many_checkboxes" attrs="{'invisible': ['|', ('has_available_route_ids', '=', False), ('type', '=', 'service')]}"/>
-                            <button id="stock.view_diagram_button" string="View Diagram" type="action" name="%(action_open_routes)d" icon="oi oi-arrow-right"
+                            <button id="stock.view_diagram_button" string="View Diagram" type="action" name="%(action_open_routes)d" icon="oi-arrow-right"
                                  attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}"
                                  class="btn btn-link pt-0" context="{'default_product_tmpl_id': id}"/>
                         </div>

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -98,7 +98,7 @@
                                 <field name="group_product_variant"/>
                                 <div class="content-group">
                                     <div class="mt8" attrs="{'invisible': [('group_product_variant', '=', False)]}">
-                                        <button name="%(product.attribute_action)d" icon="oi oi-arrow-right" type="action" string="Attributes" class="btn-link"/>
+                                        <button name="%(product.attribute_action)d" icon="oi-arrow-right" type="action" string="Attributes" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>
@@ -106,7 +106,7 @@
                                 <field name="group_uom"/>
                                 <div class="content-group">
                                     <div class="mt8" attrs="{'invisible': [('group_uom', '=', False)]}">
-                                        <button name="%(uom.product_uom_categ_form_action)d" icon="oi oi-arrow-right" type="action" string="Units Of Measure" class="btn-link"/>
+                                        <button name="%(uom.product_uom_categ_form_action)d" icon="oi-arrow-right" type="action" string="Units Of Measure" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>
@@ -114,7 +114,7 @@
                                 <field name="group_stock_packaging"/>
                                 <div class="content-group">
                                     <div class="mt8" attrs="{'invisible': [('group_stock_packaging', '=', False)]}">
-                                        <button name="%(product.action_packaging_view)d" icon="oi oi-arrow-right" type="action" string="Product Packagings" class="btn-link"/>
+                                        <button name="%(product.action_packaging_view)d" icon="oi-arrow-right" type="action" string="Product Packagings" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>
@@ -146,8 +146,8 @@
                                 <field name="group_stock_multi_locations"/>
                                 <div class="content-group">
                                     <div class="mt8" attrs="{'invisible': [('group_stock_multi_locations', '=', False)]}">
-                                        <button name="%(stock.action_location_form)d" icon="oi oi-arrow-right" type="action" string="Locations" class="btn-link"/><br/>
-                                        <button name="stock.action_putaway_tree" icon="oi oi-arrow-right" type="action" string="Putaway Rules" class="btn-link"/>
+                                        <button name="%(stock.action_location_form)d" icon="oi-arrow-right" type="action" string="Locations" class="btn-link"/><br/>
+                                        <button name="stock.action_putaway_tree" icon="oi-arrow-right" type="action" string="Putaway Rules" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>
@@ -155,7 +155,7 @@
                                 <field name="group_stock_adv_location"/>
                                 <div class="content-group">
                                     <div class="mt8" attrs="{'invisible': [('group_stock_adv_location', '=', False)]}">
-                                        <button name="%(stock.action_warehouse_form)d" icon="oi oi-arrow-right" type="action" string="Set Warehouse Routes" class="btn-link"/>
+                                        <button name="%(stock.action_warehouse_form)d" icon="oi-arrow-right" type="action" string="Set Warehouse Routes" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>
@@ -163,10 +163,10 @@
                                 <field name="group_stock_storage_categories"/>
                                 <div class="content-group" attrs="{'invisible': [('group_stock_storage_categories', '=', False)]}">
                                     <div class="mt8">
-                                        <button name="%(stock.action_storage_category)d" icon="oi oi-arrow-right" type="action" string="Storage Categories" class="btn-link"/>
+                                        <button name="%(stock.action_storage_category)d" icon="oi-arrow-right" type="action" string="Storage Categories" class="btn-link"/>
                                     </div>
                                     <div class="mt4" groups="base.group_no_one">
-                                        <button name="%(stock.action_storage_category_capacity)d" icon="oi oi-arrow-right" type="action" string="Storage Category Capacity" class="btn-link"/>
+                                        <button name="%(stock.action_storage_category_capacity)d" icon="oi-arrow-right" type="action" string="Storage Category Capacity" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>

--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -26,7 +26,7 @@
                                 <span class="o_stat_text">Location</span>
                             </div>
                         </button>
-                        <button name="%(action_stock_report)d" icon="oi oi-arrow-up" class="oe_stat_button" type="action">
+                        <button name="%(action_stock_report)d" icon="oi-arrow-up" class="oe_stat_button" type="action">
                             <div class="o_stat_info">
                                 <span class="o_stat_text">Traceability</span>
                             </div>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -155,12 +155,12 @@
                         <field name="has_scrap_move" invisible="True"/>
                         <field name="has_tracking" invisible="True"/>
                         <button name="action_see_move_scrap" string="Scraps" type="object"
-                            class="oe_stat_button" icon="oi oi-arrows-v"
+                            class="oe_stat_button" icon="oi-arrows-v"
                             attrs="{'invisible': [('has_scrap_move', '=', False)]}"/>
                         <button name="action_see_packages" string="Packages" type="object"
                             class="oe_stat_button" icon="fa-cubes"
                             attrs="{'invisible': [('has_packages', '=', False)]}"/>
-                        <button name="%(action_stock_report)d" icon="oi oi-arrow-up" class="oe_stat_button" type="action" attrs="{'invisible': ['|', ('state', '!=', 'done'), ('has_tracking', '=', False)]}" groups="stock.group_production_lot">
+                        <button name="%(action_stock_report)d" icon="oi-arrow-up" class="oe_stat_button" type="action" attrs="{'invisible': ['|', ('state', '!=', 'done'), ('has_tracking', '=', False)]}" groups="stock.group_production_lot">
                             <div class="o_stat_info">
                                 <span class="o_stat_text">Traceability</span>
                             </div>
@@ -177,7 +177,7 @@
                         <!-- Use the following button to avoid onchange on one2many -->
                         <button name="action_picking_move_tree"
                             class="oe_stat_button"
-                            icon="oi oi-arrows-v"
+                            icon="oi-arrows-v"
                             type="object"
                             help="List view of operations"
                             groups="base.group_no_one"

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -259,7 +259,7 @@
                     <div class="oe_button_box" name="button_box">
                         <button class="oe_stat_button" name="action_view_picking"
                         string="Package Transfers" type="object"
-                        widget="statinfo" icon="oi oi-arrows-v"/>
+                        widget="statinfo" icon="oi-arrows-v"/>
                     </div>
                     <div class="oe_title">
                         <label for="name" string="Package Reference"/>

--- a/addons/stock/views/stock_storage_category_views.xml
+++ b/addons/stock/views/stock_storage_category_views.xml
@@ -8,7 +8,7 @@
                 <field name="company_id" invisible="1"/>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button name="%(action_storage_category_locations)d" string="Locations" type="action" class="oe_stat_button" icon="oi oi-arrows-v"/>
+                        <button name="%(action_storage_category_locations)d" string="Locations" type="action" class="oe_stat_button" icon="oi-arrows-v"/>
                     </div>
                     <group>
                         <group>

--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -52,7 +52,7 @@
                 </header>
                 <field name="create_date" string="Date" />
                 <field name="reference"/>
-                <button name="action_open_layer" icon="oi oi-arrow-right" title="Open Valuation Layer" type="object"/>
+                <button name="action_open_layer" icon="oi-arrow-right" title="Open Valuation Layer" type="object"/>
                 <field name="product_id" />
                 <field name="company_id" groups="base.group_multi_company"/>
                 <field name="quantity" string="Moved Quantity"/>

--- a/addons/survey/views/survey_templates_management.xml
+++ b/addons/survey/views/survey_templates_management.xml
@@ -80,7 +80,7 @@
     <template id="survey_button_form_view" name="Survey: back to form view">
         <div groups="survey.group_survey_manager" t-ignore="true" class="alert alert-info alert-dismissible rounded-0 fade show d-print-none css_editable_mode_hidden mb-0">
             <div t-ignore="true" class="text-center">
-                <a t-attf-href="/web#view_type=form&amp;model=survey.survey&amp;id=#{survey.id}&amp;action=survey.action_survey_form"><span t-if="answer and answer.test_entry">This is a Test Survey. </span><i class="oi fa-fw oi-arrow-right"/>Edit Survey</a>
+                <a t-attf-href="/web#view_type=form&amp;model=survey.survey&amp;id=#{survey.id}&amp;action=survey.action_survey_form"><span t-if="answer and answer.test_entry">This is a Test Survey. </span><i class="oi oi-fw oi-arrow-right"/>Edit Survey</a>
             </div>
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -83,7 +83,7 @@
             <t t-if="env.isSmall">
                 <t t-set="previousBreadcrumb" t-value="visiblePathBreadcrumbs.slice(-1)"/>
                 <button class="o_back_button btn btn-link px-1" t-on-click.prevent="() => this.onBreadcrumbClicked(previousBreadcrumb.jsId)">
-                    <i class="oi fa-fw oi-arrow-left"/>
+                    <i class="oi oi-fw oi-arrow-left"/>
                 </button>
             </t>
             <t t-else="">

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -95,7 +95,7 @@
                 <t t-else="">
                     <b class="me-1" t-esc="nbSelected"/> selected
                     <a t-if="isPageSelected and nbTotal > nbSelected" href="#" class="o_list_select_domain ms-3 btn btn-sm btn-info p-1 me-n2 border-0 fw-normal" t-on-click="onSelectDomain">
-                        <i class="oi fa-fw oi-arrow-right"/> Select all <span t-esc="nbTotal"/>
+                        <i class="oi oi-fw oi-arrow-right"/> Select all <span t-esc="nbTotal"/>
                     </a>
                 </t>
                 <a href="#" title="Unselect All" class="o_list_unselect_all btn btn-link py-0 ms-2" t-on-click="onUnselectAll">

--- a/addons/web/static/src/views/view_button/view_button.js
+++ b/addons/web/static/src/views/view_button/view_button.js
@@ -26,6 +26,9 @@ function iconFromString(iconString) {
     if (iconString.startsWith("fa-")) {
         icon.tag = "i";
         icon.class = `o_button_icon fa ${iconString}`;
+    } else if (iconString.startsWith("oi-")) {
+        icon.tag = "i";
+        icon.class = `o_button_icon oi ${iconString}`;
     } else {
         icon.tag = "img";
         icon.src = iconString;

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -7638,7 +7638,7 @@ QUnit.module("Views", (hooks) => {
                 <form>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
-                            <button string="Inventory Moves" class="oe_stat_button" icon="oi oi-arrows-v"/>
+                            <button string="Inventory Moves" class="oe_stat_button" icon="oi-arrows-v"/>
                         </div>
                     </sheet>
                 </form>`,
@@ -12912,7 +12912,7 @@ QUnit.module("Views", (hooks) => {
                 <form>
                     <setting help="this is bar" documentation="/applications/technical/web/settings/this_is_a_test.html">
                         <field name="bar"/>
-                        <button name="buttonName" icon="oi oi-arrow-right" type="action" string="Manage Users" class="btn-link"/>
+                        <button name="buttonName" icon="oi-arrow-right" type="action" string="Manage Users" class="btn-link"/>
                     </setting>
                 </form>`,
         });

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
@@ -80,7 +80,7 @@ QUnit.module("SettingsFormView", (hooks) => {
                         <block title="Title of group Bar">
                             <setting help="this is bar" documentation="/applications/technical/web/settings/this_is_a_test.html">
                                 <field name="bar"/>
-                                <button name="buttonName" icon="oi oi-arrow-right" type="action" string="Manage Users" class="btn-link"/>
+                                <button name="buttonName" icon="oi-arrow-right" type="action" string="Manage Users" class="btn-link"/>
                             </setting>
                             <setting>
                                 <label string="Big BAZ" for="baz"/>

--- a/addons/web/views/base_document_layout_views.xml
+++ b/addons/web/views/base_document_layout_views.xml
@@ -34,7 +34,7 @@
                         </group>
                         <div>
                             <field name="preview" widget="iframe_wrapper" />
-                            <button name="web.action_report_layout_preview" string="Download PDF Preview" type="action" class="oe_link" icon="oi oi-arrow-right"/>
+                            <button name="web.action_report_layout_preview" string="Download PDF Preview" type="action" class="oe_link" icon="oi-arrow-right"/>
                         </div>
                     </group>
                     <footer>

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -357,8 +357,8 @@
                     <button type="button" title="Rotate Right" data-action="rotate" data-value="90"><i class="fa fa-fw fa-rotate-right"/></button>
                 </div>
                 <div class="btn-group" role="group">
-                    <button type="button" title="Flip Horizontal" data-action="flip" data-scale-direction="scaleX"><i class="oi fa-fw oi-arrows-h"/></button>
-                    <button type="button" title="Flip Vertical" data-action="flip" data-scale-direction="scaleY"><i class="oi fa-fw oi-arrows-v"/></button>
+                    <button type="button" title="Flip Horizontal" data-action="flip" data-scale-direction="scaleX"><i class="oi oi-fw oi-arrows-h"/></button>
+                    <button type="button" title="Flip Vertical" data-action="flip" data-scale-direction="scaleY"><i class="oi oi-fw oi-arrows-v"/></button>
                 </div>
                 <div class="btn-group" role="group">
                     <button type="button" title="Reset Image" data-action="reset"><i class="fa fa-refresh"/> Reset Image</button>

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -366,8 +366,8 @@
                 <we-button data-shape="" data-name="shape_none_opt" data-dependencies="!shape_none_opt" data-no-preview="true" class="fa fa-fw fa-times"/>
             </we-row>
             <we-row string="Flip" class="o_we_sublevel_2">
-                <we-button class="oi fa-fw oi-arrows-h" data-flip-x="true" data-no-preview="true" data-dependencies="!shape_none_opt"/>
-                <we-button class="oi fa-fw oi-arrows-v" data-flip-y="true" data-no-preview="true" data-dependencies="!shape_none_opt"/>
+                <we-button class="oi oi-fw oi-arrows-h" data-flip-x="true" data-no-preview="true" data-dependencies="!shape_none_opt"/>
+                <we-button class="oi oi-fw oi-arrows-v" data-flip-y="true" data-no-preview="true" data-dependencies="!shape_none_opt"/>
             </we-row>
             <we-row string="Colors" class="o_we_sublevel_2" data-name="colors">
                 <we-colorpicker data-select-style="" data-css-property="background-color" data-color-prefix="bg-" data-apply-to="> .o_we_shape"/>

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -45,7 +45,7 @@
                                     <field name="website_default_lang_id" options="{'no_open': True, 'no_create': True}" attrs="{'required': [('website_id', '!=', False)]}"/>
                                 </div>
                                 <div class="mt8">
-                                    <button type="action" name="%(base.action_view_base_language_install)d" string="Install languages" class="btn-link" icon="oi oi-arrow-right"/>
+                                    <button type="action" name="%(base.action_view_base_language_install)d" string="Install languages" class="btn-link" icon="oi-arrow-right"/>
                                 </div>
                             </div>
                         </setting>
@@ -88,7 +88,7 @@
                             <field name="auth_signup_uninvited" class="o_light_label" widget="radio" options="{'horizontal': true}" required="True"/>
                             <div class="content-group" attrs="{'invisible': [('auth_signup_uninvited','=','b2b')]}">
                                 <div class="mt8">
-                                    <button type="object" name="action_open_template_user" string="Default Access Rights" icon="oi oi-arrow-right" class="btn-link"/>
+                                    <button type="object" name="action_open_template_user" string="Default Access Rights" icon="oi-arrow-right" class="btn-link"/>
                                 </div>
                             </div>
                         </setting>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -154,7 +154,7 @@
             <div class="alert alert-info mx-3 mt-3 o_wesponsor_exhibitor_main_empty_website_descr_warning">
                 The sponsor website description is missing.
                 <a t-attf-href="?{{ keep_query('*', enable_editor=1) }}">
-                    <i class="oi fa-fw oi-arrow-right"></i>
+                    <i class="oi oi-fw oi-arrow-right"></i>
                     Write one.
                 </a>
             </div>

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -152,7 +152,7 @@
                 <div class="alert alert-info mx-3 mt-3 o_wesession_track_main_empty_descr_warning">
                     This track does not have a description.
                     <a t-attf-href="?{{ keep_query('*', enable_editor=1) }}">
-                        <i class="oi fa-fw oi-arrow-right"></i>
+                        <i class="oi oi-fw oi-arrow-right"></i>
                         Write one.
                     </a>
                 </div>

--- a/addons/website_payment/views/res_config_settings_views.xml
+++ b/addons/website_payment/views/res_config_settings_views.xml
@@ -19,11 +19,11 @@
                                     <button string="Activate Stripe" class="btn-primary pe-none" disabled=""
                                             style="pointer-events: none;"/>
                                 </div>
-                                <button type="action" name="%(payment.action_payment_provider)d" string="View Alternatives" class="btn-link" icon="oi oi-arrow-right"/>
+                                <button type="action" name="%(payment.action_payment_provider)d" string="View Alternatives" class="btn-link" icon="oi-arrow-right"/>
                             </div>
                             <div class="row mt8 ms-4" attrs="{'invisible': [('providers_state', '!=', 'other_than_paypal')]}">
                                 <button name="action_configure_first_provider" type="object" class="btn-primary col-auto"><field name="first_provider_label" nolabel="1" class="oe_inline"/></button>
-                                <button type="action" name="%(payment.action_payment_provider)d" string="View other providers " class="btn-link col-auto" icon="oi oi-arrow-right"/>
+                                <button type="action" name="%(payment.action_payment_provider)d" string="View other providers " class="btn-link col-auto" icon="oi-arrow-right"/>
                             </div>
                         </div>
                     </setting>

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -10,7 +10,7 @@
                 <div class="mt8" attrs="{'invisible': [('terms_type', '!=', 'html')]}" groups="website.group_website_designer">
                     <strong class="align-top">URL: </strong><field name="terms_url"/>
                     <div>
-                        <button name='action_update_terms' icon="oi oi-arrow-right" type="object" string="Edit in Website Builder" class="btn-link"/>
+                        <button name='action_update_terms' icon="oi-arrow-right" type="object" string="Edit in Website Builder" class="btn-link"/>
                     </div>
                 </div>
             </button>
@@ -49,7 +49,7 @@
                     <setting help="Add a customizable form during checkout (after address)">
                         <field name="enabled_extra_checkout_step"/>
                         <div class="row mt8 ms-4" attrs="{'invisible': [('enabled_extra_checkout_step', '=', False)]}">
-                            <button type="object" name="action_open_extra_info" string="Configure Form " class="btn-link" icon="oi oi-arrow-right"/>
+                            <button type="object" name="action_open_extra_info" string="Configure Form " class="btn-link" icon="oi-arrow-right"/>
                         </div>
                     </setting>
                     <setting id="digital_content_setting" title="Provide customers with product-specific links or downloadable content in the confirmation page of the checkout process if the payment gets through. To do so, attach some files to a product using the new Files button and publish them." help="Add download link for customers at the end of checkout">
@@ -88,7 +88,7 @@
                             <field name="product_pricelist_setting" class="o_light_label w-75" widget="radio"/>
                         </div>
                         <div attrs="{'invisible': [('group_product_pricelist', '=', False)]}">
-                            <button type="action" name="%(product.product_pricelist_action2)d" string="Pricelists" class="btn-link" icon="oi oi-arrow-right"/>
+                            <button type="action" name="%(product.product_pricelist_action2)d" string="Pricelists" class="btn-link" icon="oi-arrow-right"/>
                         </div>
                     </setting>
                     <setting help="Add a strikethrough price, as a comparison">
@@ -101,7 +101,7 @@
                         <field name="group_product_variant"/>
                         <div class="content-group" attrs="{'invisible': [('group_product_variant', '=', False)]}">
                             <div class="mt8">
-                                <button type="action" name="%(product.attribute_action)d" string="Attributes" class="btn-link" icon="oi oi-arrow-right"/>
+                                <button type="action" name="%(product.attribute_action)d" string="Attributes" class="btn-link" icon="oi-arrow-right"/>
                             </div>
                         </div>
                     </setting>
@@ -133,7 +133,7 @@
                              documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
                         <div class="content-group">
                             <div class="mt16">
-                                <button type="action" name="%(delivery.action_delivery_carrier_form)d" string="Shipping Methods" class="btn-link" icon="oi oi-arrow-right"/>
+                                <button type="action" name="%(delivery.action_delivery_carrier_form)d" string="Shipping Methods" class="btn-link" icon="oi-arrow-right"/>
                             </div>
                         </div>
                     </setting>
@@ -146,7 +146,7 @@
                         <field name="module_delivery_dhl" widget="upgrade_boolean"/>
                         <div class="content-group">
                             <div class="mt8" attrs="{'invisible': [('module_delivery_dhl', '=', False)]}">
-                                <button name="%(delivery.action_delivery_carrier_form)d" icon="oi oi-arrow-right" type="action" string="DHL Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'dhl'}"/>
+                                <button name="%(delivery.action_delivery_carrier_form)d" icon="oi-arrow-right" type="action" string="DHL Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'dhl'}"/>
                             </div>
                         </div>
                     </setting>
@@ -155,7 +155,7 @@
                         <field name="module_delivery_fedex" widget="upgrade_boolean"/>
                         <div class="content-group">
                             <div class="mt8" attrs="{'invisible': [('module_delivery_fedex', '=', False)]}">
-                                <button name="%(delivery.action_delivery_carrier_form)d" icon="oi oi-arrow-right" type="action" string="FedEx Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'fedex'}"/>
+                                <button name="%(delivery.action_delivery_carrier_form)d" icon="oi-arrow-right" type="action" string="FedEx Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'fedex'}"/>
                             </div>
                         </div>
                     </setting>
@@ -164,7 +164,7 @@
                         <field name="module_delivery_usps" widget="upgrade_boolean"/>
                         <div class="content-group">
                             <div class="mt8" attrs="{'invisible': [('module_delivery_usps', '=', False)]}">
-                                <button name="%(delivery.action_delivery_carrier_form)d" icon="oi oi-arrow-right" type="action" string="USPS Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'usps'}"/>
+                                <button name="%(delivery.action_delivery_carrier_form)d" icon="oi-arrow-right" type="action" string="USPS Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'usps'}"/>
                             </div>
                         </div>
                     </setting>
@@ -173,7 +173,7 @@
                         <field name="module_delivery_bpost" widget="upgrade_boolean"/>
                         <div class="content-group">
                             <div class="mt8" attrs="{'invisible': [('module_delivery_bpost', '=', False)]}">
-                                <button name="%(delivery.action_delivery_carrier_form)d" icon="oi oi-arrow-right" type="action" string="bpost Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'bpost'}"/>
+                                <button name="%(delivery.action_delivery_carrier_form)d" icon="oi-arrow-right" type="action" string="bpost Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'bpost'}"/>
                             </div>
                         </div>
                     </setting>
@@ -182,7 +182,7 @@
                         <field name="module_delivery_easypost" widget="upgrade_boolean"/>
                         <div class="content-group">
                             <div class="mt8" attrs="{'invisible': [('module_delivery_easypost', '=', False)]}">
-                                <button name="%(delivery.action_delivery_carrier_form)d" icon="oi oi-arrow-right" type="action" string="Easypost Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'easypost'}"/>
+                                <button name="%(delivery.action_delivery_carrier_form)d" icon="oi-arrow-right" type="action" string="Easypost Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'easypost'}"/>
                             </div>
                         </div>
                     </setting>
@@ -245,7 +245,7 @@
                         </div>
                     </div>
                     <div attrs="{'invisible': [('send_abandoned_cart_email', '=', False)]}" class="mt8">
-                        <button type="object" name="action_open_abandoned_cart_mail_template" string="Customize Abandoned Email Template" class="btn-link" icon="oi oi-arrow-right"/>
+                        <button type="object" name="action_open_abandoned_cart_mail_template" string="Customize Abandoned Email Template" class="btn-link" icon="oi-arrow-right"/>
                     </div>
                 </setting>
             </setting>

--- a/addons/website_sale_loyalty/wizard/res_config_settings_views.xml
+++ b/addons/website_sale_loyalty/wizard/res_config_settings_views.xml
@@ -12,7 +12,7 @@
                         <button name="%(loyalty.loyalty_program_discount_loyalty_action)d"
                             type="action"
                             string="Loyalty Programs"
-                            icon="oi oi-arrow-right"
+                            icon="oi-arrow-right"
                             class="btn-link"/>
                     </div>
                 </div>

--- a/addons/website_sale_mondialrelay/views/res_config_settings_views.xml
+++ b/addons/website_sale_mondialrelay/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
             <setting id="shipping_provider_mondialrelay_setting" position="inside">
                 <div class="content-group">
                     <div class="mt8" attrs="{'invisible': [('module_delivery_mondialrelay', '=', False)]}">
-                        <button name="%(delivery.action_delivery_carrier_form)d" icon="oi oi-arrow-right" type="action" string="Mondial Relay Shipping Methods" class="btn-link" context="{'search_default_is_mondialrelay': True}"/>
+                        <button name="%(delivery.action_delivery_carrier_form)d" icon="oi-arrow-right" type="action" string="Mondial Relay Shipping Methods" class="btn-link" context="{'search_default_is_mondialrelay': True}"/>
                     </div>
                 </div>
             </setting>

--- a/addons/website_sale_picking/views/res_config_settings_views.xml
+++ b/addons/website_sale_picking/views/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                            context="{'default_website_id': website_id, 'default_product_id': %(website_sale_picking.onsite_delivery_product)d, 'default_delivery_type': 'onsite', 'default_website_published': True, 'default_company_id': company_id}"/>
                 </div>
                 <div class="mt8">
-                    <button name="%(delivery.action_delivery_carrier_form)d" icon="oi oi-arrow-right" type="action" string="Customize Pickup Sites" class="btn-link" context="{'search_default_delivery_type': 'onsite'}"/>
+                    <button name="%(delivery.action_delivery_carrier_form)d" icon="oi-arrow-right" type="action" string="Customize Pickup Sites" class="btn-link" context="{'search_default_delivery_type': 'onsite'}"/>
                 </div>
             </xpath>
         </field>

--- a/addons/website_slides_forum/views/res_config_settings_views.xml
+++ b/addons/website_slides_forum/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//setting[@id='website_slide_install_website_slides_forum']" position="inside">
                 <div class="mt8">
-                    <button type="action" name="%(website_slides_forum.forum_forum_action_channel)d" string="Manage Forums" class="btn-link" icon="oi oi-arrow-right"/>
+                    <button type="action" name="%(website_slides_forum.forum_forum_action_channel)d" string="Manage Forums" class="btn-link" icon="oi-arrow-right"/>
                 </div>
             </xpath>
         </field>

--- a/addons/website_slides_survey/views/res_config_settings_views.xml
+++ b/addons/website_slides_survey/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//setting[@id='website_slide_install_website_slides_survey']" position="inside">
                 <div class="mt8">
-                    <button type="action" name="%(website_slides_survey.survey_survey_action_slides)d" string="Manage Certifications" class="btn-link" icon="oi oi-arrow-right"/>
+                    <button type="action" name="%(website_slides_survey.survey_survey_action_slides)d" string="Manage Certifications" class="btn-link" icon="oi-arrow-right"/>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
Prior to this commit, the icons in `view_button` were not rendered correctly when we used a `oi-*` icon.
This commit :
- Adds a condition to handle icon using `oi`.
- Replace `fa-fw` with `oi-fw`.

Requires:
- https://github.com/odoo-dev/enterprise/pull/571