### PR TITLE
[FIX] web: x2many kanban: always display fields in readonly

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -182,7 +182,7 @@ export class Many2XAutocomplete extends Component {
             activeActions,
             isToMany,
             onRecordSaved: (record) => {
-                return update([record.data]);
+                return update([{ ...record.data, id: record.resId }]);
             },
             onRecordDiscarded: () => {
                 if (!isToMany) {

--- a/addons/web/static/src/views/kanban/kanban_compiler.js
+++ b/addons/web/static/src/views/kanban/kanban_compiler.js
@@ -131,6 +131,20 @@ export class KanbanCompiler extends ViewCompiler {
             compiled = super.compileField(el, params);
             const fieldId = el.getAttribute("field_id");
             compiled.setAttribute("id", `'${fieldId}_' + __comp__.props.record.id`);
+            // In x2many kanban, records can be edited in a dialog. The same record as the one of
+            // the kanban is used for the form view dialog, so its mode is switched to "edit", but
+            // we don't want to see it in edition in the background. For that reason, we force its
+            // fields to be readonly when the record is in edition, i.e. when it is opened in a form
+            // view dialog.
+            const readonlyAttr = compiled.getAttribute("readonly");
+            if (readonlyAttr) {
+                compiled.setAttribute(
+                    "readonly",
+                    `__comp__.props.record.isInEdition || (${readonlyAttr})`
+                );
+            } else {
+                compiled.setAttribute("readonly", `__comp__.props.record.isInEdition`);
+            }
         }
 
         const { bold, display } = extractAttributes(el, ["bold", "display"]);

--- a/addons/web/static/src/views/relational_model/record.js
+++ b/addons/web/static/src/views/relational_model/record.js
@@ -751,7 +751,10 @@ export class Record extends DataPoint {
             await this._load(nextConfig);
         } else {
             this.model._updateConfig(this.config, { resId }, { noReload: true });
-            this._values = { ...this._values, ...this._changes, id: resId };
+            this._values = { ...this._values, ...this._changes };
+            if ("id" in this.activeFields) {
+                this._values.id = resId;
+            }
             this._changes = {};
             this.data = { ...this._values };
             this.dirty = false;

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -12699,6 +12699,52 @@ QUnit.module("Fields", (hooks) => {
         assert.containsOnce(target, ".modal .o_kanban_record:not('.o_kanban_ghost')");
     });
 
+    QUnit.test("kanban one2many (with widget) in opened view form", async function (assert) {
+        serverData.models.partner.records[0].p = [1];
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: /* xml */ `
+                <form>
+                    <field name="p">
+                        <kanban>
+                            <templates>
+                                <t t-name="kanban-box">
+                                    <div class="oe_kanban_global_click">
+                                        <field name="display_name" widget="char"/>
+                                    </div>
+                                </t>
+                            </templates>
+                        </kanban>
+                        <form>
+                            <field name="display_name"/>
+                        </form>
+                    </field>
+                </form>`,
+            resId: 1,
+        });
+
+        assert.containsOnce(target, ".o_kanban_record:not(.o_kanban_ghost)");
+        assert.strictEqual(target.querySelector(".o_kanban_record").innerText, "first record");
+
+        await click(target.querySelector(".o_kanban_record"));
+        assert.containsOnce(target, ".o_dialog .o_form_view .o_field_widget[name=display_name]");
+        assert.strictEqual(
+            target.querySelector(".o_dialog .o_form_view .o_field_widget[name=display_name] input")
+                .value,
+            "first record"
+        );
+        assert.strictEqual(target.querySelector(".o_kanban_record").innerText, "first record");
+
+        await editInput(
+            target,
+            ".o_dialog .o_form_view .o_field_widget[name=display_name] input",
+            "test"
+        );
+        assert.strictEqual(target.querySelector(".o_kanban_record").innerText, "test");
+    });
+
     QUnit.test("list one2many in opened view form", async function (assert) {
         serverData.models.partner.records[0].p = [1];
         await makeView({


### PR DESCRIPTION
Have an x2many field displayed with a kanban view containing sub fields with widgets (widget="..."). Click on a record to edit it in a form view dialog. Before this commit, the fields of the kanban card displayed in the background were switched to "edit" when the dialog was open. With this commit, we ensure they always remain displayed in "readonly".