### PR TITLE
rename powerbox_commands to phoenix_commands

### DIFF
--- a/addons/html_editor/static/src/editor/powerbox/commands.js
+++ b/addons/html_editor/static/src/editor/powerbox/commands.js
@@ -10,7 +10,7 @@ registry
     .add("format", { name: _t("Format") });
 
 registry
-    .category("powerbox_commands")
+    .category("phoenix_commands")
     // 'structure' commands
     .add("bulleted_list", {
         name: _t("Bulleted list"),

--- a/addons/html_editor/static/src/editor/powerbox/powerbox.js
+++ b/addons/html_editor/static/src/editor/powerbox/powerbox.js
@@ -6,7 +6,7 @@ import { fuzzyLookup } from "@web/core/utils/search";
 import { rotate } from "@web/core/utils/arrays";
 
 const categories = registry.category("powerbox_categories");
-const commands = registry.category("powerbox_commands");
+const commands = registry.category("phoenix_commands");
 
 export class Powerbox extends Component {
     static template = "html_editor.Powerbox";

--- a/addons/html_editor/static/src/editor/table/commands.js
+++ b/addons/html_editor/static/src/editor/table/commands.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("powerbox_commands").add("table", {
+registry.category("phoenix_commands").add("table", {
     name: _t("Table"),
     description: _t("Insert a table"),
     category: "structure",


### PR DESCRIPTION
As those commands will not only be used in powerbox, it does not make sense to relate them to the powerbox.