### PR TITLE
[FIX] mass_mailing: alert margin issues, adapt for milk

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -74,7 +74,7 @@
 
                         <field name="state" readonly="1" widget="statusbar"/>
                     </header>
-                    <div class="alert alert-info my-0 mx-3 text-center" role="alert"
+                    <div class="alert alert-info mb-2 text-center" role="alert"
                         attrs="{'invisible': ['&amp;','&amp;','&amp;','&amp;','&amp;',('state', '!=', 'in_queue'),('sent', '=', 0),('canceled', '=', 0),('scheduled', '=', 0),('failed', '=', 0),('warning_message', '=', False)]}">
                         <div class="o_mails_canceled" attrs="{'invisible': [('canceled', '=', 0)]}">
                             <button class="btn-link py-0"


### PR DESCRIPTION
This commit fixes the following issue:

- [XLU] mass_mailing: missing margin between alert and sheet https://tinyurl.com/2psq2de6

task-2818586