### PR TITLE
fixup! [IMP] base: `onboarding`, milk adaptations

### DIFF
--- a/odoo/addons/base/static/src/scss/onboarding.scss
+++ b/odoo/addons/base/static/src/scss/onboarding.scss
@@ -26,32 +26,39 @@ $o-onboarding-step-width: map-get($container-max-widths, 'lg') / 4 !default;
             }
         }
 
-        &:last-child,
-        &:first-child {
-            .o_onboarding_progress_overlay {
-                background-color: $o-onboarding-main-bg;
+        &:first-child, &:last-child {
+            .o_onboarding_line {
+                width: $o-onboarding-line-width / 2 ;
             }
         }
 
-        &:last-child .o_onboarding_progress_overlay {
-            right: 0;
+        &:first-child {
+            .o_onboarding_line {
+                margin-left: $o-onboarding-line-width / 2;
+            }
         }
 
-        &:first-child .o_onboarding_progress_overlay {
-            left: 0;
+        &:last-child {
+            .o_onboarding_line {
+                margin-right: $o-onboarding-line-width / 2;
+            }
+        }
+
+        .o_onboarding_line {
+            background: linear-gradient(to right, $o-onboarding-color-orange 0%, $o-onboarding-color-blue 100%);
+            height: $o-onboarding-line-height;
+            width: $o-onboarding-line-width;
+            top: $o-onboarding-image-size / 2;
+            background-attachment: fixed;
         }
 
         .o_onboarding_step_content {
             width: $o-onboarding-step-width;
         }
 
-        .o_onboarding_step_side {
-            background-color: $o-onboarding-main-bg;
-            
-            img {
-                width: $o-onboarding-image-size;
-                height: $o-onboarding-image-size;
-            }
+        .o_onboarding_step_side img {            
+            width: $o-onboarding-image-size;
+            height: $o-onboarding-image-size;
         }
 
         .o_onboarding_step_action {
@@ -65,10 +72,6 @@ $o-onboarding-step-width: map-get($container-max-widths, 'lg') / 4 !default;
                 background-color: $o-onboarding-color-orange;
                 color: #FFF;
             }
-        }
-
-        &:first-of-type .o_onboarding_progress {
-            display: none;
         }
 
         // = "To do" Step Design
@@ -101,12 +104,6 @@ $o-onboarding-step-width: map-get($container-max-widths, 'lg') / 4 !default;
             }
         }
     }
-
-    .o_onboarding_progress {
-        height: $o-onboarding-progress-size;
-        background: linear-gradient(to right, #{$o-onboarding-color-orange} 0%,  #{$o-onboarding-color-blue} 100%);
-        transform: translateY($o-onboarding-image-size / 2);
-    } 
 
     // = Animations
     // ------------------------------------------------------------------------

--- a/odoo/addons/base/static/src/scss/onboarding.variables.scss
+++ b/odoo/addons/base/static/src/scss/onboarding.variables.scss
@@ -1,6 +1,7 @@
 $o-onboarding-base-time: 0.5s !default;
 $o-onboarding-image-size: 64px !default;
-$o-onboarding-progress-size: 2px !default;
+$o-onboarding-line-height: 2px !default;
+$o-onboarding-line-width: 100% !default;
 $o-onboarding-main-bg: $o-gray-200 !default;
 $o-onboarding-color-blue: #374874 !default;
 $o-onboarding-color-orange: #F39D9B !default;

--- a/odoo/addons/base/views/onboarding_views.xml
+++ b/odoo/addons/base/views/onboarding_views.xml
@@ -27,7 +27,6 @@
             <div class="o_onboarding_main position-relative border-bottom overflow-hidden">
                 <div class="o_onboarding_wrap py-3">
                     <a href="#" data-bs-toggle="modal" data-bs-target=".o_onboarding_modal" class="o_onboarding_btn_close position-absolute top-0 end-0 py-2 px-3 h2 z-index-1" title="Close the onboarding panel"><i class="oi oi-close"/></a>
-                    <div class="o_onboarding_progress position-absolute w-100"/>
                     <div class="o_onboarding_steps d-flex" t-out="0"/>
 
 
@@ -52,8 +51,8 @@
         <div class="o_onboarding_step position-relative d-flex flex-column align-items-center justify-content-start text-center" t-att-data-step-state="state">
             <img t-if="state == 'just_done'" class="o_onboarding_confetti position-absolute w-100" src="/base/static/img/onboarding_confetti.svg" alt="o_onboarding_confetti"/>
 
-            <div class="o_onboarding_progress_overlay position-absolute w-50 h-100 z-index-0"/>
-            <div class="o_onboarding_step_side d-flex pt-0">
+            <div class="o_onboarding_line position-absolute"/>
+            <div class="o_onboarding_step_side d-flex">
                 <img class="z-index-1" t-attf-src="#{image}" t-attf-alt="#{alt}"/>
             </div>
 


### PR DESCRIPTION
This fixup modifies the way the gradient line is displayed. 

Previously, a line with a linear gradient extended across the entire main div, causing certain parts to be concealed.

Now, to incorporate new steps and alter the background if wanted, the following adjustments have been made:

A line with a linear gradient is now applied to each step. The gradient is set with a background-attachment of fixed, ensuring that the gradient is not repeated for each step. Instead, it remains consistent and uniform across the entire line, regardless of the number of steps.