### PR TITLE
Remove set contenteditable attribute from history plugin

### DIFF
--- a/addons/html_editor/static/src/editor/core/history_plugin.js
+++ b/addons/html_editor/static/src/editor/core/history_plugin.js
@@ -7,7 +7,6 @@ export class HistoryPlugin extends Plugin {
     static shared = ["enableObserver", "disableObserver"];
 
     setup() {
-        this.el.setAttribute("contenteditable", true);
         this.observer = new MutationObserver(() => this.handleDOMChange());
         this.enableObserver();
         this._cleanups.push(() => this.observer.disconnect());


### PR DESCRIPTION
This is done by the Editor class in `attachTo`, before starting the plugins.