### PR TITLE
Toolbar buttons and active state as props

### DIFF
--- a/addons/html_editor/static/src/editor/toolbar/toolbar.js
+++ b/addons/html_editor/static/src/editor/toolbar/toolbar.js
@@ -1,10 +1,17 @@
 /** @odoo-module */
 
-import { Component, onMounted, useRef } from "@odoo/owl";
+import { Component, onMounted, useRef, useState, useExternalListener } from "@odoo/owl";
 
 export class Toolbar extends Component {
     static template = "html_editor.Toolbar";
-    static props = { onMounted: Function, dispatch: Function, close: Function };
+    static props = {
+        onMounted: Function,
+        dispatch: Function,
+        close: Function,
+        // TODO: more specific prop validation for buttons after its format has been defined.
+        buttons: Array,
+        buttonsActiveState: Object,
+    };
 
     setup() {
         const ref = useRef("root");

--- a/addons/html_editor/static/src/editor/toolbar/toolbar.xml
+++ b/addons/html_editor/static/src/editor/toolbar/toolbar.xml
@@ -2,10 +2,16 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.Toolbar">
         <div t-ref="root" class="o-we-toolbar position-absolute bg-white d-flex align-items-center" style="width:300px;height:40px">
-            <div class="btn btn-light fa fa-bold fa-fw ps-1 pe-3 mx-1" title="Toggle bold" t-on-click="() => this.dispatch('TOGGLE_BOLD')"/>
-            <div class="btn btn-light fa fa-italic fa-fw ps-1 pe-3 mx-1" title="Toggle italic" t-on-click="() => this.dispatch('TOGGLE_ITALIC')"/>
-            <div class="btn btn-light fa fa-underline fa-fw ps-1 pe-3 mx-1" title="Toggle underline" t-on-click="() => this.dispatch('TOGGLE_UNDERLINE')"/>
-            <div class="btn btn-light fa fa-strikethrough fa-fw ps-1 pe-3 mx-1" title="Toggle strikethrough" t-on-click="() => this.dispatch('TOGGLE_STRIKETHROUGH')"/>
+            <t t-foreach="props.buttons" t-as="button" t-key="button.id">
+                <div
+                    class="btn btn-light fa fa-fw ps-1 pe-3 mx-1"
+                    t-att-class="{
+                        [button.icon]: true,
+                        active: props.buttonsActiveState[button.id]
+                    }"
+                    t-att-title="button.name"
+                    t-on-click="() => this.dispatch(button.cmd)"/>
+            </t>
         </div>
     </t>
 </templates>

--- a/addons/html_editor/static/src/editor/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/editor/toolbar/toolbar_plugin.js
@@ -2,14 +2,64 @@
 
 import { Plugin } from "../plugin";
 import { Toolbar } from "./toolbar";
+import { reactive } from "@odoo/owl";
+
+// TODO: This comes from a command registry?
+const buttons = [
+    {
+        id: "bold",
+        cmd: "TOGGLE_BOLD",
+        icon: "fa-bold",
+        name: "Toggle bold",
+        isFormatApplied: hasTag("strong"),
+    },
+    {
+        id: "italic",
+        cmd: "TOGGLE_ITALIC",
+        icon: "fa-italic",
+        name: "Toggle italic",
+        isFormatApplied: hasTag("em"),
+    },
+    {
+        id: "underline",
+        cmd: "TOGGLE_UNDERLINE",
+        icon: "fa-underline",
+        name: "Toggle underline",
+        isFormatApplied: hasTag("u"),
+    },
+    {
+        id: "strikethrough",
+        cmd: "TOGGLE_STRIKETHROUGH",
+        icon: "fa-strikethrough",
+        name: "Toggle strikethrough",
+        isFormatApplied: hasTag("s"),
+    },
+];
+
+// TODO: This is a temporary naive solution to generate isFormatApplied callback.
+function hasTag(tagName) {
+    return (range) => {
+        let el = range.startContainer;
+        if (el.nodeType !== Node.ELEMENT_NODE) {
+            el = el.parentElement;
+        }
+        return !!el.closest(tagName);
+    };
+}
 
 export class ToolbarPlugin extends Plugin {
     static name = "toolbar";
     static dependencies = ["overlay"];
 
     setup() {
+        this.buttons = buttons;
+        this.buttonsActiveState = reactive(Object.fromEntries(this.buttons.map(b => [b.id, false])));
         /** @type {import("../core/overlay_plugin").Overlay} */
-        this.overlay = this.shared.createOverlay(Toolbar, "top", { dispatch: this.dispatch });
+        this.overlay = this.shared.createOverlay(Toolbar, "top", {
+            dispatch: this.dispatch,
+            buttons: this.buttons,
+            buttonsActiveState: this.buttonsActiveState,
+        });
         this.addDomListener(document, "selectionchange", this.handleSelectionChange);
     }
 
@@ -28,6 +78,13 @@ export class ToolbarPlugin extends Plugin {
 
     handleSelectionChange() {
         const range = window.getSelection().getRangeAt(0);
+        this.updateToolbarVisibility(range);
+        if (this.overlay.isOpen) {
+            this.updateButtonsActiveState(range);
+        }
+    }
+
+    updateToolbarVisibility(range) {
         const inEditor = this.el.contains(range.commonAncestorContainer);
         if (this.overlay.isOpen) {
             if (!inEditor || range.collapsed) {
@@ -37,6 +94,12 @@ export class ToolbarPlugin extends Plugin {
             }
         } else if (inEditor && !range.collapsed) {
             this.overlay.open();
+        }
+    }
+
+    updateButtonsActiveState(range) {
+        for (const button of this.buttons) {
+            this.buttonsActiveState[button.id] = button.isFormatApplied(range);
         }
     }
 }


### PR DESCRIPTION
- Replace hardcoded buttons in the toolbar template for a list of buttons
    received as props.

- Buttons active state managed by the toolbar plugin.