### PR TITLE
fixup! [REF][TMP] web: formView

### DIFF
--- a/addons/mail/static/src/web/chatter.xml
+++ b/addons/mail/static/src/web/chatter.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Chatter" owl="1">
-    <div class="o-mail-Chatter h-100 flex-grow-1 d-flex flex-column" t-att-class="{ 'overflow-auto': props.hasMessageListScrollAdjust, 'o-chatter-disabled': props.threadId === false }" t-ref="root">
+    <div class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex flex-column" t-att-class="{ 'overflow-auto': props.hasMessageListScrollAdjust, 'o-chatter-disabled': props.threadId === false }" t-ref="root">
         <div class="o-mail-Chatter-topbar d-flex flex-shrink-0 flex-grow-0 px-3 overflow-x-auto">
             <button t-if="props.hasMessageList" class="o-mail-Chatter-sendMessage btn text-nowrap me-1" t-att-class="{ 'btn-primary': state.thread.composer.type !== 'note', 'btn-secondary': state.thread.composer.type === 'note', 'o-active': state.thread.composer.type === 'message', 'my-2': !props.compactHeight }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
                 Send message
@@ -145,7 +145,7 @@
 </t>
 
 <t t-name="mail.Chatter.attachFiles" owl="1">
-    <button class="btn btn-link text-action px-1" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments">
+    <button class="btn btn-link text-action text-nowrap px-1" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments">
         <i class="fa fa-paperclip fa-lg me-1"/>
         <span t-if="attachments.length > 0" t-esc="attachments.length"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -16,12 +16,12 @@
 }
 // Compensate margins
 @mixin o-form-sheet-negative-margin {
-    margin-left: -$o-horizontal-padding;
-    margin-right: -$o-horizontal-padding;
+    margin-left: calc(var(--formView-sheet-padding-x) * -1);
+    margin-right: calc(var(--formView-sheet-padding-x) * -1);
 }
 @mixin o-form-nosheet-negative-margin {
-    margin-left: -$o-horizontal-padding;
-    margin-right: -$o-horizontal-padding;
+    margin-left: calc(var(--formView-sheet-padding-x) * -1);
+    margin-right: calc(var(--formView-sheet-padding-x) * -1);
 }
 
 // XXS form view specific rules
@@ -1094,6 +1094,10 @@
 
 .o_form_view.o_xxl_form_view {
     flex-flow: row nowrap !important;
+
+    .o_form_view_container {
+        width: 1px; // List view needs a width value to recompute the size correctly
+    }
 
     .o_form_sheet_bg {
         overflow: auto;


### PR DESCRIPTION
This PR fixes the formView's overflowing problem (between 1534px and 1600px) by adding a width to `.o_form_view_container`. The issue was caused by the list view which needs a width value to recompute the size correctly, whatever the value.

We also fix the negative margin on the list view and the overflowing chatter in mobile view.

task-2818586


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
