### PR TITLE
[IMP] t9n: add languages data when initializing the module.

### DIFF
--- a/addons/t9n/__manifest__.py
+++ b/addons/t9n/__manifest__.py
@@ -11,9 +11,11 @@
         ],
     },
     "data": [
+        "data/t9n.language.csv",
         "security/ir.model.access.csv",
         "views/t9n_project_views.xml",
         "views/t9n_menu_views.xml",
+        "views/t9n_language_views.xml",
     ],
     "license": "LGPL-3",
 }

--- a/addons/t9n/data/t9n.language.csv
+++ b/addons/t9n/data/t9n.language.csv
@@ -1,0 +1,723 @@
+id,code,name,native_name,direction
+t9n_lang_af,af,Afrikaans,Afrikaans,ltr
+t9n_lang_af_NA,af_NA,Afrikaans (Namibia),Afrikaans (Namibië),ltr
+t9n_lang_af_ZA,af_ZA,Afrikaans (South Africa),Afrikaans (Suid-Afrika),ltr
+t9n_lang_agq,agq,Aghem,Aghem,ltr
+t9n_lang_agq_CM,agq_CM,Aghem (Cameroon),Aghem (Kàmàlûŋ),ltr
+t9n_lang_ak,ak,Akan,Akan,ltr
+t9n_lang_ak_GH,ak_GH,Akan (Ghana),Akan (Gaana),ltr
+t9n_lang_am,am,Amharic,አማርኛ,ltr
+t9n_lang_am_ET,am_ET,Amharic (Ethiopia),አማርኛ (ኢትዮጵያ),ltr
+t9n_lang_ar,ar,Arabic,العربية,rtl
+t9n_lang_ar_001,ar_001,Arabic (World),العربية (العالم),rtl
+t9n_lang_ar_AE,ar_AE,Arabic (United Arab Emirates),العربية (الإمارات العربية المتحدة),rtl
+t9n_lang_ar_BH,ar_BH,Arabic (Bahrain),العربية (البحرين),rtl
+t9n_lang_ar_DJ,ar_DJ,Arabic (Djibouti),العربية (جيبوتي),rtl
+t9n_lang_ar_DZ,ar_DZ,Arabic (Algeria),العربية (الجزائر),rtl
+t9n_lang_ar_EG,ar_EG,Arabic (Egypt),العربية (مصر),rtl
+t9n_lang_ar_EH,ar_EH,Arabic (Western Sahara),العربية (الصحراء الغربية),rtl
+t9n_lang_ar_ER,ar_ER,Arabic (Eritrea),العربية (إريتريا),rtl
+t9n_lang_ar_IL,ar_IL,Arabic (Israel),العربية (إسرائيل),rtl
+t9n_lang_ar_IQ,ar_IQ,Arabic (Iraq),العربية (العراق),rtl
+t9n_lang_ar_JO,ar_JO,Arabic (Jordan),العربية (الأردن),rtl
+t9n_lang_ar_KM,ar_KM,Arabic (Comoros),العربية (جزر القمر),rtl
+t9n_lang_ar_KW,ar_KW,Arabic (Kuwait),العربية (الكويت),rtl
+t9n_lang_ar_LB,ar_LB,Arabic (Lebanon),العربية (لبنان),rtl
+t9n_lang_ar_LY,ar_LY,Arabic (Libya),العربية (ليبيا),rtl
+t9n_lang_ar_MA,ar_MA,Arabic (Morocco),العربية (المغرب),rtl
+t9n_lang_ar_MR,ar_MR,Arabic (Mauritania),العربية (موريتانيا),rtl
+t9n_lang_ar_OM,ar_OM,Arabic (Oman),العربية (عُمان),rtl
+t9n_lang_ar_PS,ar_PS,Arabic (Palestinian Territories),العربية (الأراضي الفلسطينية),rtl
+t9n_lang_ar_QA,ar_QA,Arabic (Qatar),العربية (قطر),rtl
+t9n_lang_ar_SA,ar_SA,Arabic (Saudi Arabia),العربية (المملكة العربية السعودية),rtl
+t9n_lang_ar_SD,ar_SD,Arabic (Sudan),العربية (السودان),rtl
+t9n_lang_ar_SO,ar_SO,Arabic (Somalia),العربية (الصومال),rtl
+t9n_lang_ar_SS,ar_SS,Arabic (South Sudan),العربية (جنوب السودان),rtl
+t9n_lang_ar_SY,ar_SY,Arabic (Syria),العربية (سوريا),rtl
+t9n_lang_ar_TD,ar_TD,Arabic (Chad),العربية (تشاد),rtl
+t9n_lang_ar_TN,ar_TN,Arabic (Tunisia),العربية (تونس),rtl
+t9n_lang_ar_YE,ar_YE,Arabic (Yemen),العربية (اليمن),rtl
+t9n_lang_as,as,Assamese,অসমীয়া,ltr
+t9n_lang_as_IN,as_IN,Assamese (India),অসমীয়া (ভারত),ltr
+t9n_lang_asa,asa,Asu,Kipare,ltr
+t9n_lang_asa_TZ,asa_TZ,Asu (Tanzania),Kipare (Tadhania),ltr
+t9n_lang_ast,ast,Asturian,asturianu,ltr
+t9n_lang_ast_ES,ast_ES,Asturian (Spain),asturianu (España),ltr
+t9n_lang_az,az,Azerbaijani,azərbaycan,ltr
+t9n_lang_az_Cyrl,az_Cyrl,Azerbaijani (Cyrillic),азәрбајҹан (Кирил),ltr
+t9n_lang_az_Cyrl_AZ,az_Cyrl_AZ,"Azerbaijani (Cyrillic, Azerbaijan)","азәрбајҹан (Кирил, Азәрбајҹан)",ltr
+t9n_lang_az_Latn,az_Latn,Azerbaijani (Latin),azərbaycan (latın),ltr
+t9n_lang_az_Latn_AZ,az_Latn_AZ,"Azerbaijani (Latin, Azerbaijan)","azərbaycan (latın, Azərbaycan)",ltr
+t9n_lang_bas,bas,Basaa,Ɓàsàa,ltr
+t9n_lang_bas_CM,bas_CM,Basaa (Cameroon),Ɓàsàa (Kàmɛ̀rûn),ltr
+t9n_lang_be,be,Belarusian,беларуская,ltr
+t9n_lang_be_BY,be_BY,Belarusian (Belarus),беларуская (Беларусь),ltr
+t9n_lang_bem,bem,Bemba,Ichibemba,ltr
+t9n_lang_bem_ZM,bem_ZM,Bemba (Zambia),Ichibemba (Zambia),ltr
+t9n_lang_bez,bez,Bena,Hibena,ltr
+t9n_lang_bez_TZ,bez_TZ,Bena (Tanzania),Hibena (Hutanzania),ltr
+t9n_lang_bg,bg,Bulgarian,български,ltr
+t9n_lang_bg_BG,bg_BG,Bulgarian (Bulgaria),български (България),ltr
+t9n_lang_bm,bm,Bambara,bamanakan,ltr
+t9n_lang_bm_ML,bm_ML,Bambara (Mali),bamanakan (Mali),ltr
+t9n_lang_bn,bn,Bangla,বাংলা,ltr
+t9n_lang_bn_BD,bn_BD,Bangla (Bangladesh),বাংলা (বাংলাদেশ),ltr
+t9n_lang_bn_IN,bn_IN,Bangla (India),বাংলা (ভারত),ltr
+t9n_lang_bo,bo,Tibetan,བོད་སྐད་,ltr
+t9n_lang_bo_CN,bo_CN,Tibetan (China),བོད་སྐད་ (རྒྱ་ནག),ltr
+t9n_lang_bo_IN,bo_IN,Tibetan (India),བོད་སྐད་ (རྒྱ་གར་),ltr
+t9n_lang_br,br,Breton,brezhoneg,ltr
+t9n_lang_br_FR,br_FR,Breton (France),brezhoneg (Frañs),ltr
+t9n_lang_brx,brx,Bodo,बड़ो,ltr
+t9n_lang_brx_IN,brx_IN,Bodo (India),बड़ो (भारत),ltr
+t9n_lang_bs,bs,Bosnian,bosanski,ltr
+t9n_lang_bs_Cyrl,bs_Cyrl,Bosnian (Cyrillic),босански (ћирилица),ltr
+t9n_lang_bs_Cyrl_BA,bs_Cyrl_BA,"Bosnian (Cyrillic, Bosnia & Herzegovina)","босански (ћирилица, Босна и Херцеговина)",ltr
+t9n_lang_bs_Latn,bs_Latn,Bosnian (Latin),bosanski (latinica),ltr
+t9n_lang_bs_Latn_BA,bs_Latn_BA,"Bosnian (Latin, Bosnia & Herzegovina)","bosanski (latinica, Bosna i Hercegovina)",ltr
+t9n_lang_ca,ca,Catalan,català,ltr
+t9n_lang_ca_AD,ca_AD,Catalan (Andorra),català (Andorra),ltr
+t9n_lang_ca_ES,ca_ES,Catalan (Spain),català (Espanya),ltr
+t9n_lang_ca_FR,ca_FR,Catalan (France),català (França),ltr
+t9n_lang_ca_IT,ca_IT,Catalan (Italy),català (Itàlia),ltr
+t9n_lang_ccp,ccp,Chakma,𑄌𑄋𑄴𑄟𑄳𑄦,ltr
+t9n_lang_ccp_BD,ccp_BD,Chakma (Bangladesh),𑄌𑄋𑄴𑄟𑄳𑄦 (𑄝𑄁𑄣𑄘𑄬𑄌𑄴),ltr
+t9n_lang_ccp_IN,ccp_IN,Chakma (India),𑄌𑄋𑄴𑄟𑄳𑄦 (𑄞𑄢𑄧𑄖𑄴),ltr
+t9n_lang_ce,ce,Chechen,нохчийн,ltr
+t9n_lang_ce_RU,ce_RU,Chechen (Russia),нохчийн (Росси),ltr
+t9n_lang_cgg,cgg,Chiga,Rukiga,ltr
+t9n_lang_cgg_UG,cgg_UG,Chiga (Uganda),Rukiga (Uganda),ltr
+t9n_lang_chr,chr,Cherokee,ᏣᎳᎩ,ltr
+t9n_lang_chr_US,chr_US,Cherokee (United States),ᏣᎳᎩ (ᏌᏊ ᎢᏳᎾᎵᏍᏔᏅ ᏍᎦᏚᎩ),ltr
+t9n_lang_ckb,ckb,Central Kurdish,کوردیی ناوەندی,rtl
+t9n_lang_ckb_IQ,ckb_IQ,Central Kurdish (Iraq),کوردیی ناوەندی (عێراق),rtl
+t9n_lang_ckb_IR,ckb_IR,Central Kurdish (Iran),کوردیی ناوەندی (ئێران),rtl
+t9n_lang_cs,cs,Czech,čeština,ltr
+t9n_lang_cs_CZ,cs_CZ,Czech (Czechia),čeština (Česko),ltr
+t9n_lang_cy,cy,Welsh,Cymraeg,ltr
+t9n_lang_cy_GB,cy_GB,Welsh (United Kingdom),Cymraeg (Y Deyrnas Unedig),ltr
+t9n_lang_da,da,Danish,dansk,ltr
+t9n_lang_da_DK,da_DK,Danish (Denmark),dansk (Danmark),ltr
+t9n_lang_da_GL,da_GL,Danish (Greenland),dansk (Grønland),ltr
+t9n_lang_dav,dav,Taita,Kitaita,ltr
+t9n_lang_dav_KE,dav_KE,Taita (Kenya),Kitaita (Kenya),ltr
+t9n_lang_de,de,German,Deutsch,ltr
+t9n_lang_de_AT,de_AT,German (Austria),Deutsch (Österreich),ltr
+t9n_lang_de_BE,de_BE,German (Belgium),Deutsch (Belgien),ltr
+t9n_lang_de_CH,de_CH,German (Switzerland),Deutsch (Schweiz),ltr
+t9n_lang_de_DE,de_DE,German (Germany),Deutsch (Deutschland),ltr
+t9n_lang_de_IT,de_IT,German (Italy),Deutsch (Italien),ltr
+t9n_lang_de_LI,de_LI,German (Liechtenstein),Deutsch (Liechtenstein),ltr
+t9n_lang_de_LU,de_LU,German (Luxembourg),Deutsch (Luxemburg),ltr
+t9n_lang_dje,dje,Zarma,Zarmaciine,ltr
+t9n_lang_dje_NE,dje_NE,Zarma (Niger),Zarmaciine (Nižer),ltr
+t9n_lang_dsb,dsb,Lower Sorbian,dolnoserbšćina,ltr
+t9n_lang_dsb_DE,dsb_DE,Lower Sorbian (Germany),dolnoserbšćina (Nimska),ltr
+t9n_lang_dua,dua,Duala,duálá,ltr
+t9n_lang_dua_CM,dua_CM,Duala (Cameroon),duálá (Cameroun),ltr
+t9n_lang_dyo,dyo,Jola-Fonyi,joola,ltr
+t9n_lang_dyo_SN,dyo_SN,Jola-Fonyi (Senegal),joola (Senegal),ltr
+t9n_lang_dz,dz,Dzongkha,རྫོང་ཁ,ltr
+t9n_lang_dz_BT,dz_BT,Dzongkha (Bhutan),རྫོང་ཁ། (འབྲུག།),ltr
+t9n_lang_ebu,ebu,Embu,Kĩembu,ltr
+t9n_lang_ebu_KE,ebu_KE,Embu (Kenya),Kĩembu (Kenya),ltr
+t9n_lang_ee,ee,Ewe,Eʋegbe,ltr
+t9n_lang_ee_GH,ee_GH,Ewe (Ghana),Eʋegbe (Ghana nutome),ltr
+t9n_lang_ee_TG,ee_TG,Ewe (Togo),Eʋegbe (Togo nutome),ltr
+t9n_lang_el,el,Greek,Ελληνικά,ltr
+t9n_lang_el_CY,el_CY,Greek (Cyprus),Ελληνικά (Κύπρος),ltr
+t9n_lang_el_GR,el_GR,Greek (Greece),Ελληνικά (Ελλάδα),ltr
+t9n_lang_en,en,English,English,ltr
+t9n_lang_en_001,en_001,English (World),English (World),ltr
+t9n_lang_en_150,en_150,English (Europe),English (Europe),ltr
+t9n_lang_en_AG,en_AG,English (Antigua & Barbuda),English (Antigua & Barbuda),ltr
+t9n_lang_en_AI,en_AI,English (Anguilla),English (Anguilla),ltr
+t9n_lang_en_AS,en_AS,English (American Samoa),English (American Samoa),ltr
+t9n_lang_en_AT,en_AT,English (Austria),English (Austria),ltr
+t9n_lang_en_AU,en_AU,English (Australia),English (Australia),ltr
+t9n_lang_en_BB,en_BB,English (Barbados),English (Barbados),ltr
+t9n_lang_en_BE,en_BE,English (Belgium),English (Belgium),ltr
+t9n_lang_en_BI,en_BI,English (Burundi),English (Burundi),ltr
+t9n_lang_en_BM,en_BM,English (Bermuda),English (Bermuda),ltr
+t9n_lang_en_BS,en_BS,English (Bahamas),English (Bahamas),ltr
+t9n_lang_en_BW,en_BW,English (Botswana),English (Botswana),ltr
+t9n_lang_en_BZ,en_BZ,English (Belize),English (Belize),ltr
+t9n_lang_en_CA,en_CA,English (Canada),English (Canada),ltr
+t9n_lang_en_CC,en_CC,English (Cocos [Keeling] Islands),English (Cocos [Keeling] Islands),ltr
+t9n_lang_en_CH,en_CH,English (Switzerland),English (Switzerland),ltr
+t9n_lang_en_CK,en_CK,English (Cook Islands),English (Cook Islands),ltr
+t9n_lang_en_CM,en_CM,English (Cameroon),English (Cameroon),ltr
+t9n_lang_en_CX,en_CX,English (Christmas Island),English (Christmas Island),ltr
+t9n_lang_en_CY,en_CY,English (Cyprus),English (Cyprus),ltr
+t9n_lang_en_DE,en_DE,English (Germany),English (Germany),ltr
+t9n_lang_en_DG,en_DG,English (Diego Garcia),English (Diego Garcia),ltr
+t9n_lang_en_DK,en_DK,English (Denmark),English (Denmark),ltr
+t9n_lang_en_DM,en_DM,English (Dominica),English (Dominica),ltr
+t9n_lang_en_ER,en_ER,English (Eritrea),English (Eritrea),ltr
+t9n_lang_en_FI,en_FI,English (Finland),English (Finland),ltr
+t9n_lang_en_FJ,en_FJ,English (Fiji),English (Fiji),ltr
+t9n_lang_en_FK,en_FK,English (Falkland Islands),English (Falkland Islands),ltr
+t9n_lang_en_FM,en_FM,English (Micronesia),English (Micronesia),ltr
+t9n_lang_en_GB,en_GB,English (United Kingdom),English (United Kingdom),ltr
+t9n_lang_en_GD,en_GD,English (Grenada),English (Grenada),ltr
+t9n_lang_en_GG,en_GG,English (Guernsey),English (Guernsey),ltr
+t9n_lang_en_GH,en_GH,English (Ghana),English (Ghana),ltr
+t9n_lang_en_GI,en_GI,English (Gibraltar),English (Gibraltar),ltr
+t9n_lang_en_GM,en_GM,English (Gambia),English (Gambia),ltr
+t9n_lang_en_GU,en_GU,English (Guam),English (Guam),ltr
+t9n_lang_en_GY,en_GY,English (Guyana),English (Guyana),ltr
+t9n_lang_en_HK,en_HK,English (Hong Kong SAR China),English (Hong Kong SAR China),ltr
+t9n_lang_en_IE,en_IE,English (Ireland),English (Ireland),ltr
+t9n_lang_en_IL,en_IL,English (Israel),English (Israel),ltr
+t9n_lang_en_IM,en_IM,English (Isle of Man),English (Isle of Man),ltr
+t9n_lang_en_IN,en_IN,English (India),English (India),ltr
+t9n_lang_en_IO,en_IO,English (British Indian Ocean Territory),English (British Indian Ocean Territory),ltr
+t9n_lang_en_JE,en_JE,English (Jersey),English (Jersey),ltr
+t9n_lang_en_JM,en_JM,English (Jamaica),English (Jamaica),ltr
+t9n_lang_en_KE,en_KE,English (Kenya),English (Kenya),ltr
+t9n_lang_en_KI,en_KI,English (Kiribati),English (Kiribati),ltr
+t9n_lang_en_KN,en_KN,English (St. Kitts & Nevis),English (St. Kitts & Nevis),ltr
+t9n_lang_en_KY,en_KY,English (Cayman Islands),English (Cayman Islands),ltr
+t9n_lang_en_LC,en_LC,English (St. Lucia),English (St. Lucia),ltr
+t9n_lang_en_LR,en_LR,English (Liberia),English (Liberia),ltr
+t9n_lang_en_LS,en_LS,English (Lesotho),English (Lesotho),ltr
+t9n_lang_en_MG,en_MG,English (Madagascar),English (Madagascar),ltr
+t9n_lang_en_MH,en_MH,English (Marshall Islands),English (Marshall Islands),ltr
+t9n_lang_en_MO,en_MO,English (Macau SAR China),English (Macau SAR China),ltr
+t9n_lang_en_MP,en_MP,English (Northern Mariana Islands),English (Northern Mariana Islands),ltr
+t9n_lang_en_MS,en_MS,English (Montserrat),English (Montserrat),ltr
+t9n_lang_en_MT,en_MT,English (Malta),English (Malta),ltr
+t9n_lang_en_MU,en_MU,English (Mauritius),English (Mauritius),ltr
+t9n_lang_en_MW,en_MW,English (Malawi),English (Malawi),ltr
+t9n_lang_en_MY,en_MY,English (Malaysia),English (Malaysia),ltr
+t9n_lang_en_NA,en_NA,English (Namibia),English (Namibia),ltr
+t9n_lang_en_NF,en_NF,English (Norfolk Island),English (Norfolk Island),ltr
+t9n_lang_en_NG,en_NG,English (Nigeria),English (Nigeria),ltr
+t9n_lang_en_NL,en_NL,English (Netherlands),English (Netherlands),ltr
+t9n_lang_en_NR,en_NR,English (Nauru),English (Nauru),ltr
+t9n_lang_en_NU,en_NU,English (Niue),English (Niue),ltr
+t9n_lang_en_NZ,en_NZ,English (New Zealand),English (New Zealand),ltr
+t9n_lang_en_PG,en_PG,English (Papua New Guinea),English (Papua New Guinea),ltr
+t9n_lang_en_PH,en_PH,English (Philippines),English (Philippines),ltr
+t9n_lang_en_PK,en_PK,English (Pakistan),English (Pakistan),ltr
+t9n_lang_en_PN,en_PN,English (Pitcairn Islands),English (Pitcairn Islands),ltr
+t9n_lang_en_PR,en_PR,English (Puerto Rico),English (Puerto Rico),ltr
+t9n_lang_en_PW,en_PW,English (Palau),English (Palau),ltr
+t9n_lang_en_RW,en_RW,English (Rwanda),English (Rwanda),ltr
+t9n_lang_en_SB,en_SB,English (Solomon Islands),English (Solomon Islands),ltr
+t9n_lang_en_SC,en_SC,English (Seychelles),English (Seychelles),ltr
+t9n_lang_en_SD,en_SD,English (Sudan),English (Sudan),ltr
+t9n_lang_en_SE,en_SE,English (Sweden),English (Sweden),ltr
+t9n_lang_en_SG,en_SG,English (Singapore),English (Singapore),ltr
+t9n_lang_en_SH,en_SH,English (St. Helena),English (St. Helena),ltr
+t9n_lang_en_SI,en_SI,English (Slovenia),English (Slovenia),ltr
+t9n_lang_en_SL,en_SL,English (Sierra Leone),English (Sierra Leone),ltr
+t9n_lang_en_SS,en_SS,English (South Sudan),English (South Sudan),ltr
+t9n_lang_en_SX,en_SX,English (Sint Maarten),English (Sint Maarten),ltr
+t9n_lang_en_SZ,en_SZ,English (Swaziland),English (Swaziland),ltr
+t9n_lang_en_TC,en_TC,English (Turks & Caicos Islands),English (Turks & Caicos Islands),ltr
+t9n_lang_en_TK,en_TK,English (Tokelau),English (Tokelau),ltr
+t9n_lang_en_TO,en_TO,English (Tonga),English (Tonga),ltr
+t9n_lang_en_TT,en_TT,English (Trinidad & Tobago),English (Trinidad & Tobago),ltr
+t9n_lang_en_TV,en_TV,English (Tuvalu),English (Tuvalu),ltr
+t9n_lang_en_TZ,en_TZ,English (Tanzania),English (Tanzania),ltr
+t9n_lang_en_UG,en_UG,English (Uganda),English (Uganda),ltr
+t9n_lang_en_UM,en_UM,English (U.S. Outlying Islands),English (U.S. Outlying Islands),ltr
+t9n_lang_en_US,en_US,English (United States),English (United States),ltr
+t9n_lang_en_US_POSIX,en_US_POSIX,"English (United States, Computer)","English (United States, Computer)",ltr
+t9n_lang_en_VC,en_VC,English (St. Vincent & Grenadines),English (St. Vincent & Grenadines),ltr
+t9n_lang_en_VG,en_VG,English (British Virgin Islands),English (British Virgin Islands),ltr
+t9n_lang_en_VI,en_VI,English (U.S. Virgin Islands),English (U.S. Virgin Islands),ltr
+t9n_lang_en_VU,en_VU,English (Vanuatu),English (Vanuatu),ltr
+t9n_lang_en_WS,en_WS,English (Samoa),English (Samoa),ltr
+t9n_lang_en_ZA,en_ZA,English (South Africa),English (South Africa),ltr
+t9n_lang_en_ZM,en_ZM,English (Zambia),English (Zambia),ltr
+t9n_lang_en_ZW,en_ZW,English (Zimbabwe),English (Zimbabwe),ltr
+t9n_lang_eo,eo,Esperanto,esperanto,ltr
+t9n_lang_es,es,Spanish,español,ltr
+t9n_lang_es_419,es_419,Spanish (Latin America),español (Latinoamérica),ltr
+t9n_lang_es_AR,es_AR,Spanish (Argentina),español (Argentina),ltr
+t9n_lang_es_BO,es_BO,Spanish (Bolivia),español (Bolivia),ltr
+t9n_lang_es_BR,es_BR,Spanish (Brazil),español (Brasil),ltr
+t9n_lang_es_BZ,es_BZ,Spanish (Belize),español (Belice),ltr
+t9n_lang_es_CL,es_CL,Spanish (Chile),español (Chile),ltr
+t9n_lang_es_CO,es_CO,Spanish (Colombia),español (Colombia),ltr
+t9n_lang_es_CR,es_CR,Spanish (Costa Rica),español (Costa Rica),ltr
+t9n_lang_es_CU,es_CU,Spanish (Cuba),español (Cuba),ltr
+t9n_lang_es_DO,es_DO,Spanish (Dominican Republic),español (República Dominicana),ltr
+t9n_lang_es_EA,es_EA,Spanish (Ceuta & Melilla),español (Ceuta y Melilla),ltr
+t9n_lang_es_EC,es_EC,Spanish (Ecuador),español (Ecuador),ltr
+t9n_lang_es_ES,es_ES,Spanish (Spain),español (España),ltr
+t9n_lang_es_GQ,es_GQ,Spanish (Equatorial Guinea),español (Guinea Ecuatorial),ltr
+t9n_lang_es_GT,es_GT,Spanish (Guatemala),español (Guatemala),ltr
+t9n_lang_es_HN,es_HN,Spanish (Honduras),español (Honduras),ltr
+t9n_lang_es_IC,es_IC,Spanish (Canary Islands),español (Canarias),ltr
+t9n_lang_es_MX,es_MX,Spanish (Mexico),español (México),ltr
+t9n_lang_es_NI,es_NI,Spanish (Nicaragua),español (Nicaragua),ltr
+t9n_lang_es_PA,es_PA,Spanish (Panama),español (Panamá),ltr
+t9n_lang_es_PE,es_PE,Spanish (Peru),español (Perú),ltr
+t9n_lang_es_PH,es_PH,Spanish (Philippines),español (Filipinas),ltr
+t9n_lang_es_PR,es_PR,Spanish (Puerto Rico),español (Puerto Rico),ltr
+t9n_lang_es_PY,es_PY,Spanish (Paraguay),español (Paraguay),ltr
+t9n_lang_es_SV,es_SV,Spanish (El Salvador),español (El Salvador),ltr
+t9n_lang_es_US,es_US,Spanish (United States),español (Estados Unidos),ltr
+t9n_lang_es_UY,es_UY,Spanish (Uruguay),español (Uruguay),ltr
+t9n_lang_es_VE,es_VE,Spanish (Venezuela),español (Venezuela),ltr
+t9n_lang_et,et,Estonian,eesti,ltr
+t9n_lang_et_EE,et_EE,Estonian (Estonia),eesti (Eesti),ltr
+t9n_lang_eu,eu,Basque,euskara,ltr
+t9n_lang_eu_ES,eu_ES,Basque (Spain),euskara (Espainia),ltr
+t9n_lang_ewo,ewo,Ewondo,ewondo,ltr
+t9n_lang_ewo_CM,ewo_CM,Ewondo (Cameroon),ewondo (Kamərún),ltr
+t9n_lang_fa,fa,Persian,فارسی,rtl
+t9n_lang_fa_AF,fa_AF,Persian (Afghanistan),فارسی (افغانستان),rtl
+t9n_lang_fa_IR,fa_IR,Persian (Iran),فارسی (ایران),rtl
+t9n_lang_ff,ff,Fulah,Pulaar,ltr
+t9n_lang_ff_CM,ff_CM,Fulah (Cameroon),Pulaar (Kameruun),ltr
+t9n_lang_ff_GN,ff_GN,Fulah (Guinea),Pulaar (Gine),ltr
+t9n_lang_ff_MR,ff_MR,Fulah (Mauritania),Pulaar (Muritani),ltr
+t9n_lang_ff_SN,ff_SN,Fulah (Senegal),Pulaar (Senegaal),ltr
+t9n_lang_fi,fi,Finnish,suomi,ltr
+t9n_lang_fi_FI,fi_FI,Finnish (Finland),suomi (Suomi),ltr
+t9n_lang_fil,fil,Filipino,Filipino,ltr
+t9n_lang_fil_PH,fil_PH,Filipino (Philippines),Filipino (Pilipinas),ltr
+t9n_lang_fo,fo,Faroese,føroyskt,ltr
+t9n_lang_fo_DK,fo_DK,Faroese (Denmark),føroyskt (Danmark),ltr
+t9n_lang_fo_FO,fo_FO,Faroese (Faroe Islands),føroyskt (Føroyar),ltr
+t9n_lang_fr,fr,French,français,ltr
+t9n_lang_fr_BE,fr_BE,French (Belgium),français (Belgique),ltr
+t9n_lang_fr_BF,fr_BF,French (Burkina Faso),français (Burkina Faso),ltr
+t9n_lang_fr_BI,fr_BI,French (Burundi),français (Burundi),ltr
+t9n_lang_fr_BJ,fr_BJ,French (Benin),français (Bénin),ltr
+t9n_lang_fr_BL,fr_BL,French (St. Barthélemy),français (Saint-Barthélemy),ltr
+t9n_lang_fr_CA,fr_CA,French (Canada),français (Canada),ltr
+t9n_lang_fr_CD,fr_CD,French (Congo - Kinshasa),français (Congo-Kinshasa),ltr
+t9n_lang_fr_CF,fr_CF,French (Central African Republic),français (République centrafricaine),ltr
+t9n_lang_fr_CG,fr_CG,French (Congo - Brazzaville),français (Congo-Brazzaville),ltr
+t9n_lang_fr_CH,fr_CH,French (Switzerland),français (Suisse),ltr
+t9n_lang_fr_CI,fr_CI,French (Côte d’Ivoire),français (Côte d’Ivoire),ltr
+t9n_lang_fr_CM,fr_CM,French (Cameroon),français (Cameroun),ltr
+t9n_lang_fr_DJ,fr_DJ,French (Djibouti),français (Djibouti),ltr
+t9n_lang_fr_DZ,fr_DZ,French (Algeria),français (Algérie),ltr
+t9n_lang_fr_FR,fr_FR,French (France),français (France),ltr
+t9n_lang_fr_GA,fr_GA,French (Gabon),français (Gabon),ltr
+t9n_lang_fr_GF,fr_GF,French (French Guiana),français (Guyane française),ltr
+t9n_lang_fr_GN,fr_GN,French (Guinea),français (Guinée),ltr
+t9n_lang_fr_GP,fr_GP,French (Guadeloupe),français (Guadeloupe),ltr
+t9n_lang_fr_GQ,fr_GQ,French (Equatorial Guinea),français (Guinée équatoriale),ltr
+t9n_lang_fr_HT,fr_HT,French (Haiti),français (Haïti),ltr
+t9n_lang_fr_KM,fr_KM,French (Comoros),français (Comores),ltr
+t9n_lang_fr_LU,fr_LU,French (Luxembourg),français (Luxembourg),ltr
+t9n_lang_fr_MA,fr_MA,French (Morocco),français (Maroc),ltr
+t9n_lang_fr_MC,fr_MC,French (Monaco),français (Monaco),ltr
+t9n_lang_fr_MF,fr_MF,French (St. Martin),français (Saint-Martin),ltr
+t9n_lang_fr_MG,fr_MG,French (Madagascar),français (Madagascar),ltr
+t9n_lang_fr_ML,fr_ML,French (Mali),français (Mali),ltr
+t9n_lang_fr_MQ,fr_MQ,French (Martinique),français (Martinique),ltr
+t9n_lang_fr_MR,fr_MR,French (Mauritania),français (Mauritanie),ltr
+t9n_lang_fr_MU,fr_MU,French (Mauritius),français (Maurice),ltr
+t9n_lang_fr_NC,fr_NC,French (New Caledonia),français (Nouvelle-Calédonie),ltr
+t9n_lang_fr_NE,fr_NE,French (Niger),français (Niger),ltr
+t9n_lang_fr_PF,fr_PF,French (French Polynesia),français (Polynésie française),ltr
+t9n_lang_fr_PM,fr_PM,French (St. Pierre & Miquelon),français (Saint-Pierre-et-Miquelon),ltr
+t9n_lang_fr_RE,fr_RE,French (Réunion),français (La Réunion),ltr
+t9n_lang_fr_RW,fr_RW,French (Rwanda),français (Rwanda),ltr
+t9n_lang_fr_SC,fr_SC,French (Seychelles),français (Seychelles),ltr
+t9n_lang_fr_SN,fr_SN,French (Senegal),français (Sénégal),ltr
+t9n_lang_fr_SY,fr_SY,French (Syria),français (Syrie),ltr
+t9n_lang_fr_TD,fr_TD,French (Chad),français (Tchad),ltr
+t9n_lang_fr_TG,fr_TG,French (Togo),français (Togo),ltr
+t9n_lang_fr_TN,fr_TN,French (Tunisia),français (Tunisie),ltr
+t9n_lang_fr_VU,fr_VU,French (Vanuatu),français (Vanuatu),ltr
+t9n_lang_fr_WF,fr_WF,French (Wallis & Futuna),français (Wallis-et-Futuna),ltr
+t9n_lang_fr_YT,fr_YT,French (Mayotte),français (Mayotte),ltr
+t9n_lang_fur,fur,Friulian,furlan,ltr
+t9n_lang_fur_IT,fur_IT,Friulian (Italy),furlan (Italie),ltr
+t9n_lang_fy,fy,Western Frisian,Frysk,ltr
+t9n_lang_fy_NL,fy_NL,Western Frisian (Netherlands),Frysk (Nederlân),ltr
+t9n_lang_ga,ga,Irish,Gaeilge,ltr
+t9n_lang_ga_IE,ga_IE,Irish (Ireland),Gaeilge (Éire),ltr
+t9n_lang_gd,gd,Scottish Gaelic,Gàidhlig,ltr
+t9n_lang_gd_GB,gd_GB,Scottish Gaelic (United Kingdom),Gàidhlig (An Rìoghachd Aonaichte),ltr
+t9n_lang_gl,gl,Galician,galego,ltr
+t9n_lang_gl_ES,gl_ES,Galician (Spain),galego (España),ltr
+t9n_lang_gsw,gsw,Swiss German,Schwiizertüütsch,ltr
+t9n_lang_gsw_CH,gsw_CH,Swiss German (Switzerland),Schwiizertüütsch (Schwiiz),ltr
+t9n_lang_gsw_FR,gsw_FR,Swiss German (France),Schwiizertüütsch (Frankriich),ltr
+t9n_lang_gsw_LI,gsw_LI,Swiss German (Liechtenstein),Schwiizertüütsch (Liächteschtäi),ltr
+t9n_lang_gu,gu,Gujarati,ગુજરાતી,ltr
+t9n_lang_gu_IN,gu_IN,Gujarati (India),ગુજરાતી (ભારત),ltr
+t9n_lang_guz,guz,Gusii,Ekegusii,ltr
+t9n_lang_guz_KE,guz_KE,Gusii (Kenya),Ekegusii (Kenya),ltr
+t9n_lang_gv,gv,Manx,Gaelg,ltr
+t9n_lang_gv_IM,gv_IM,Manx (Isle of Man),Gaelg (Ellan Vannin),ltr
+t9n_lang_ha,ha,Hausa,Hausa,ltr
+t9n_lang_ha_GH,ha_GH,Hausa (Ghana),Hausa (Gana),ltr
+t9n_lang_ha_NE,ha_NE,Hausa (Niger),Hausa (Nijar),ltr
+t9n_lang_ha_NG,ha_NG,Hausa (Nigeria),Hausa (Najeriya),ltr
+t9n_lang_haw,haw,Hawaiian,ʻŌlelo Hawaiʻi,ltr
+t9n_lang_haw_US,haw_US,Hawaiian (United States),ʻŌlelo Hawaiʻi (ʻAmelika Hui Pū ʻIa),ltr
+t9n_lang_he,he,Hebrew,עברית,rtl
+t9n_lang_he_IL,he_IL,Hebrew (Israel),עברית (ישראל),rtl
+t9n_lang_hi,hi,Hindi,हिन्दी,ltr
+t9n_lang_hi_IN,hi_IN,Hindi (India),हिन्दी (भारत),ltr
+t9n_lang_hr,hr,Croatian,hrvatski,ltr
+t9n_lang_hr_BA,hr_BA,Croatian (Bosnia & Herzegovina),hrvatski (Bosna i Hercegovina),ltr
+t9n_lang_hr_HR,hr_HR,Croatian (Croatia),hrvatski (Hrvatska),ltr
+t9n_lang_hsb,hsb,Upper Sorbian,hornjoserbšćina,ltr
+t9n_lang_hsb_DE,hsb_DE,Upper Sorbian (Germany),hornjoserbšćina (Němska),ltr
+t9n_lang_hu,hu,Hungarian,magyar,ltr
+t9n_lang_hu_HU,hu_HU,Hungarian (Hungary),magyar (Magyarország),ltr
+t9n_lang_hy,hy,Armenian,հայերեն,ltr
+t9n_lang_hy_AM,hy_AM,Armenian (Armenia),հայերեն (Հայաստան),ltr
+t9n_lang_id,id,Indonesian,Indonesia,ltr
+t9n_lang_id_ID,id_ID,Indonesian (Indonesia),Indonesia (Indonesia),ltr
+t9n_lang_ig,ig,Igbo,Igbo,ltr
+t9n_lang_ig_NG,ig_NG,Igbo (Nigeria),Igbo (Naịjịrịa),ltr
+t9n_lang_ii,ii,Sichuan Yi,ꆈꌠꉙ,ltr
+t9n_lang_ii_CN,ii_CN,Sichuan Yi (China),ꆈꌠꉙ (ꍏꇩ),ltr
+t9n_lang_is,is,Icelandic,íslenska,ltr
+t9n_lang_is_IS,is_IS,Icelandic (Iceland),íslenska (Ísland),ltr
+t9n_lang_it,it,Italian,italiano,ltr
+t9n_lang_it_CH,it_CH,Italian (Switzerland),italiano (Svizzera),ltr
+t9n_lang_it_IT,it_IT,Italian (Italy),italiano (Italia),ltr
+t9n_lang_it_SM,it_SM,Italian (San Marino),italiano (San Marino),ltr
+t9n_lang_it_VA,it_VA,Italian (Vatican City),italiano (Città del Vaticano),ltr
+t9n_lang_ja,ja,Japanese,日本語,ltr
+t9n_lang_ja_JP,ja_JP,Japanese (Japan),日本語 (日本),ltr
+t9n_lang_jgo,jgo,Ngomba,Ndaꞌa,ltr
+t9n_lang_jgo_CM,jgo_CM,Ngomba (Cameroon),Ndaꞌa (Kamɛlûn),ltr
+t9n_lang_jmc,jmc,Machame,Kimachame,ltr
+t9n_lang_jmc_TZ,jmc_TZ,Machame (Tanzania),Kimachame (Tanzania),ltr
+t9n_lang_ka,ka,Georgian,ქართული,ltr
+t9n_lang_ka_GE,ka_GE,Georgian (Georgia),ქართული (საქართველო),ltr
+t9n_lang_kab,kab,Kabyle,Taqbaylit,ltr
+t9n_lang_kab_DZ,kab_DZ,Kabyle (Algeria),Taqbaylit (Lezzayer),ltr
+t9n_lang_kam,kam,Kamba,Kikamba,ltr
+t9n_lang_kam_KE,kam_KE,Kamba (Kenya),Kikamba (Kenya),ltr
+t9n_lang_kde,kde,Makonde,Chimakonde,ltr
+t9n_lang_kde_TZ,kde_TZ,Makonde (Tanzania),Chimakonde (Tanzania),ltr
+t9n_lang_kea,kea,Kabuverdianu,kabuverdianu,ltr
+t9n_lang_kea_CV,kea_CV,Kabuverdianu (Cape Verde),kabuverdianu (Kabu Verdi),ltr
+t9n_lang_khq,khq,Koyra Chiini,Koyra ciini,ltr
+t9n_lang_khq_ML,khq_ML,Koyra Chiini (Mali),Koyra ciini (Maali),ltr
+t9n_lang_ki,ki,Kikuyu,Gikuyu,ltr
+t9n_lang_ki_KE,ki_KE,Kikuyu (Kenya),Gikuyu (Kenya),ltr
+t9n_lang_kk,kk,Kazakh,қазақ тілі,ltr
+t9n_lang_kk_KZ,kk_KZ,Kazakh (Kazakhstan),қазақ тілі (Қазақстан),ltr
+t9n_lang_kkj,kkj,Kako,kakɔ,ltr
+t9n_lang_kkj_CM,kkj_CM,Kako (Cameroon),kakɔ (Kamɛrun),ltr
+t9n_lang_kl,kl,Kalaallisut,kalaallisut,ltr
+t9n_lang_kl_GL,kl_GL,Kalaallisut (Greenland),kalaallisut (Kalaallit Nunaat),ltr
+t9n_lang_kln,kln,Kalenjin,Kalenjin,ltr
+t9n_lang_kln_KE,kln_KE,Kalenjin (Kenya),Kalenjin (Emetab Kenya),ltr
+t9n_lang_km,km,Khmer,ខ្មែរ,ltr
+t9n_lang_km_KH,km_KH,Khmer (Cambodia),ខ្មែរ (កម្ពុជា),ltr
+t9n_lang_kn,kn,Kannada,ಕನ್ನಡ,ltr
+t9n_lang_kn_IN,kn_IN,Kannada (India),ಕನ್ನಡ (ಭಾರತ),ltr
+t9n_lang_ko,ko,Korean,한국어,ltr
+t9n_lang_ko_KP,ko_KP,Korean (North Korea),한국어(조선민주주의인민공화국),ltr
+t9n_lang_ko_KR,ko_KR,Korean (South Korea),한국어(대한민국),ltr
+t9n_lang_kok,kok,Konkani,कोंकणी,ltr
+t9n_lang_kok_IN,kok_IN,Konkani (India),कोंकणी (भारत),ltr
+t9n_lang_ks,ks,Kashmiri,کٲشُر,rtl
+t9n_lang_ks_IN,ks_IN,Kashmiri (India),کٲشُر (ہِنٛدوستان),rtl
+t9n_lang_ksb,ksb,Shambala,Kishambaa,ltr
+t9n_lang_ksb_TZ,ksb_TZ,Shambala (Tanzania),Kishambaa (Tanzania),ltr
+t9n_lang_ksf,ksf,Bafia,rikpa,ltr
+t9n_lang_ksf_CM,ksf_CM,Bafia (Cameroon),rikpa (kamɛrún),ltr
+t9n_lang_ksh,ksh,Colognian,Kölsch,ltr
+t9n_lang_ksh_DE,ksh_DE,Colognian (Germany),Kölsch en Doütschland,ltr
+t9n_lang_kw,kw,Cornish,kernewek,ltr
+t9n_lang_kw_GB,kw_GB,Cornish (United Kingdom),kernewek (Rywvaneth Unys),ltr
+t9n_lang_ky,ky,Kyrgyz,кыргызча,ltr
+t9n_lang_ky_KG,ky_KG,Kyrgyz (Kyrgyzstan),кыргызча (Кыргызстан),ltr
+t9n_lang_lag,lag,Langi,Kɨlaangi,ltr
+t9n_lang_lag_TZ,lag_TZ,Langi (Tanzania),Kɨlaangi (Taansanía),ltr
+t9n_lang_lb,lb,Luxembourgish,Lëtzebuergesch,ltr
+t9n_lang_lb_LU,lb_LU,Luxembourgish (Luxembourg),Lëtzebuergesch (Lëtzebuerg),ltr
+t9n_lang_lg,lg,Ganda,Luganda,ltr
+t9n_lang_lg_UG,lg_UG,Ganda (Uganda),Luganda (Yuganda),ltr
+t9n_lang_lkt,lkt,Lakota,Lakȟólʼiyapi,ltr
+t9n_lang_lkt_US,lkt_US,Lakota (United States),Lakȟólʼiyapi (Mílahaŋska Tȟamákȟočhe),ltr
+t9n_lang_ln,ln,Lingala,lingála,ltr
+t9n_lang_ln_AO,ln_AO,Lingala (Angola),lingála (Angóla),ltr
+t9n_lang_ln_CD,ln_CD,Lingala (Congo - Kinshasa),lingála (Republíki ya Kongó Demokratíki),ltr
+t9n_lang_ln_CF,ln_CF,Lingala (Central African Republic),lingála (Repibiki ya Afríka ya Káti),ltr
+t9n_lang_ln_CG,ln_CG,Lingala (Congo - Brazzaville),lingála (Kongo),ltr
+t9n_lang_lo,lo,Lao,ລາວ,ltr
+t9n_lang_lo_LA,lo_LA,Lao (Laos),ລາວ (ລາວ),ltr
+t9n_lang_lrc,lrc,Northern Luri,لۊری شومالی,rtl
+t9n_lang_lrc_IQ,lrc_IQ,Northern Luri (Iraq),لۊری شومالی (IQ),rtl
+t9n_lang_lrc_IR,lrc_IR,Northern Luri (Iran),لۊری شومالی (IR),rtl
+t9n_lang_lt,lt,Lithuanian,lietuvių,ltr
+t9n_lang_lt_LT,lt_LT,Lithuanian (Lithuania),lietuvių (Lietuva),ltr
+t9n_lang_lu,lu,Luba-Katanga,Tshiluba,ltr
+t9n_lang_lu_CD,lu_CD,Luba-Katanga (Congo - Kinshasa),Tshiluba (Ditunga wa Kongu),ltr
+t9n_lang_luo,luo,Luo,Dholuo,ltr
+t9n_lang_luo_KE,luo_KE,Luo (Kenya),Dholuo (Kenya),ltr
+t9n_lang_luy,luy,Luyia,Luluhia,ltr
+t9n_lang_luy_KE,luy_KE,Luyia (Kenya),Luluhia (Kenya),ltr
+t9n_lang_lv,lv,Latvian,latviešu,ltr
+t9n_lang_lv_LV,lv_LV,Latvian (Latvia),latviešu (Latvija),ltr
+t9n_lang_mas,mas,Masai,Maa,ltr
+t9n_lang_mas_KE,mas_KE,Masai (Kenya),Maa (Kenya),ltr
+t9n_lang_mas_TZ,mas_TZ,Masai (Tanzania),Maa (Tansania),ltr
+t9n_lang_mer,mer,Meru,Kĩmĩrũ,ltr
+t9n_lang_mer_KE,mer_KE,Meru (Kenya),Kĩmĩrũ (Kenya),ltr
+t9n_lang_mfe,mfe,Morisyen,kreol morisien,ltr
+t9n_lang_mfe_MU,mfe_MU,Morisyen (Mauritius),kreol morisien (Moris),ltr
+t9n_lang_mg,mg,Malagasy,Malagasy,ltr
+t9n_lang_mg_MG,mg_MG,Malagasy (Madagascar),Malagasy (Madagasikara),ltr
+t9n_lang_mgh,mgh,Makhuwa-Meetto,Makua,ltr
+t9n_lang_mgh_MZ,mgh_MZ,Makhuwa-Meetto (Mozambique),Makua (Umozambiki),ltr
+t9n_lang_mgo,mgo,Metaʼ,metaʼ,ltr
+t9n_lang_mgo_CM,mgo_CM,Metaʼ (Cameroon),metaʼ (Kamalun),ltr
+t9n_lang_mk,mk,Macedonian,македонски,ltr
+t9n_lang_mk_MK,mk_MK,Macedonian (Macedonia),македонски (Македонија),ltr
+t9n_lang_ml,ml,Malayalam,മലയാളം,ltr
+t9n_lang_ml_IN,ml_IN,Malayalam (India),മലയാളം (ഇന്ത്യ),ltr
+t9n_lang_mn,mn,Mongolian,монгол,ltr
+t9n_lang_mn_MN,mn_MN,Mongolian (Mongolia),монгол (Монгол),ltr
+t9n_lang_mr,mr,Marathi,मराठी,ltr
+t9n_lang_mr_IN,mr_IN,Marathi (India),मराठी (भारत),ltr
+t9n_lang_ms,ms,Malay,Melayu,ltr
+t9n_lang_ms_BN,ms_BN,Malay (Brunei),Melayu (Brunei),ltr
+t9n_lang_ms_MY,ms_MY,Malay (Malaysia),Melayu (Malaysia),ltr
+t9n_lang_ms_SG,ms_SG,Malay (Singapore),Melayu (Singapura),ltr
+t9n_lang_mt,mt,Maltese,Malti,ltr
+t9n_lang_mt_MT,mt_MT,Maltese (Malta),Malti (Malta),ltr
+t9n_lang_mua,mua,Mundang,MUNDAŊ,ltr
+t9n_lang_mua_CM,mua_CM,Mundang (Cameroon),MUNDAŊ (kameruŋ),ltr
+t9n_lang_my,my,Burmese,မြန်မာ,ltr
+t9n_lang_my_MM,my_MM,Burmese (Myanmar [Burma]),မြန်မာ (မြန်မာ),ltr
+t9n_lang_mzn,mzn,Mazanderani,مازرونی,rtl
+t9n_lang_mzn_IR,mzn_IR,Mazanderani (Iran),مازرونی (ایران),rtl
+t9n_lang_naq,naq,Nama,Khoekhoegowab,ltr
+t9n_lang_naq_NA,naq_NA,Nama (Namibia),Khoekhoegowab (Namibiab),ltr
+t9n_lang_nb,nb,Norwegian Bokmål,norsk bokmål,ltr
+t9n_lang_nb_NO,nb_NO,Norwegian Bokmål (Norway),norsk bokmål (Norge),ltr
+t9n_lang_nb_SJ,nb_SJ,Norwegian Bokmål (Svalbard & Jan Mayen),norsk bokmål (Svalbard og Jan Mayen),ltr
+t9n_lang_nd,nd,North Ndebele,isiNdebele,ltr
+t9n_lang_nd_ZW,nd_ZW,North Ndebele (Zimbabwe),isiNdebele (Zimbabwe),ltr
+t9n_lang_nds,nds,Low German,nds,ltr
+t9n_lang_nds_DE,nds_DE,Low German (Germany),nds (DE),ltr
+t9n_lang_nds_NL,nds_NL,Low German (Netherlands),nds (NL),ltr
+t9n_lang_ne,ne,Nepali,नेपाली,ltr
+t9n_lang_ne_IN,ne_IN,Nepali (India),नेपाली (भारत),ltr
+t9n_lang_ne_NP,ne_NP,Nepali (Nepal),नेपाली (नेपाल),ltr
+t9n_lang_nl,nl,Dutch,Nederlands,ltr
+t9n_lang_nl_AW,nl_AW,Dutch (Aruba),Nederlands (Aruba),ltr
+t9n_lang_nl_BE,nl_BE,Dutch (Belgium),Nederlands (België),ltr
+t9n_lang_nl_BQ,nl_BQ,Dutch (Caribbean Netherlands),Nederlands (Caribisch Nederland),ltr
+t9n_lang_nl_CW,nl_CW,Dutch (Curaçao),Nederlands (Curaçao),ltr
+t9n_lang_nl_NL,nl_NL,Dutch (Netherlands),Nederlands (Nederland),ltr
+t9n_lang_nl_SR,nl_SR,Dutch (Suriname),Nederlands (Suriname),ltr
+t9n_lang_nl_SX,nl_SX,Dutch (Sint Maarten),Nederlands (Sint-Maarten),ltr
+t9n_lang_nmg,nmg,Kwasio,nmg,ltr
+t9n_lang_nmg_CM,nmg_CM,Kwasio (Cameroon),nmg (Kamerun),ltr
+t9n_lang_nn,nn,Norwegian Nynorsk,nynorsk,ltr
+t9n_lang_nn_NO,nn_NO,Norwegian Nynorsk (Norway),nynorsk (Noreg),ltr
+t9n_lang_nnh,nnh,Ngiemboon,Shwóŋò ngiembɔɔn,ltr
+t9n_lang_nnh_CM,nnh_CM,Ngiemboon (Cameroon),Shwóŋò ngiembɔɔn (Kàmalûm),ltr
+t9n_lang_nus,nus,Nuer,Thok Nath,ltr
+t9n_lang_nus_SS,nus_SS,Nuer (South Sudan),Thok Nath (SS),ltr
+t9n_lang_nyn,nyn,Nyankole,Runyankore,ltr
+t9n_lang_nyn_UG,nyn_UG,Nyankole (Uganda),Runyankore (Uganda),ltr
+t9n_lang_om,om,Oromo,Oromoo,ltr
+t9n_lang_om_ET,om_ET,Oromo (Ethiopia),Oromoo (Itoophiyaa),ltr
+t9n_lang_om_KE,om_KE,Oromo (Kenya),Oromoo (Keeniyaa),ltr
+t9n_lang_or,or,Odia,ଓଡ଼ିଆ,ltr
+t9n_lang_or_IN,or_IN,Odia (India),ଓଡ଼ିଆ (ଭାରତ),ltr
+t9n_lang_os,os,Ossetic,ирон,ltr
+t9n_lang_os_GE,os_GE,Ossetic (Georgia),ирон (Гуырдзыстон),ltr
+t9n_lang_os_RU,os_RU,Ossetic (Russia),ирон (Уӕрӕсе),ltr
+t9n_lang_pa,pa,Punjabi,ਪੰਜਾਬੀ,ltr
+t9n_lang_pa_Arab,pa_Arab,Punjabi (Arabic),پنجابی (عربی),rtl
+t9n_lang_pa_Arab_PK,pa_Arab_PK,"Punjabi (Arabic, Pakistan)","پنجابی (عربی, پاکستان)",rtl
+t9n_lang_pa_Guru,pa_Guru,Punjabi (Gurmukhi),ਪੰਜਾਬੀ (ਗੁਰਮੁਖੀ),ltr
+t9n_lang_pa_Guru_IN,pa_Guru_IN,"Punjabi (Gurmukhi, India)","ਪੰਜਾਬੀ (ਗੁਰਮੁਖੀ, ਭਾਰਤ)",ltr
+t9n_lang_pl,pl,Polish,polski,ltr
+t9n_lang_pl_PL,pl_PL,Polish (Poland),polski (Polska),ltr
+t9n_lang_ps,ps,Pashto,پښتو,rtl
+t9n_lang_ps_AF,ps_AF,Pashto (Afghanistan),پښتو (افغانستان),rtl
+t9n_lang_pt,pt,Portuguese,português,ltr
+t9n_lang_pt_AO,pt_AO,Portuguese (Angola),português (Angola),ltr
+t9n_lang_pt_BR,pt_BR,Portuguese (Brazil),português (Brasil),ltr
+t9n_lang_pt_CH,pt_CH,Portuguese (Switzerland),português (Suíça),ltr
+t9n_lang_pt_CV,pt_CV,Portuguese (Cape Verde),português (Cabo Verde),ltr
+t9n_lang_pt_GQ,pt_GQ,Portuguese (Equatorial Guinea),português (Guiné Equatorial),ltr
+t9n_lang_pt_GW,pt_GW,Portuguese (Guinea-Bissau),português (Guiné-Bissau),ltr
+t9n_lang_pt_LU,pt_LU,Portuguese (Luxembourg),português (Luxemburgo),ltr
+t9n_lang_pt_MO,pt_MO,Portuguese (Macau SAR China),"português (Macau, RAE da China)",ltr
+t9n_lang_pt_MZ,pt_MZ,Portuguese (Mozambique),português (Moçambique),ltr
+t9n_lang_pt_PT,pt_PT,Portuguese (Portugal),português (Portugal),ltr
+t9n_lang_pt_ST,pt_ST,Portuguese (São Tomé & Príncipe),português (São Tomé e Príncipe),ltr
+t9n_lang_pt_TL,pt_TL,Portuguese (Timor-Leste),português (Timor-Leste),ltr
+t9n_lang_qu,qu,Quechua,Runasimi,ltr
+t9n_lang_qu_BO,qu_BO,Quechua (Bolivia),Runasimi (Bolivia),ltr
+t9n_lang_qu_EC,qu_EC,Quechua (Ecuador),Runasimi (Ecuador),ltr
+t9n_lang_qu_PE,qu_PE,Quechua (Peru),Runasimi (Perú),ltr
+t9n_lang_rm,rm,Romansh,rumantsch,ltr
+t9n_lang_rm_CH,rm_CH,Romansh (Switzerland),rumantsch (Svizra),ltr
+t9n_lang_rn,rn,Rundi,Ikirundi,ltr
+t9n_lang_rn_BI,rn_BI,Rundi (Burundi),Ikirundi (Uburundi),ltr
+t9n_lang_ro,ro,Romanian,română,ltr
+t9n_lang_ro_MD,ro_MD,Romanian (Moldova),română (Republica Moldova),ltr
+t9n_lang_ro_RO,ro_RO,Romanian (Romania),română (România),ltr
+t9n_lang_rof,rof,Rombo,Kihorombo,ltr
+t9n_lang_rof_TZ,rof_TZ,Rombo (Tanzania),Kihorombo (Tanzania),ltr
+t9n_lang_ru,ru,Russian,русский,ltr
+t9n_lang_ru_BY,ru_BY,Russian (Belarus),русский (Беларусь),ltr
+t9n_lang_ru_KG,ru_KG,Russian (Kyrgyzstan),русский (Киргизия),ltr
+t9n_lang_ru_KZ,ru_KZ,Russian (Kazakhstan),русский (Казахстан),ltr
+t9n_lang_ru_MD,ru_MD,Russian (Moldova),русский (Молдова),ltr
+t9n_lang_ru_RU,ru_RU,Russian (Russia),русский (Россия),ltr
+t9n_lang_ru_UA,ru_UA,Russian (Ukraine),русский (Украина),ltr
+t9n_lang_rw,rw,Kinyarwanda,Kinyarwanda,ltr
+t9n_lang_rw_RW,rw_RW,Kinyarwanda (Rwanda),Kinyarwanda (U Rwanda),ltr
+t9n_lang_rwk,rwk,Rwa,Kiruwa,ltr
+t9n_lang_rwk_TZ,rwk_TZ,Rwa (Tanzania),Kiruwa (Tanzania),ltr
+t9n_lang_sah,sah,Sakha,саха тыла,ltr
+t9n_lang_sah_RU,sah_RU,Sakha (Russia),саха тыла (Арассыыйа),ltr
+t9n_lang_saq,saq,Samburu,Kisampur,ltr
+t9n_lang_saq_KE,saq_KE,Samburu (Kenya),Kisampur (Kenya),ltr
+t9n_lang_sbp,sbp,Sangu,Ishisangu,ltr
+t9n_lang_sbp_TZ,sbp_TZ,Sangu (Tanzania),Ishisangu (Tansaniya),ltr
+t9n_lang_se,se,Northern Sami,davvisámegiella,ltr
+t9n_lang_se_FI,se_FI,Northern Sami (Finland),davvisámegiella (Suopma),ltr
+t9n_lang_se_NO,se_NO,Northern Sami (Norway),davvisámegiella (Norga),ltr
+t9n_lang_se_SE,se_SE,Northern Sami (Sweden),davvisámegiella (Ruoŧŧa),ltr
+t9n_lang_seh,seh,Sena,sena,ltr
+t9n_lang_seh_MZ,seh_MZ,Sena (Mozambique),sena (Moçambique),ltr
+t9n_lang_ses,ses,Koyraboro Senni,Koyraboro senni,ltr
+t9n_lang_ses_ML,ses_ML,Koyraboro Senni (Mali),Koyraboro senni (Maali),ltr
+t9n_lang_sg,sg,Sango,Sängö,ltr
+t9n_lang_sg_CF,sg_CF,Sango (Central African Republic),Sängö (Ködörösêse tî Bêafrîka),ltr
+t9n_lang_shi,shi,Tachelhit,ⵜⴰⵛⵍⵃⵉⵜ,ltr
+t9n_lang_shi_Latn,shi_Latn,Tachelhit (Latin),Tashelḥiyt (Latn),ltr
+t9n_lang_shi_Latn_MA,shi_Latn_MA,"Tachelhit (Latin, Morocco)","Tashelḥiyt (Latn, lmɣrib)",ltr
+t9n_lang_shi_Tfng,shi_Tfng,Tachelhit (Tifinagh),ⵜⴰⵛⵍⵃⵉⵜ (Tfng),ltr
+t9n_lang_shi_Tfng_MA,shi_Tfng_MA,"Tachelhit (Tifinagh, Morocco)","ⵜⴰⵛⵍⵃⵉⵜ (Tfng, ⵍⵎⵖⵔⵉⴱ)",ltr
+t9n_lang_si,si,Sinhala,සිංහල,ltr
+t9n_lang_si_LK,si_LK,Sinhala (Sri Lanka),සිංහල (ශ්‍රී ලංකාව),ltr
+t9n_lang_sk,sk,Slovak,slovenčina,ltr
+t9n_lang_sk_SK,sk_SK,Slovak (Slovakia),slovenčina (Slovensko),ltr
+t9n_lang_sl,sl,Slovenian,slovenščina,ltr
+t9n_lang_sl_SI,sl_SI,Slovenian (Slovenia),slovenščina (Slovenija),ltr
+t9n_lang_smn,smn,Inari Sami,anarâškielâ,ltr
+t9n_lang_smn_FI,smn_FI,Inari Sami (Finland),anarâškielâ (Suomâ),ltr
+t9n_lang_sn,sn,Shona,chiShona,ltr
+t9n_lang_sn_ZW,sn_ZW,Shona (Zimbabwe),chiShona (Zimbabwe),ltr
+t9n_lang_so,so,Somali,Soomaali,ltr
+t9n_lang_so_DJ,so_DJ,Somali (Djibouti),Soomaali (Jabuuti),ltr
+t9n_lang_so_ET,so_ET,Somali (Ethiopia),Soomaali (Itoobiya),ltr
+t9n_lang_so_KE,so_KE,Somali (Kenya),Soomaali (Kiiniya),ltr
+t9n_lang_so_SO,so_SO,Somali (Somalia),Soomaali (Soomaaliya),ltr
+t9n_lang_sq,sq,Albanian,shqip,ltr
+t9n_lang_sq_AL,sq_AL,Albanian (Albania),shqip (Shqipëri),ltr
+t9n_lang_sq_MK,sq_MK,Albanian (Macedonia),shqip (Maqedoni),ltr
+t9n_lang_sq_XK,sq_XK,Albanian (Kosovo),shqip (Kosovë),ltr
+t9n_lang_sr,sr,Serbian,српски,ltr
+t9n_lang_sr_Cyrl,sr_Cyrl,Serbian (Cyrillic),српски (ћирилица),ltr
+t9n_lang_sr_Cyrl_BA,sr_Cyrl_BA,"Serbian (Cyrillic, Bosnia & Herzegovina)","српски (ћирилица, Босна и Херцеговина)",ltr
+t9n_lang_sr_Cyrl_ME,sr_Cyrl_ME,"Serbian (Cyrillic, Montenegro)","српски (ћирилица, Црна Гора)",ltr
+t9n_lang_sr_Cyrl_RS,sr_Cyrl_RS,"Serbian (Cyrillic, Serbia)","српски (ћирилица, Србија)",ltr
+t9n_lang_sr_Cyrl_XK,sr_Cyrl_XK,"Serbian (Cyrillic, Kosovo)","српски (ћирилица, Косово)",ltr
+t9n_lang_sr_Latn,sr_Latn,Serbian (Latin),srpski (latinica),ltr
+t9n_lang_sr_Latn_BA,sr_Latn_BA,"Serbian (Latin, Bosnia & Herzegovina)","srpski (latinica, Bosna i Hercegovina)",ltr
+t9n_lang_sr_Latn_ME,sr_Latn_ME,"Serbian (Latin, Montenegro)","srpski (latinica, Crna Gora)",ltr
+t9n_lang_sr_Latn_RS,sr_Latn_RS,"Serbian (Latin, Serbia)","srpski (latinica, Srbija)",ltr
+t9n_lang_sr_Latn_XK,sr_Latn_XK,"Serbian (Latin, Kosovo)","srpski (latinica, Kosovo)",ltr
+t9n_lang_sv,sv,Swedish,svenska,ltr
+t9n_lang_sv_AX,sv_AX,Swedish (Åland Islands),svenska (Åland),ltr
+t9n_lang_sv_FI,sv_FI,Swedish (Finland),svenska (Finland),ltr
+t9n_lang_sv_SE,sv_SE,Swedish (Sweden),svenska (Sverige),ltr
+t9n_lang_sw,sw,Swahili,Kiswahili,ltr
+t9n_lang_sw_CD,sw_CD,Swahili (Congo - Kinshasa),Kiswahili (Jamhuri ya Kidemokrasia ya Kongo),ltr
+t9n_lang_sw_KE,sw_KE,Swahili (Kenya),Kiswahili (Kenya),ltr
+t9n_lang_sw_TZ,sw_TZ,Swahili (Tanzania),Kiswahili (Tanzania),ltr
+t9n_lang_sw_UG,sw_UG,Swahili (Uganda),Kiswahili (Uganda),ltr
+t9n_lang_ta,ta,Tamil,தமிழ்,ltr
+t9n_lang_ta_IN,ta_IN,Tamil (India),தமிழ் (இந்தியா),ltr
+t9n_lang_ta_LK,ta_LK,Tamil (Sri Lanka),தமிழ் (இலங்கை),ltr
+t9n_lang_ta_MY,ta_MY,Tamil (Malaysia),தமிழ் (மலேசியா),ltr
+t9n_lang_ta_SG,ta_SG,Tamil (Singapore),தமிழ் (சிங்கப்பூர்),ltr
+t9n_lang_te,te,Telugu,తెలుగు,ltr
+t9n_lang_te_IN,te_IN,Telugu (India),తెలుగు (భారతదేశం),ltr
+t9n_lang_teo,teo,Teso,Kiteso,ltr
+t9n_lang_teo_KE,teo_KE,Teso (Kenya),Kiteso (Kenia),ltr
+t9n_lang_teo_UG,teo_UG,Teso (Uganda),Kiteso (Uganda),ltr
+t9n_lang_tg,tg,Tajik,тоҷикӣ,ltr
+t9n_lang_tg_TJ,tg_TJ,Tajik (Tajikistan),тоҷикӣ (Тоҷикистон),ltr
+t9n_lang_th,th,Thai,ไทย,ltr
+t9n_lang_th_TH,th_TH,Thai (Thailand),ไทย (ไทย),ltr
+t9n_lang_ti,ti,Tigrinya,ትግርኛ,ltr
+t9n_lang_ti_ER,ti_ER,Tigrinya (Eritrea),ትግርኛ (ኤርትራ),ltr
+t9n_lang_ti_ET,ti_ET,Tigrinya (Ethiopia),ትግርኛ (ኢትዮጵያ),ltr
+t9n_lang_to,to,Tongan,lea fakatonga,ltr
+t9n_lang_to_TO,to_TO,Tongan (Tonga),lea fakatonga (Tonga),ltr
+t9n_lang_tr,tr,Turkish,Türkçe,ltr
+t9n_lang_tr_CY,tr_CY,Turkish (Cyprus),Türkçe (Kıbrıs),ltr
+t9n_lang_tr_TR,tr_TR,Turkish (Turkey),Türkçe (Türkiye),ltr
+t9n_lang_tt,tt,Tatar,татар,ltr
+t9n_lang_tt_RU,tt_RU,Tatar (Russia),татар (Россия),ltr
+t9n_lang_twq,twq,Tasawaq,Tasawaq senni,ltr
+t9n_lang_twq_NE,twq_NE,Tasawaq (Niger),Tasawaq senni (Nižer),ltr
+t9n_lang_tzm,tzm,Central Atlas Tamazight,Tamaziɣt n laṭlaṣ,ltr
+t9n_lang_tzm_MA,tzm_MA,Central Atlas Tamazight (Morocco),Tamaziɣt n laṭlaṣ (Meṛṛuk),ltr
+t9n_lang_ug,ug,Uyghur,ئۇيغۇرچە,rtl
+t9n_lang_ug_CN,ug_CN,Uyghur (China),ئۇيغۇرچە (جۇڭگو),rtl
+t9n_lang_uk,uk,Ukrainian,українська,ltr
+t9n_lang_uk_UA,uk_UA,Ukrainian (Ukraine),українська (Україна),ltr
+t9n_lang_ur,ur,Urdu,اردو,rtl
+t9n_lang_ur_IN,ur_IN,Urdu (India),اردو (بھارت),rtl
+t9n_lang_ur_PK,ur_PK,Urdu (Pakistan),اردو (پاکستان),rtl
+t9n_lang_uz,uz,Uzbek,o‘zbek,ltr
+t9n_lang_uz_Arab,uz_Arab,Uzbek (Arabic),اوزبیک (عربی),rtl
+t9n_lang_uz_Arab_AF,uz_Arab_AF,"Uzbek (Arabic, Afghanistan)","اوزبیک (عربی, افغانستان)",rtl
+t9n_lang_uz_Cyrl,uz_Cyrl,Uzbek (Cyrillic),ўзбекча (Кирил),ltr
+t9n_lang_uz_Cyrl_UZ,uz_Cyrl_UZ,"Uzbek (Cyrillic, Uzbekistan)","ўзбекча (Кирил, Ўзбекистон)",ltr
+t9n_lang_uz_Latn,uz_Latn,Uzbek (Latin),o‘zbek (lotin),ltr
+t9n_lang_uz_Latn_UZ,uz_Latn_UZ,"Uzbek (Latin, Uzbekistan)","o‘zbek (lotin, Oʻzbekiston)",ltr
+t9n_lang_vai,vai,Vai,ꕙꔤ,ltr
+t9n_lang_vai_Latn,vai_Latn,Vai (Latin),Vai (Latn),ltr
+t9n_lang_vai_Latn_LR,vai_Latn_LR,"Vai (Latin, Liberia)","Vai (Latn, Laibhiya)",ltr
+t9n_lang_vai_Vaii,vai_Vaii,Vai (Vai),ꕙꔤ (Vaii),ltr
+t9n_lang_vai_Vaii_LR,vai_Vaii_LR,"Vai (Vai, Liberia)","ꕙꔤ (Vaii, ꕞꔤꔫꕩ)",ltr
+t9n_lang_vi,vi,Vietnamese,Tiếng Việt,ltr
+t9n_lang_vi_VN,vi_VN,Vietnamese (Vietnam),Tiếng Việt (Việt Nam),ltr
+t9n_lang_vun,vun,Vunjo,Kyivunjo,ltr
+t9n_lang_vun_TZ,vun_TZ,Vunjo (Tanzania),Kyivunjo (Tanzania),ltr
+t9n_lang_wae,wae,Walser,Walser,ltr
+t9n_lang_wae_CH,wae_CH,Walser (Switzerland),Walser (Schwiz),ltr
+t9n_lang_wo,wo,Wolof,Wolof,ltr
+t9n_lang_wo_SN,wo_SN,Wolof (Senegal),Wolof (Senegaal),ltr
+t9n_lang_xog,xog,Soga,Olusoga,ltr
+t9n_lang_xog_UG,xog_UG,Soga (Uganda),Olusoga (Yuganda),ltr
+t9n_lang_yav,yav,Yangben,nuasue,ltr
+t9n_lang_yav_CM,yav_CM,Yangben (Cameroon),nuasue (Kemelún),ltr
+t9n_lang_yi,yi,Yiddish,ייִדיש,rtl
+t9n_lang_yi_001,yi_001,Yiddish (World),ייִדיש (וועלט),rtl
+t9n_lang_yo,yo,Yoruba,Èdè Yorùbá,ltr
+t9n_lang_yo_BJ,yo_BJ,Yoruba (Benin),Èdè Yorùbá (Orílɛ́ède Bɛ̀nɛ̀),ltr
+t9n_lang_yo_NG,yo_NG,Yoruba (Nigeria),Èdè Yorùbá (Orílẹ́ède Nàìjíríà),ltr
+t9n_lang_yue,yue,Cantonese,粵語,ltr
+t9n_lang_yue_Hans,yue_Hans,Cantonese (Simplified),粤语 (简体),ltr
+t9n_lang_yue_Hans_CN,yue_Hans_CN,"Cantonese (Simplified, China)",粤语 (简体，中华人民共和国),ltr
+t9n_lang_yue_Hant,yue_Hant,Cantonese (Traditional),粵語 (繁體),ltr
+t9n_lang_yue_Hant_HK,yue_Hant_HK,"Cantonese (Traditional, Hong Kong SAR China)",粵語 (繁體，中華人民共和國香港特別行政區),ltr
+t9n_lang_zgh,zgh,Standard Moroccan Tamazight,ⵜⴰⵎⴰⵣⵉⵖⵜ,ltr
+t9n_lang_zgh_MA,zgh_MA,Standard Moroccan Tamazight (Morocco),ⵜⴰⵎⴰⵣⵉⵖⵜ (ⵍⵎⵖⵔⵉⴱ),ltr
+t9n_lang_zh,zh,Chinese,中文,ltr
+t9n_lang_zh_Hans,zh_Hans,Chinese (Simplified),中文（简体）,ltr
+t9n_lang_zh_Hans_CN,zh_Hans_CN,"Chinese (Simplified, China)",中文（简体，中国）,ltr
+t9n_lang_zh_Hans_HK,zh_Hans_HK,"Chinese (Simplified, Hong Kong SAR China)",中文（简体，中国香港特别行政区）,ltr
+t9n_lang_zh_Hans_MO,zh_Hans_MO,"Chinese (Simplified, Macau SAR China)",中文（简体，中国澳门特别行政区）,ltr
+t9n_lang_zh_Hans_SG,zh_Hans_SG,"Chinese (Simplified, Singapore)",中文（简体，新加坡）,ltr
+t9n_lang_zh_Hant,zh_Hant,Chinese (Traditional),中文（繁體）,ltr
+t9n_lang_zh_Hant_HK,zh_Hant_HK,"Chinese (Traditional, Hong Kong SAR China)",中文（繁體字，中國香港特別行政區）,ltr
+t9n_lang_zh_Hant_MO,zh_Hant_MO,"Chinese (Traditional, Macau SAR China)",中文（繁體字，中國澳門特別行政區）,ltr
+t9n_lang_zh_Hant_TW,zh_Hant_TW,"Chinese (Traditional, Taiwan)",中文（繁體，台灣）,ltr
+t9n_lang_zu,zu,Zulu,isiZulu,ltr
+t9n_lang_zu_ZA,zu_ZA,Zulu (South Africa),isiZulu (iNingizimu Afrika),ltr

--- a/addons/t9n/models/language.py
+++ b/addons/t9n/models/language.py
@@ -5,4 +5,17 @@ class Language(models.Model):
     _name = "t9n.language"
     _description = "Language"
 
-    name = fields.Char("Language", required=True)
+    name = fields.Char("Formal Name", required=True)
+    code = fields.Char("Code", required=True)
+    native_name = fields.Char("Native Name")
+    direction = fields.Selection(
+        required=True,
+        selection=[
+            ("ltr", "left-to-right"),
+            ("rtl", "right-to-left"),
+        ],
+    )
+
+    _sql_constraints = [
+        ("language_code_unique", "unique(code)", "The language code must be unique.")
+    ]

--- a/addons/t9n/views/t9n_language_views.xml
+++ b/addons/t9n/views/t9n_language_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="t9n.language_view_tree" model="ir.ui.view">
+        <field name="name">t9n.language.tree</field>
+        <field name="model">t9n.language</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="native_name"/>
+            </tree>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This commit add all languages data that will be imported automatically into t9n.language model when initializing the module.

Task-3783071