### PR TITLE
fix parseHTML

### DIFF
--- a/addons/html_editor/static/src/editor/utils/html.js
+++ b/addons/html_editor/static/src/editor/utils/html.js
@@ -2,7 +2,7 @@
 
 export function parseHTML(document, html) {
     const fragment = document.createDocumentFragment();
-    const parser = new DOMParser();
+    const parser = new document.defaultView.DOMParser();
     const parsedDocument = parser.parseFromString(html, "text/html");
     fragment.replaceChildren(...parsedDocument.body.childNodes);
     return fragment;


### PR DESCRIPTION
This commit updates this util to its current version on stable (17.0).

The goal is to avoid mixing HTMLElements with different constructors in the resulting document fragment.