### PR TITLE
ListPlugin: merge siblings lists

### DIFF
--- a/addons/html_editor/static/src/editor/list/list_plugin.js
+++ b/addons/html_editor/static/src/editor/list/list_plugin.js
@@ -31,6 +31,9 @@ export class ListPlugin extends Plugin {
             case "TOGGLE_LIST":
                 this.toggleList(payload.type);
                 break;
+            case "SANITIZE":
+                this.mergeLists();
+                break;
         }
     }
 
@@ -72,6 +75,21 @@ export class ListPlugin extends Plugin {
                 );
             }
         }
+        this.dispatch("SANITIZE");
+    }
+
+    // @todo Naive implementation. Known issues:
+    // - merges a checklist into a unordered list
+    // - fails to merge list with pre-existing previous siblings
+    mergeLists() {
+        const restoreCursor = preserveCursor(this.document);
+        const range = this.document.getSelection().getRangeAt(0);
+        const list = closestElement(range.startContainer, "ul, ol");
+        while (list && list.nextElementSibling?.tagName === list.tagName) {
+            list.append(...list.nextElementSibling.childNodes);
+            list.nextElementSibling.remove();
+        }
+        restoreCursor();
     }
 }
 

--- a/addons/html_editor/static/src/editor/list/list_plugin.js
+++ b/addons/html_editor/static/src/editor/list/list_plugin.js
@@ -44,11 +44,11 @@ export class ListPlugin extends Plugin {
         const li = new Set();
         const blocks = new Set();
 
-        const selectedBlocks = getTraversedNodes(this.editable);
-        const deepestSelectedBlocks = selectedBlocks.filter(
-            (block) => !descendants(block).some((descendant) => selectedBlocks.includes(descendant))
+        const selectedNodes = getTraversedNodes(this.editable);
+        const deepestSelectedNodes = selectedNodes.filter(
+            (node) => !descendants(node).some((descendant) => selectedNodes.includes(descendant))
         );
-        for (const node of deepestSelectedBlocks) {
+        for (const node of deepestSelectedNodes) {
             if (
                 node.nodeType === Node.TEXT_NODE &&
                 isWhitespace(node) &&

--- a/addons/html_editor/static/tests/editor/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/editor/list/toggle_cl.test.js
@@ -397,31 +397,25 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo("should turn two paragraphs into a checklist with two items", async () => {
+        test("should turn two paragraphs into a checklist with two items", async () => {
             await testEditor({
-                removeCheckIds: true,
                 contentBefore: "<p>ab</p><p>cd[ef</p><p>gh]ij</p>",
                 stepFunction: toggleCheckList,
                 contentAfter: '<p>ab</p><ul class="o_checklist"><li>cd[ef</li><li>gh]ij</li></ul>',
             });
         });
 
-        test.todo(
-            "should turn two paragraphs in a div into a checklist with two items",
-            async () => {
-                await testEditor({
-                    removeCheckIds: true,
-                    contentBefore: "<div><p>ab[cd</p><p>ef]gh</p></div>",
-                    stepFunction: toggleCheckList,
-                    contentAfter:
-                        '<div><ul class="o_checklist"><li>ab[cd</li><li>ef]gh</li></ul></div>',
-                });
-            }
-        );
-
-        test.todo("should turn a paragraph and a checklist item into two list items", async () => {
+        test("should turn two paragraphs in a div into a checklist with two items", async () => {
             await testEditor({
-                removeCheckIds: true,
+                contentBefore: "<div><p>ab[cd</p><p>ef]gh</p></div>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<div><ul class="o_checklist"><li>ab[cd</li><li>ef]gh</li></ul></div>',
+            });
+        });
+
+        test("should turn a paragraph and a checklist item into two list items", async () => {
+            await testEditor({
                 contentBefore:
                     '<p>a[b</p><ul class="o_checklist"><li class="o_checked">c]d</li><li>ef</li></ul>',
                 stepFunction: toggleCheckList,
@@ -429,7 +423,6 @@ describe("Range not collapsed", () => {
                     '<ul class="o_checklist"><li>a[b</li><li class="o_checked">c]d</li><li>ef</li></ul>',
             });
             await testEditor({
-                removeCheckIds: true,
                 contentBefore:
                     '<p>a[b</p><ul class="o_checklist"><li class="o_checked">c]d</li><li class="o_checked">ef</li></ul>',
                 stepFunction: toggleCheckList,
@@ -438,9 +431,8 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo("should turn a checklist item and a paragraph into two list items", async () => {
+        test("should turn a checklist item and a paragraph into two list items", async () => {
             await testEditor({
-                removeCheckIds: true,
                 contentBefore:
                     '<ul class="o_checklist"><li>ab</li><li class="o_checked">c[d</li></ul><p>e]f</p>',
                 stepFunction: toggleCheckList,
@@ -449,19 +441,15 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo(
-            "should turn a checklist, a paragraph and another list into one list with three list items",
-            async () => {
-                await testEditor({
-                    removeCheckIds: true,
-                    contentBefore:
-                        '<ul class="o_checklist"><li>a[b</li></ul><p>cd</p><ul class="o_checklist"><li class="o_checked">e]f</li></ul>',
-                    stepFunction: toggleCheckList,
-                    contentAfter:
-                        '<ul class="o_checklist"><li>a[b</li><li>cd</li><li class="o_checked">e]f</li></ul>',
-                });
-            }
-        );
+        test("should turn a checklist, a paragraph and another list into one list with three list items", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li>a[b</li></ul><p>cd</p><ul class="o_checklist"><li class="o_checked">e]f</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li>a[b</li><li>cd</li><li class="o_checked">e]f</li></ul>',
+            });
+        });
 
         test.todo(
             "should turn a checklist item, a paragraph and another list into one list with all three as list items",
@@ -477,19 +465,15 @@ describe("Range not collapsed", () => {
             }
         );
 
-        test.todo(
-            "should turn a checklist, a paragraph and a checklist item into one list with all three as list items",
-            async () => {
-                await testEditor({
-                    removeCheckIds: true,
-                    contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">a[b</li></ul><p>cd</p><ul class="o_checklist"><li class="o_checked">e]f</li><li>gh</li></ul>',
-                    stepFunction: toggleCheckList,
-                    contentAfter:
-                        '<ul class="o_checklist"><li class="o_checked">a[b</li><li>cd</li><li class="o_checked">e]f</li><li>gh</li></ul>',
-                });
-            }
-        );
+        test("should turn a checklist, a paragraph and a checklist item into one list with all three as list items", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li class="o_checked">a[b</li></ul><p>cd</p><ul class="o_checklist"><li class="o_checked">e]f</li><li>gh</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li class="o_checked">a[b</li><li>cd</li><li class="o_checked">e]f</li><li>gh</li></ul>',
+            });
+        });
     });
     describe("Remove", () => {
         test("should turn a checklist into a paragraph", async () => {

--- a/addons/html_editor/static/tests/editor/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/editor/list/toggle_ol.test.js
@@ -230,7 +230,7 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo("should turn two paragraphs into a list with two items", async () => {
+        test("should turn two paragraphs into a list with two items", async () => {
             await testEditor({
                 contentBefore: "<p>ab</p><p>cd[ef</p><p>gh]ij</p>",
                 stepFunction: toggleOrderedList,
@@ -238,7 +238,7 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo("should turn two paragraphs in a div into a list with two items", async () => {
+        test("should turn two paragraphs in a div into a list with two items", async () => {
             await testEditor({
                 contentBefore: "<div><p>ab[cd</p><p>ef]gh</p></div>",
                 stepFunction: toggleOrderedList,
@@ -246,7 +246,7 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo("should turn a paragraph and a list item into two list items", async () => {
+        test("should turn a paragraph and a list item into two list items", async () => {
             await testEditor({
                 contentBefore: "<p>a[b</p><ol><li>c]d</li><li>ef</li></ol>",
                 stepFunction: toggleOrderedList,
@@ -254,7 +254,7 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo("should turn a list item and a paragraph into two list items", async () => {
+        test("should turn a list item and a paragraph into two list items", async () => {
             await testEditor({
                 contentBefore: "<ol><li>ab</li><li>c[d</li></ol><p>e]f</p>",
                 stepFunction: toggleOrderedList,
@@ -262,16 +262,13 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo(
-            "should turn a list, a paragraph and another list into one list with three list items",
-            async () => {
-                await testEditor({
-                    contentBefore: "<ol><li>a[b</li></ol><p>cd</p><ol><li>e]f</li></ol>",
-                    stepFunction: toggleOrderedList,
-                    contentAfter: "<ol><li>a[b</li><li>cd</li><li>e]f</li></ol>",
-                });
-            }
-        );
+        test("should turn a list, a paragraph and another list into one list with three list items", async () => {
+            await testEditor({
+                contentBefore: "<ol><li>a[b</li></ol><p>cd</p><ol><li>e]f</li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>a[b</li><li>cd</li><li>e]f</li></ol>",
+            });
+        });
 
         test.todo(
             "should turn a list item, a paragraph and another list into one list with all three as list items",
@@ -284,16 +281,13 @@ describe("Range not collapsed", () => {
             }
         );
 
-        test.todo(
-            "should turn a list, a paragraph and a list item into one list with all three as list items",
-            async () => {
-                await testEditor({
-                    contentBefore: "<ol><li>a[b</li></ol><p>cd</p><ol><li>e]f</li><li>gh</li></ol>",
-                    stepFunction: toggleOrderedList,
-                    contentAfter: "<ol><li>a[b</li><li>cd</li><li>e]f</li><li>gh</li></ol>",
-                });
-            }
-        );
+        test("should turn a list, a paragraph and a list item into one list with all three as list items", async () => {
+            await testEditor({
+                contentBefore: "<ol><li>a[b</li></ol><p>cd</p><ol><li>e]f</li><li>gh</li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>a[b</li><li>cd</li><li>e]f</li><li>gh</li></ol>",
+            });
+        });
     });
     describe("Remove", () => {
         test("should turn a list into a paragraph", async () => {

--- a/addons/html_editor/static/tests/editor/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/editor/list/toggle_ul.test.js
@@ -289,7 +289,7 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo("should turn two paragraphs into a list with two items", async () => {
+        test("should turn two paragraphs into a list with two items", async () => {
             await testEditor({
                 contentBefore: "<p>ab</p><p>cd[ef</p><p>gh]ij</p>",
                 stepFunction: toggleUnorderedList,
@@ -297,7 +297,7 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo("should turn two paragraphs in a div into a list with two items", async () => {
+        test("should turn two paragraphs in a div into a list with two items", async () => {
             await testEditor({
                 contentBefore: "<div><p>ab[cd</p><p>ef]gh</p></div>",
                 stepFunction: toggleUnorderedList,
@@ -305,7 +305,7 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo("should turn a paragraph and a list item into two list items", async () => {
+        test("should turn a paragraph and a list item into two list items", async () => {
             await testEditor({
                 contentBefore: "<p>a[b</p><ul><li>c]d</li><li>ef</li></ul>",
                 stepFunction: toggleUnorderedList,
@@ -313,7 +313,7 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo("should turn a list item and a paragraph into two list items", async () => {
+        test("should turn a list item and a paragraph into two list items", async () => {
             await testEditor({
                 contentBefore: "<ul><li>ab</li><li>c[d</li></ul><p>e]f</p>",
                 stepFunction: toggleUnorderedList,
@@ -321,16 +321,13 @@ describe("Range not collapsed", () => {
             });
         });
 
-        test.todo(
-            "should turn a list, a paragraph and another list into one list with three list items",
-            async () => {
-                await testEditor({
-                    contentBefore: "<ul><li>a[b</li></ul><p>cd</p><ul><li>e]f</li></ul>",
-                    stepFunction: toggleUnorderedList,
-                    contentAfter: "<ul><li>a[b</li><li>cd</li><li>e]f</li></ul>",
-                });
-            }
-        );
+        test("should turn a list, a paragraph and another list into one list with three list items", async () => {
+            await testEditor({
+                contentBefore: "<ul><li>a[b</li></ul><p>cd</p><ul><li>e]f</li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>a[b</li><li>cd</li><li>e]f</li></ul>",
+            });
+        });
 
         test.todo(
             "should turn a list item, a paragraph and another list into one list with all three as list items",
@@ -343,16 +340,13 @@ describe("Range not collapsed", () => {
             }
         );
 
-        test.todo(
-            "should turn a list, a paragraph and a list item into one list with all three as list items",
-            async () => {
-                await testEditor({
-                    contentBefore: "<ul><li>a[b</li></ul><p>cd</p><ul><li>e]f</li><li>gh</li></ul>",
-                    stepFunction: toggleUnorderedList,
-                    contentAfter: "<ul><li>a[b</li><li>cd</li><li>e]f</li><li>gh</li></ul>",
-                });
-            }
-        );
+        test("should turn a list, a paragraph and a list item into one list with all three as list items", async () => {
+            await testEditor({
+                contentBefore: "<ul><li>a[b</li></ul><p>cd</p><ul><li>e]f</li><li>gh</li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>a[b</li><li>cd</li><li>e]f</li><li>gh</li></ul>",
+            });
+        });
 
         test("should not turn a non-editable paragraph into a list", async () => {
             await testEditor({


### PR DESCRIPTION
When converting multiple paragraphs into a list, in a first moment multiple UL are
created.

In web_editor's current code, the sibling lists are then merged into a single
list by `sanitize`.

This commit makes sure the ListPlugin does the whole job.