### PR TITLE
[FIX] web: view with a record without properties crash

### DIFF
--- a/addons/web/static/src/views/relational_model/relational_model.js
+++ b/addons/web/static/src/views/relational_model/relational_model.js
@@ -205,7 +205,7 @@ export class RelationalModel extends Model {
         for (const record of records) {
             for (const fieldName in record) {
                 const field = config.fields[fieldName];
-                if (fieldName !== "id" && field.type === "properties") {
+                if (fieldName !== "id" && field.type === "properties" && record[fieldName]) {
                     const parent = record[field.definition_record];
                     const relatedPropertyField = {
                         fieldName,

--- a/addons/web/static/tests/views/fields/properties_field_tests.js
+++ b/addons/web/static/tests/views/fields/properties_field_tests.js
@@ -1353,34 +1353,36 @@ QUnit.module("Fields", (hooks) => {
         assert.equal(items.length, 2);
     });
 
-    QUnit.test("properties: kanban view with date and datetime property fields", async function (assert) {
-        serverData.models.partner.records.push({
-            id: 40,
-            display_name: "fifth partner",
-            properties: [
-                {
-                    name: "property_1",
-                    string: "My Date",
-                    type: "date",
-                    value: "2019-01-01",
-                    view_in_kanban: true,
-                },
-                {
-                    name: "property_2",
-                    string: "My DateTime",
-                    type: "datetime",
-                    value: "2019-01-01 10:00:00",
-                    view_in_kanban: true,
-                },
-            ],
-            company_id: 37,
-        });
+    QUnit.test(
+        "properties: kanban view with date and datetime property fields",
+        async function (assert) {
+            serverData.models.partner.records.push({
+                id: 40,
+                display_name: "fifth partner",
+                properties: [
+                    {
+                        name: "property_1",
+                        string: "My Date",
+                        type: "date",
+                        value: "2019-01-01",
+                        view_in_kanban: true,
+                    },
+                    {
+                        name: "property_2",
+                        string: "My DateTime",
+                        type: "datetime",
+                        value: "2019-01-01 10:00:00",
+                        view_in_kanban: true,
+                    },
+                ],
+                company_id: 37,
+            });
 
-        await makeView({
-            type: "kanban",
-            resModel: "partner",
-            serverData,
-            arch: `
+            await makeView({
+                type: "kanban",
+                resModel: "partner",
+                serverData,
+                arch: `
             <kanban>
                 <templates>
                     <t t-name="kanban-box">
@@ -1392,18 +1394,19 @@ QUnit.module("Fields", (hooks) => {
                     </t>
                 </templates>
             </kanban>`,
-        });
+            });
 
-        // check fifth card
-        const property1 = target.querySelector(
-            ".o_kanban_record:nth-child(5) .o_kanban_property_field:nth-child(1) span"
-        );
-        assert.equal(property1.innerText, "01/01/2019");
-        const property2 = target.querySelector(
-            ".o_kanban_record:nth-child(5) .o_kanban_property_field:nth-child(2) span"
-        );
-        assert.equal(property2.innerText, "01/01/2019 11:00:00");
-    });
+            // check fifth card
+            const property1 = target.querySelector(
+                ".o_kanban_record:nth-child(5) .o_kanban_property_field:nth-child(1) span"
+            );
+            assert.equal(property1.innerText, "01/01/2019");
+            const property2 = target.querySelector(
+                ".o_kanban_record:nth-child(5) .o_kanban_property_field:nth-child(2) span"
+            );
+            assert.equal(property2.innerText, "01/01/2019 11:00:00");
+        }
+    );
 
     QUnit.test(
         "properties: kanban view with multiple sources of properties definitions",
@@ -1567,6 +1570,38 @@ QUnit.module("Fields", (hooks) => {
                 ".o_kanban_record:nth-child(5) .o_kanban_property_field:nth-child(5) label"
             ).innerText,
             "My Checkbox"
+        );
+    });
+
+    QUnit.test("properties: kanban view without properties", async function (assert) {
+        serverData.models.partner.records = [
+            {
+                id: 40,
+                display_name: "first partner",
+                properties: false,
+                company_id: 37,
+            },
+        ];
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="company_id"/> <hr/>
+                            <field name="display_name"/> <hr/>
+                            <field name="properties" widget="properties"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        });
+        assert.strictEqual(
+            target.querySelector(".o_kanban_record").textContent,
+            "Company 1 first partner "
         );
     });
 


### PR DESCRIPTION
Before this commit, going into a view with a record that had no properties displayed a crash.

Why ?
If no properties exist, the value is false and was not handled.