### PR TITLE
[IMP] website_forum: search and filter tags

### DIFF
--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -1,25 +1,23 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import json
+import logging
+from datetime import datetime
+
 import lxml
 import requests
-import logging
 import werkzeug.exceptions
 import werkzeug.urls
 import werkzeug.wrappers
 
-from datetime import datetime
-
-from odoo import http, tools, _
-from odoo.exceptions import AccessError
+from odoo import _, http, tools
 from odoo.addons.http_routing.models.ir_http import slug
+from odoo.addons.portal.controllers.portal import _build_url_w_params
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.website_profile.controllers.main import WebsiteProfile
-from odoo.addons.portal.controllers.portal import _build_url_w_params
-
-from odoo.exceptions import UserError
+from odoo.exceptions import AccessError, UserError
 from odoo.http import request
-
+from odoo.osv import expression
 
 _logger = logging.getLogger(__name__)
 
@@ -167,6 +165,9 @@ class WebsiteForum(WebsiteProfile):
         values = self._prepare_user_values(forum=forum, header={'is_guidelines': True, 'is_karma': True}, **post)
         return request.render("website_forum.faq_karma", values)
 
+    # Tags
+    # --------------------------------------------------
+
     @http.route('/forum/get_tags', type='http', auth="public", methods=['GET'], website=True, sitemap=False)
     def tag_read(self, forum_id, query='', limit=25, **post):
         data = request.env['forum.tag'].search_read(
@@ -179,31 +180,53 @@ class WebsiteForum(WebsiteProfile):
             headers=[("Content-Type", "application/json")]
         )
 
-    @http.route(['/forum/<model("forum.forum"):forum>/tag', '/forum/<model("forum.forum"):forum>/tag/<string:tag_char>'], type='http', auth="public", website=True, sitemap=False)
-    def tags(self, forum, tag_char=None, **post):
-        # build the list of tag first char, with their value as tag_char param Ex : [('All', 'all'), ('C', 'c'), ('G', 'g'), ('Z', z)]
-        first_char_tag = forum.get_tags_first_char()
+    @http.route(['/forum/<model("forum.forum"):forum>/tag',
+                 '/forum/<model("forum.forum"):forum>/tag/<string:tag_char>',
+                 ], type='http', auth="public", website=True, sitemap=False)
+    def tags(self, forum, tag_char=None, filters='all', search='', **post):
+        # Build tags result without using tag_char to build pager, then return tags matching it
+        values = self._prepare_user_values(forum=forum, searches={'tags': True}, **post)
+        request.env["forum.post"].flush_model()
+        tags = request.env["forum.tag"]
+        order = 'posts_count DESC' if tag_char and tag_char != "all" else 'name'
+
+        if search:
+            values.update(search=search)
+            __, details, __ = request.website._search_with_fuzzy(
+                'forum_tags_only', search, limit=None, order=order, options={'forum': forum},
+            )
+            tags = details[0].get('results', tags)
+
+        if filters in ('unused', 'most_used'):
+            filter_tags = forum.tag_most_used_ids if filters == 'most_used' else forum.tag_unused_ids
+            tags = tags & filter_tags if tags else filter_tags
+
+        elif filters in ('all', 'followed'):
+            domain = [('forum_id', '=', forum.id), ('posts_count', '>', 0)]
+            if filters == 'followed' and not request.env.user._is_public():
+                domain = expression.AND([domain, [('message_is_follower', '=', True)]])
+            if search:
+                tags = tags.filtered_domain(domain) if tags else tags
+            else:
+                tags = request.env['forum.tag'].search(domain, limit=None, order=order)
+
+        else:
+            raise werkzeug.exceptions.BadRequest(f'Unknown tag "filters" {filters}')
+
+        first_char_tag = forum._get_tags_first_char(tags=tags)
         first_char_list = [(t, t.lower()) for t in first_char_tag if t.isalnum()]
         first_char_list.insert(0, (_('All'), 'all'))
-
-        active_char_tag = tag_char and tag_char.lower() or 'all'
-
-        # generate domain for searched tags
-        domain = [('forum_id', '=', forum.id), ('posts_count', '>', 0)]
-        order_by = 'name'
-        if active_char_tag and active_char_tag != 'all':
-            domain.append(('name', '=ilike', tools.escape_psql(active_char_tag) + '%'))
-            order_by = 'posts_count DESC'
-        tags = request.env['forum.tag'].search(domain, limit=None, order=order_by)
-        # prepare values and render template
-        values = self._prepare_user_values(forum=forum, searches={'tags': True}, **post)
+        active_tag_char = tag_char.lower() if tag_char else 'all'
+        if tag_char and tag_char != 'all':
+            tags = tags.filtered(lambda t: t.name.startswith((tag_char.lower(), tag_char.upper())))
 
         values.update({
-            'tags': tags,
+            'active_char_tag': active_tag_char,
             'pager_tag_chars': first_char_list,
-            'active_char_tag': active_char_tag,
+            'search_count': len(tags) if search else None,
+            'tags': tags,
         })
-        return request.render("website_forum.tag", values)
+        return request.render("website_forum.forum_index_tags", values)
 
     # Questions
     # --------------------------------------------------

--- a/addons/website_forum/models/forum_tag.py
+++ b/addons/website_forum/models/forum_tag.py
@@ -2,13 +2,18 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.exceptions import AccessError
 
 
 class Tags(models.Model):
     _name = "forum.tag"
     _description = "Forum Tag"
-    _inherit = ['mail.thread', 'website.seo.metadata']
+    _inherit = [
+        'mail.thread',
+        'website.searchable.mixin',
+        'website.seo.metadata',
+    ]
 
     name = fields.Char('Name', required=True)
     forum_id = fields.Many2one('forum.forum', string='Forum', required=True)
@@ -16,7 +21,7 @@ class Tags(models.Model):
         'forum.post', 'forum_tag_rel', 'forum_tag_id', 'forum_id',
         string='Posts', domain=[('state', '=', 'active')])
     posts_count = fields.Integer('Number of Posts', compute='_compute_posts_count', store=True)
-
+    website_url = fields.Char("Link to questions with the tag", compute='_compute_website_url')
     _sql_constraints = [
         ('name_uniq', 'unique (name, forum_id)', "Tag name already exists!"),
     ]
@@ -26,6 +31,11 @@ class Tags(models.Model):
         for tag in self:
             tag.posts_count = len(tag.post_ids)  # state filter is in field domain
 
+    @api.depends("forum_id", "forum_id.name", "name")
+    def _compute_website_url(self):
+        for tag in self:
+            tag.website_url = f'/forum/{slug(tag.forum_id)}/tag/{slug(tag)}/questions'
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
@@ -33,3 +43,29 @@ class Tags(models.Model):
             if self.env.user.karma < forum.karma_tag_create and not self.env.is_admin():
                 raise AccessError(_('%d karma required to create a new Tag.', forum.karma_tag_create))
         return super(Tags, self.with_context(mail_create_nolog=True, mail_create_nosubscribe=True)).create(vals_list)
+
+    # ----------------------------------------------------------------------
+    # WEBSITE
+    # ----------------------------------------------------------------------
+
+    @api.model
+    def _search_get_detail(self, website, order, options):
+        search_fields = ['name']
+        fetch_fields = ['id', 'name', 'website_url']
+        mapping = {
+            'name': {'name': 'name', 'type': 'text', 'match': True},
+            'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
+        }
+        base_domain = []
+        if forum := options.get("forum"):
+            forum_ids = (unslug(forum)[1], ) if isinstance(forum, str) else forum.ids
+            base_domain = [[('forum_id', 'in', forum_ids)]]
+        return {
+            'model': 'forum.tag',
+            'base_domain': base_domain,
+            'search_fields': search_fields,
+            'fetch_fields': fetch_fields,
+            'mapping': mapping,
+            'icon': 'fa-tag',
+            'order': ','.join(filter(lambda f: 'is_published' not in f, order.split(','))),
+        }

--- a/addons/website_forum/models/website.py
+++ b/addons/website_forum/models/website.py
@@ -38,6 +38,8 @@ class Website(models.Model):
             result.append(self.env['forum.forum']._search_get_detail(self, order, options))
         if search_type in ['forums', 'forum_posts_only', 'all']:
             result.append(self.env['forum.post']._search_get_detail(self, order, options))
+        if search_type in ['forums', 'forum_tags_only', 'all']:
+            result.append(self.env['forum.tag']._search_get_detail(self, order, options))
         return result
 
     def _update_forum_count(self):

--- a/addons/website_forum/tests/__init__.py
+++ b/addons/website_forum/tests/__init__.py
@@ -3,5 +3,6 @@
 from . import common
 from . import test_forum_internals
 from . import test_forum_karma_access
+from . import test_forum_tag
 from . import test_forum_tours
 from . import test_web_editor

--- a/addons/website_forum/tests/test_forum_tag.py
+++ b/addons/website_forum/tests/test_forum_tag.py
@@ -1,0 +1,50 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.website_forum.models.forum_forum import MOST_USED_TAGS_COUNT
+from odoo.addons.website_forum.tests.common import TestForumCommon
+
+
+class TestForumTag(TestForumCommon):
+    def setUp(self):
+        super().setUp()
+        # Reset tags
+        forums = self.forum | self.base_forum
+        self.env['forum.tag'].search([]).unlink()
+        self.env['forum.tag'].create(
+            [{'forum_id': forum_id.id, 'name': f'Test Tag {tag_idx}'} for forum_id in forums for tag_idx in range(1, 8)]
+        )
+
+    def test_tags_counts_most_used(self):
+        posts_per_tag = [(tag_id, post_count) for tag_id, post_count in zip(self.base_forum.tag_ids, range(2, 9))]
+        vals_list = [
+            {'forum_id': self.base_forum.id, 'name': 'A post', 'content': 'A content', 'tag_ids': [tag_id.id]}
+            for tag_id, post_count in posts_per_tag
+            for __ in range(post_count)
+        ]
+        self.env['forum.post'].create(vals_list)
+        self.env['forum.tag'].flush_model()
+
+        self.assertListEqual(
+            self.base_forum.tag_most_used_ids.ids,
+            [tag_id.id for tag_id, _ in reversed(posts_per_tag[-MOST_USED_TAGS_COUNT:])],
+        )
+        self.assertEqual(self.base_forum.tag_unused_ids, self.env['forum.tag'])
+
+    def test_tags_counts_unused(self):
+        used_tag = self.forum.tag_ids[5]
+        self.env['forum.post'].create(
+            [
+                {'forum_id': tag_id.forum_id.id, 'tag_ids': [tag_id.id], 'name': 'A post', 'content': 'A content'}
+                for tag_id in (used_tag | self.base_forum.tag_ids)
+            ]
+        )
+        self.env['forum.tag'].flush_model()
+
+        # trigger batch compute
+        __ = (self.forum | self.base_forum).tag_most_used_ids
+
+        self.assertEqual(self.forum.tag_most_used_ids, used_tag)
+        self.assertEqual(self.forum.tag_unused_ids, self.forum.tag_ids - used_tag)
+
+        self.assertEqual(self.base_forum.tag_most_used_ids, self.base_forum.tag_ids[:MOST_USED_TAGS_COUNT])
+        self.assertEqual(self.base_forum.tag_unused_ids, self.env['forum.tag'])

--- a/addons/website_forum/views/forum_forum_templates.xml
+++ b/addons/website_forum/views/forum_forum_templates.xml
@@ -4,7 +4,7 @@
 
 <!-- Specific Forum Layout -->
 <template id="forum_index" name="Forum">
-    <t t-set="no_filters" t-value="not filters in ('solved', 'unsolved', 'unanswered') and not tag_filters"/>
+    <t t-set="no_filters" t-value="not filters in ('solved', 'unsolved', 'unanswered')"/>
     <t t-if="my == 'mine'" t-set="_page_name" t-valuef="My Posts"/>
     <t t-elif="my == 'favourites'" t-set="_page_name" t-valuef="My Favourites"/>
     <t t-else="" t-set="_page_name" t-valuef="list_questions"/>
@@ -39,7 +39,10 @@
                 </t>
             </t>
         </table>
-        <t t-if="question_count == 0 or original_search" t-call="website_forum.no_results_message"/>
+        <t t-if="question_count == 0 or original_search" t-call="website_forum.no_results_message">
+            <t t-set="record_name_plural">posts</t>
+            <t t-set="go_back_url" t-valuef="/forum/#{ slug(forum) }/"/>
+        </t>
         <t t-call="website.pager"/>
     </t>
 </template>
@@ -179,7 +182,7 @@
     </t>
 </template>
 
-<template id="tag" name="Forum Tags">
+<template id="forum_index_tags" name="Forum Tags">
     <t t-set="_page_name" t-valuef="Tags"/>
 
     <t t-call="website_forum.header">
@@ -188,7 +191,12 @@
                 <ul class="pagination overflow-auto mt0 mb0">
                     <t t-foreach="pager_tag_chars" t-as="tuple_char">
                         <t t-if="tuple_char_index &lt; 11">
-                            <li t-attf-class="page-item #{active_char_tag == tuple_char[1] and 'active'}"><a t-attf-href="/forum/#{slug(forum)}/tag/#{quote_plus(tuple_char[1])}" class="page-link"><t t-esc="tuple_char[0]"/></a></li>
+                            <li t-attf-class="page-item #{active_char_tag == tuple_char[1] and 'active'}">
+                                <a t-attf-href="/forum/#{slug(forum)}/tag/#{quote_plus(tuple_char[1]) + '?' + keep_query('filters', 'search')}"
+                                   class="page-link">
+                                    <t t-out="tuple_char[0]"/>
+                                </a>
+                            </li>
                         </t>
                     </t>
                 </ul>
@@ -198,7 +206,9 @@
                 <select name="filter" class="form-select w-auto" onchange="location = this.value;">
                     <t t-foreach="pager_tag_chars" t-as="tuple_char">
                         <option t-if="active_char_tag == tuple_char[1]" selected="selected" value="" t-out="tuple_char[0]"/>
-                        <option t-else="" t-attf-value="/forum/#{slug(forum)}/tag/#{quote_plus(tuple_char[1])}" t-esc="tuple_char[0]"/>
+                        <option t-else="" t-attf-value="/forum/#{slug(forum)}/tag/#{quote_plus(tuple_char[1]) + '?' + keep_query('filters')}"
+                                t-out="tuple_char[0]"
+                        />
                     </t>
                 </select>
             </div>
@@ -225,14 +235,16 @@
         </div>
         <t t-else="">
             <t t-set="tag_filter" t-value="keep_query('filters') and keep_query('filters').split('=')[1] or ''"/>
+            <t t-set="go_back_url" t-valuef="/forum/#{ slug(forum) }/tag"/>
+            <t t-set="record_name_plural">tags</t>
             <t t-call="website_forum.no_results_message">
-                <t t-if="tag_filter and tag_filter != 'all'" t-set="results_msg">
-                    There are no tags matching the selected filter.
+                <t t-if="tag_filter and tag_filter != 'all'" t-set="result_msg">
+                    There are no tags matching the selected filter <t t-if="search">and search</t>.
                 </t>
-                <t t-if="search" t-set="results_msg">
+                <t t-elif="search" t-set="result_msg">
                     There are no tags matching the selected search.
                 </t>
-                <t t-else="" t-set="results_msg">
+                <t t-else="" t-set="result_msg">
                     There are no tags being used in this forum.
                 </t>
             </t>

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -107,12 +107,12 @@
             </button>
         </div>
         <div t-if="_page_name != 'single_question'" class="d-flex justify-content-lg-end gap-2 flex-grow-1 mw-lg-50">
-            <span t-if="search or tag" class="btn btn-light rounded ps-2">
+            <span t-if="search or (tag and not tags)" class="btn btn-light rounded ps-2">
                 <span t-if="tag"><i class="fa fa-tag me-1 text-muted"/><t t-esc="tag.name"></t></span>
                 <em t-if="search" class="text-muted">"<t t-esc="search"/>"</em>
                 <a t-attf-href="#{tag and url_for('/forum') + '/' + slug(forum) + '?' + keep_query( 'search', 'sorting', 'filters', 'my') or url_for('') + '?' + keep_query( 'filters', 'sorting', 'my')}" class="p-1 text-decoration-none text-muted"><i class="oi oi-close d-inline-block"/></a>
             </span>
-            <div t-if="question_count != 0" class="dropdown ms-lg-auto">
+            <div t-if="question_count != 0 or tags" class="dropdown ms-lg-auto">
                 <t t-if="_page_name == 'Tags'" t-set="tag_filter" t-value="keep_query('filters') and keep_query('filters').split('=')[1] or ''"/>
                 <a href="#" class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown">
                     <!-- Foreach tag_filter/ Foreach filters -->
@@ -127,7 +127,6 @@
                         <t t-elif="filters == 'unsolved'">Unsolved</t>
                         <t t-elif="filters == 'unanswered'">Unanswered</t>
                     </t>
-
                 </a>
                 <div class="dropdown-menu" role="menu">
                     <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', filters='all')"
@@ -135,42 +134,46 @@
                         All
                     </a>
                     <div class="dropdown-divider"/>
-                        <t t-if="_page_name == 'Tags'">
-                            <t t-if="not request.env.user._is_public()">
-                                <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='followed')"
-                                    class="dropdown-item">Followed Tags
-                                </a>
-                            </t>
-                            <t t-if="forum.can_moderate">
-                                <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='unused')"
-                                    class="dropdown-item">Unused Tags
-                                </a>
-                            </t>
-                            <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='most_used')"
-                                class="dropdown-item">Most Used Tags
+                    <t t-if="_page_name == 'Tags'">
+                        <t t-if="not request.env.user._is_public()">
+                            <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='followed')"
+                                class="dropdown-item">Followed Tags
                             </a>
                         </t>
-                        <t t-else="">
-                            <t t-if="forum.mode == 'questions'">
-                                <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='solved')"
-                                    class="dropdown-item">Solved
-                                </a>
-                                <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='unsolved')"
-                                    class="dropdown-item">Unsolved
-                                </a>
-                            </t>
-                            <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='unanswered')"
-                                class="dropdown-item">Unanswered
+                        <t t-if="forum.can_moderate">
+                            <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='unused')"
+                                class="dropdown-item">Unused Tags
                             </a>
                         </t>
+                        <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='most_used')"
+                            class="dropdown-item">Most Used Tags
+                        </a>
+                    </t>
+                    <t t-else="">
+                        <t t-if="forum.mode == 'questions'">
+                            <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='solved')"
+                            class="dropdown-item">Solved
+                            </a>
+                            <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='unsolved')"
+                            class="dropdown-item">Unsolved
+                            </a>
+                        </t>
+                        <a t-att-href="url_for('') + '?' + keep_query( 'search', 'sorting', 'my', filters='unanswered')"
+                        class="dropdown-item">Unanswered
+                        </a>
+                    </t>
                 </div>
             </div>
-            <!-- 'Search Box' [TODO] tags-->
-            <t t-if="question_count != 0" t-call="website.website_search_box_input">
-                <t t-if="_page_name == 'Tags'" t-set="search_type" t-valuef="forum_tags_only"/>
-                <t t-else="" t-set="search_type" t-valuef="forums"/>
-                <t t-if="_page_name == 'Tags'" t-set="action" t-value="'/forum/%s/tag' % (slug(forum))"/>
-                <t t-else="" t-set="action" t-value="'/forum/%s%s' % (slug(forum), tag and ('/tag/%s/questions' % slug(tag)) or '')"/>
+            <!-- 'Search Box' -->
+            <t  t-if="question_count != 0 or tags" t-call="website.website_search_box_input">
+                <t t-if="_page_name == 'Tags'">
+                    <t t-set="search_type" t-valuef="forum_tags_only"/>
+                    <t t-set="action" t-value="'/forum/%s/tag' % (slug(forum))"/>
+                </t>
+                <t t-else="">
+                    <t t-set="search_type" t-valuef="forums"/>
+                    <t t-set="action" t-value="'/forum/%s' % (slug(forum))"/>
+                </t>
                 <t t-set="display_description" t-valuef="true"/>
                 <t t-set="display_detail" t-valuef="true"/>
                 <t t-set="_form_classes" t-valuef="flex-grow-1"/>
@@ -190,7 +193,7 @@
                 <a t-elif="uid" role="button" type="button" t-attf-class="o_wforum_ask_btn btn btn-primary #{(user.karma &lt; forum.karma_ask) and 'karma_required'}" t-att-data-karma="forum.karma_ask" t-att-href="'/forum/' + slug(forum) + '/ask'">New Post</a>
             </t>
             <t t-if="website_forum_action and not queue_type == 'close' and question_count != 0">
-                    <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#markAllAsSpam"><i class="fa fa-bug"></i> Filter Tool</button>
+                <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#markAllAsSpam"><i class="fa fa-bug"></i> Filter Tool</button>
             </t>
         </div>
     </nav>
@@ -286,7 +289,7 @@
 
 <template id="website_forum.user_sidebar_body">
     <div class="o_wforum_sidebar_section">
-        <t t-set="location" t-value="url_for('/forum') + '/' + slug(forum) + ( ('/tag/' + slug(tag) + '/questions?') if tag else '?' )"/>
+        <t t-set="location" t-value="url_for('/forum') + '/' + slug(forum) + ( ('/tag/' + slug(tag) + '/questions?') if (tag and not tags) else '?' )"/>
         <!-- All Posts -->
         <a t-attf-class="nav-link my-1 py-1 #{request.httprequest.path ==  (url_for('/forum') + '/' + slug(forum)) and no_filters and not my and not queue_type and not tags and 'bg-primary-light text-primary disabled' or 'text-reset'}" t-att-href="location">
             <i t-attf-class="fa fa-list fa-fw #{(request.httprequest.path != (url_for('/forum') + '/' + slug(forum)) or my or queue_type) and 'opacity-50'}"/> Posts
@@ -327,13 +330,13 @@
             <i t-attf-class="fa fa-window-close fa-fw #{queue_type != 'close' and 'opacity-50'}"/> Closed
         </a>
     </div>
-    <div t-if="forum.post_ids.tag_ids" class="o_wforum_sidebar_section pt-3">
+    <div t-if="forum.tag_most_used_ids" class="o_wforum_sidebar_section pt-3">
         <div class="d-flex align-items-center px-3 pb-1 fw-bold">Tags
             <a class="ms-auto px-0 fw-normal" t-attf-href="/forum/#{slug(forum)}/tag">
                 <small>View all</small>
             </a>
         </div>
-        <t t-foreach="forum.post_ids.tag_ids" t-as="tag">
+        <t t-foreach="forum.tag_most_used_ids" t-as="tag">
             <a t-att-href="'/forum/' + slug(tag.forum_id) + '/tag/' + slug(tag) + '/questions?' + keep_query( 'search', 'sorting', 'my', filters='tag')"
                 t-attf-class="nav-link my-1 py-1 text-reset">
                 <i class="fa fa-tag fa-fw small opacity-50"/>
@@ -379,11 +382,15 @@
    <t t-if="queue_type">
         <t t-set="_no_results_title">You've Completely Caught&amp;nbsp;Up!</t>
         <t t-set="result_msg">Go enjoy a cup of coffee</t>
+        <t t-set="record_name_plural" t-value="'posts'"/>
+        <t t-set="go_back_url" t-valuef="/forum/#{ slug(forum) }/"/>
    </t>
    <t t-else="">
         <t t-set="_no_results_title">Oops!</t>
-        <t t-set="result_msg">Sorry, we could not find any<b>%s</b> results<b>%s</b>%s%s%s.</t>
-        <t t-set="result_msg" t-value="result_msg % (_filters_str.strip(), _my_str.strip(), _search_str.strip(), _search_and_tag_str.strip(), _tag_str.strip())"></t>
+        <t t-if="not result_msg">
+            <t t-set="result_msg">Sorry, we could not find any<b>%s</b> results<b>%s</b>%s%s%s.</t>
+            <t t-set="result_msg" t-value="result_msg % (_filters_str.strip(), _my_str.strip(), _search_str.strip(), _search_and_tag_str.strip(), _tag_str.strip())"></t>
+       </t>
    </t>
     <div t-attf-class="#{queue_type and 'o_caught_up_alert'} row g-0 justify-content-center">
         <div class="p-3 d-flex flex-column align-items-center">
@@ -399,7 +406,7 @@
             <span t-elif="forum.total_posts == 0">Because there are no posts in this forum yet.</span>
             <div class="mt-3">
                 <a t-if="uid and forum.total_posts == 0" role="button" type="button" class="o_forum_ask_btn btn btn-primary ms-2" t-attf-href="/forum/#{slug(forum)}/ask">Start by creating a post</a>
-                <a t-else="" role="button" type="button" class="btn btn-primary mt-2" t-attf-href="/forum/#{slug(forum)}/">Go back to questions list</a>
+                <a t-else="" role="button" type="button" class="btn btn-primary mt-2" t-att-href="go_back_url">Go back to the list of <t t-out="record_name_plural"/></a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The first commit is a bugfix that will come from earlier versions.

The second commit enables user to

* Track, show, and use the forum's
  * Most commonly used tags
  * Unused tags (for the moderators)
* Search tags
* Get an improved "no results" experience with tags

Task-3349375