### PR TITLE
[FIX] web: prevent crash with statusbar field

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -145,7 +145,8 @@ export function useSpecialData(loadFn) {
     const component = useComponent();
     const record = component.props.record;
     const key = `${record.resModel}-${component.props.name}`;
-    const { specialDataCaches, orm } = record.model;
+    const { specialDataCaches } = record.model;
+    const orm = component.env.services.orm;
     const ormWithCache = Object.create(orm);
     if (!specialDataCaches[key]) {
         specialDataCaches[key] = new Cache(

--- a/addons/web/static/tests/views/fields/statusbar_field_tests.js
+++ b/addons/web/static/tests/views/fields/statusbar_field_tests.js
@@ -666,4 +666,50 @@ QUnit.module("Fields", (hooks) => {
             assert.verifySteps([]);
         }
     );
+
+    QUnit.test(
+        "open form with statusbar, leave and come back to another one with other domain",
+        async function (assert) {
+            serverData.views = {
+                "partner,3,list": '<tree><field name="display_name"/></tree>',
+                "partner,9,search": `<search></search>`,
+                "partner,false,form": `<form>
+                <header>
+                    <field name="trululu" widget="statusbar" domain="[['id', '>', id]]" readonly="1"/>
+                </header>
+            </form>`,
+            };
+
+            serverData.actions = {
+                1: {
+                    id: 1,
+                    name: "Partners",
+                    res_model: "partner",
+                    type: "ir.actions.act_window",
+                    views: [
+                        [false, "list"],
+                        [false, "form"],
+                    ],
+                },
+            };
+
+            const mockRPC = (route, args) => {
+                if (args.method === "search_read") {
+                    assert.step("search_read");
+                }
+            };
+
+            const webClient = await createWebClient({ serverData, mockRPC });
+            await doAction(webClient, 1);
+
+            // open first record
+            await click(target.querySelector(".o_data_row .o_data_cell"));
+            assert.verifySteps(["search_read"]);
+
+            // go back and open second record
+            await click(target, ".o_back_button");
+            await click(target.querySelectorAll(".o_data_row")[1].querySelector(".o_data_cell"));
+            assert.verifySteps(["search_read"]);
+        }
+    );
 });


### PR DESCRIPTION
From a list or kanban view, open a form view with a statusbar field (e.g. in crm.lead). Go back to the list. Open another record for which the domain of the statusbar is different. Before this commit, it crashed, because the component bound to the orm service used by the specialData cache (i.e. the previous FormController) is destroyed.