### PR TITLE
RM shared methods from history plugin

### DIFF
--- a/addons/html_editor/static/src/editor/core/history_plugin.js
+++ b/addons/html_editor/static/src/editor/core/history_plugin.js
@@ -5,12 +5,7 @@ import { getCommonAncestor } from "../utils/dom_traversal";
 export class HistoryPlugin extends Plugin {
     static name = "history";
     static dependencies = ["dom", "selection"];
-    static shared = [
-        "getCurrentMutations",
-        "revertCurrentMutationsUntil",
-        "handleObserverRecords",
-        "makeSavePoint",
-    ];
+    static shared = ["makeSavePoint"];
     static resources = () => ({
         shortcuts: [
             { hotkey: "control+z", command: "HISTORY_UNDO" },
@@ -320,9 +315,6 @@ export class HistoryPlugin extends Plugin {
             }
         }
     }
-    getCurrentMutations() {
-        return [...this.currentStep.mutations];
-    }
 
     setNodeId(node) {
         let id = this.nodeToIdMap.get(node);
@@ -574,10 +566,6 @@ export class HistoryPlugin extends Plugin {
                 }
             }
         }
-    }
-    revertCurrentMutationsUntil(index) {
-        const mutationToRevert = this.currentStep.mutations.splice(index);
-        this.revertMutations(mutationToRevert);
     }
 
     serializeSelection(selection, nodeToIdMap) {

--- a/addons/html_editor/static/src/editor/plugin.js
+++ b/addons/html_editor/static/src/editor/plugin.js
@@ -8,9 +8,6 @@
  *
  * @typedef { Object } SharedMethods
  *
- * @property { HistoryPlugin['getCurrentMutations'] } getCurrentMutations
- * @property { HistoryPlugin['revertCurrentMutationsUntil'] } revertCurrentMutationsUntil
- * @property { HistoryPlugin['handleObserverRecords'] } handleObserverRecords
  * @property { HistoryPlugin['makeSavePoint'] } makeSavePoint
  * @property { SelectionPlugin['getEditableSelection'] } getEditableSelection
  * @property { SelectionPlugin['setSelection'] } setSelection


### PR DESCRIPTION
Crossing out the following TODO from the pad:
history plugin: try to remove `getCurrentMutations`, `revertCurrentMutationsUntil` and `handleObserverRecords`**

** `handleObserverRecords` was not removed, but it is no longer shared.
