### PR TITLE
[IMP] t9n: add the ability to search the languages with native name.

### DIFF
--- a/addons/t9n/models/language.py
+++ b/addons/t9n/models/language.py
@@ -5,15 +5,16 @@ class Language(models.Model):
     _name = "t9n.language"
     _description = "Language"
 
-    name = fields.Char("Formal Name", required=True)
-    code = fields.Char("Code", required=True)
-    native_name = fields.Char("Native Name")
+    name = fields.Char("Formal Name", required=True, readonly=True)
+    code = fields.Char("Code", required=True, readonly=True)
+    native_name = fields.Char("Native Name", readonly=True)
     direction = fields.Selection(
         required=True,
         selection=[
             ("ltr", "left-to-right"),
             ("rtl", "right-to-left"),
         ],
+        readonly=True,
     )
 
     _sql_constraints = [

--- a/addons/t9n/views/t9n_language_views.xml
+++ b/addons/t9n/views/t9n_language_views.xml
@@ -4,10 +4,23 @@
         <field name="name">t9n.language.tree</field>
         <field name="model">t9n.language</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree create="false" edit="false">
+                <field name="code"/>
                 <field name="name"/>
                 <field name="native_name"/>
             </tree>
+        </field>
+    </record>
+    <record id="t9n.language_view_search" model="ir.ui.view">
+        <field name="name">t9n.language.search</field>
+        <field name="model">t9n.language</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" string="All Languages" filter_domain="[ '|', '|', ('name', 'ilike', self), ('native_name', 'ilike', self), ('code', 'ilike', self)]"/>
+                <field name="name"/>
+                <field name="native_name"/>
+                <field name="code"/>
+            </search>
         </field>
     </record>
 </odoo>

--- a/addons/t9n/views/t9n_project_views.xml
+++ b/addons/t9n/views/t9n_project_views.xml
@@ -22,7 +22,7 @@
                         <page string="Description">
                             <group>
                                 <group>
-                                    <field name="src_lang_id" domain="[('id', 'not in', target_lang_ids)]"/>
+                                    <field name="src_lang_id" domain="[('id', 'not in', target_lang_ids)]" options="{'no_create': True}"/>
                                     <field name="target_lang_ids" domain="[('id', '!=', src_lang_id)]"/>
                                 </group>
                             </group>


### PR DESCRIPTION
Previously, you were only able to search the languages with the formal name. This commit add the ability to also search with the native name which is the name of the language in the language itself.

Task-3783071