### PR TITLE
[IMP] t9n: add tab in the menu to list available projects.

### DIFF
--- a/addons/t9n/__manifest__.py
+++ b/addons/t9n/__manifest__.py
@@ -4,14 +4,17 @@
     "category": "TODO: find the appropriate category",
     "description": "TODO: write a description of the module",
     "depends": ["base", "web"],
-    "data": [
-        "views/t9n_templates.xml"
-    ],
     "application": True,
     "assets": {
         "web.assets_backend": [
             "t9n/static/src/**/*",
         ],
     },
+    "data": [
+        "security/ir.model.access.csv",
+        "views/t9n_templates.xml",
+        "views/t9n_project_views.xml",
+        "views/t9n_menus_views.xml",
+    ],
     "license": "LGPL-3",
 }

--- a/addons/t9n/models/language.py
+++ b/addons/t9n/models/language.py
@@ -4,3 +4,5 @@ from odoo import fields, models
 class Language(models.Model):
     _name = "t9n.language"
     _description = "Language"
+
+    name = fields.Char('Language', required=True)

--- a/addons/t9n/models/project.py
+++ b/addons/t9n/models/project.py
@@ -1,4 +1,5 @@
-from odoo import fields, models
+from odoo import fields, models, api, _
+from odoo.exceptions import ValidationError
 
 
 class Project(models.Model):
@@ -8,6 +9,7 @@ class Project(models.Model):
     _name = "t9n.project"
     _description = "Translation project"
 
+    name = fields.Char('Project', required=True)
     src_lang_id = fields.Many2one(
         comodel_name="t9n.language",
         string="Source Language",
@@ -23,3 +25,10 @@ class Project(models.Model):
         string="Languages",
         help="The list of languages into which the project can be translated.",
     )
+
+    @api.constrains('src_lang_id', 'target_lang_ids')
+    def _check_source_and_target_languages(self):
+        for record in self:
+            if record.src_lang_id in record.target_lang_ids:
+                raise ValidationError(
+                    _("The source language can not be one of the target languages."))

--- a/addons/t9n/models/resource.py
+++ b/addons/t9n/models/resource.py
@@ -5,6 +5,7 @@ class Resource(models.Model):
     _name = "t9n.resource"
     _description = "Resource file"
 
+    name = fields.Char('Resource')
     message_ids = fields.One2many(
         comodel_name="t9n.message",
         inverse_name="resource_id",

--- a/addons/t9n/security/ir.model.access.csv
+++ b/addons/t9n/security/ir.model.access.csv
@@ -1,1 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_t9n_project_system,t9n.project.system,t9n.model_t9n_project,base.group_system,1,1,1,1
+access_t9n_language_system,t9n.language.system,t9n.model_t9n_language,base.group_system,1,1,1,1
+access_t9n_message_system,t9n.message.system,t9n.model_t9n_message,base.group_system,1,1,1,1
+access_t9n_resource_system,t9n.resource.system,t9n.model_t9n_resource,base.group_system,1,1,1,1
+access_t9n_translation_system,t9n.translation.system,t9n.model_t9n_translation,base.group_system,1,1,1,1

--- a/addons/t9n/views/t9n_menus_views.xml
+++ b/addons/t9n/views/t9n_menus_views.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<odoo>
+    <menuitem id="t9n.project_menu" name="Projects" action="t9n.project_action" parent="t9n.menu_root"/>
+</odoo>

--- a/addons/t9n/views/t9n_project_views.xml
+++ b/addons/t9n/views/t9n_project_views.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="t9n.project_action" model="ir.actions.act_window">
+        <field name="name">Projects</field>
+        <field name="res_model">t9n.project</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record id="t9n.project_view_form" model="ir.ui.view">
+        <field name="name">t9n.project.form</field>
+        <field name="model">t9n.project</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <h1>
+                        <field name="name"/>
+                    </h1>
+                    <notebook>
+                        <page string="Resources">
+                            <field name="resource_ids"/>
+                        </page>
+                        <page string="Description">
+                            <group>
+                                <group>
+                                    <field name="src_lang_id" domain="['!', ('id', 'in', target_lang_ids)]"/>
+                                    <field name="target_lang_ids" domain="[('id', '!=', src_lang_id)]"/>
+                                </group>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This commit adds a tab in the menu bar that lists the available projects. Also, the form view of the project is configured to have two tabs: one for the resources and the other one for the description of the project. Also, security permissions have been included in the manifest file. A tag model has been added for the future as it will be used to tag the message model.