### PR TITLE
Multiple changes related to remove format and color stuffs

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -473,6 +473,14 @@ export class SelectionPlugin extends Plugin {
                         );
                     }
                 } else {
+                    // ignore edges nodes if they do not have content selected
+                    if (
+                        (node === selection.endContainer && selection.endOffset === 0) ||
+                        (node === selection.startContainer &&
+                            selection.startOffset === nodeSize(selection.startContainer))
+                    ) {
+                        continue;
+                    }
                     traversedNodes.add(node);
                 }
             }

--- a/addons/html_editor/static/src/main/toolbar/toolbar.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.js
@@ -15,6 +15,7 @@ export class Toolbar extends Component {
                     type: Object,
                     shape: {
                         buttonsActiveState: Object,
+                        buttonsDisabledState: Object,
                         namespace: {
                             type: String,
                             optional: true,

--- a/addons/html_editor/static/src/main/toolbar/toolbar.xml
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.xml
@@ -10,7 +10,10 @@
                         </t>
                         <button t-else=""
                             class="btn btn-light"
-                            t-attf-class="btn btn-light {{button.icon ? 'fa fa-fw ps-1 pe-3 mx-1 ' + button.icon : 'px-1'}} {{ state.buttonsActiveState[button.id] ? 'active': ''}}"
+                            t-attf-class="btn btn-light
+                                {{button.icon ? 'fa fa-fw ps-1 pe-3 mx-1 ' + button.icon : 'px-1'}}
+                                {{ state.buttonsActiveState[button.id] ? 'active': ''}}
+                                {{ state.buttonsDisabledState[button.id] ? 'disabled': ''}}"
                             t-att-title="button.name"
                             t-att-name="button.id"
                             t-on-click="() => this.dispatch(button.cmd, button.cmdPayload)">

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -18,6 +18,9 @@ export class ToolbarPlugin extends Plugin {
             buttonsActiveState: this.buttonGroups.flatMap((g) =>
                 g.buttons.map((b) => [b.id, false])
             ),
+            buttonsDisabledState: this.buttonGroups.flatMap((g) =>
+                g.buttons.map((b) => [b.id, false])
+            ),
             namespace: undefined,
         });
     }
@@ -30,7 +33,7 @@ export class ToolbarPlugin extends Plugin {
                     if (sel.isCollapsed) {
                         this.overlay.close();
                     }
-                    this.updateButtonsActiveState(this.shared.getEditableSelection());
+                    this.updateButtonsStates(this.shared.getEditableSelection());
                 }
                 break;
         }
@@ -58,7 +61,7 @@ export class ToolbarPlugin extends Plugin {
             } else {
                 this.state.namespace = undefined;
             }
-            this.updateButtonsActiveState(selection);
+            this.updateButtonsStates(selection);
         }
     }
 
@@ -87,13 +90,15 @@ export class ToolbarPlugin extends Plugin {
         }
     }
 
-    updateButtonsActiveState(selection) {
+    updateButtonsStates(selection) {
         if (selection.inEditable) {
             for (const buttonGroup of this.buttonGroups) {
                 if (buttonGroup.namespace === this.state.namespace) {
                     for (const button of buttonGroup.buttons) {
                         this.state.buttonsActiveState[button.id] =
                             button.isFormatApplied?.(selection);
+                        this.state.buttonsDisabledState[button.id] =
+                            button.hasFormat != null && !button.hasFormat?.(selection);
                     }
                 }
             }

--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -1,3 +1,5 @@
+import { closestElement } from "@html_editor/utils/dom_traversal";
+
 export const COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES = [
     "primary",
     "secondary",
@@ -131,4 +133,56 @@ export function isColorCombinationName(name) {
  */
 export function isColorGradient(value) {
     return value && value.includes("-gradient(");
+}
+
+export const TEXT_CLASSES_REGEX = /\btext-[^\s]*\b/;
+export const BG_CLASSES_REGEX = /\bbg-[^\s]*\b/;
+
+/**
+ * Returns true if the given element has a visible color (fore- or
+ * -background depending on the given mode).
+ *
+ * @param {Element} element
+ * @param {string} mode 'color' or 'backgroundColor'
+ * @returns {boolean}
+ */
+export function hasColor(element, mode) {
+    const style = element.style;
+    const parent = element.parentNode;
+    const classRegex = mode === "color" ? TEXT_CLASSES_REGEX : BG_CLASSES_REGEX;
+    if (isColorGradient(style["background-image"])) {
+        if (element.classList.contains("text-gradient")) {
+            if (mode === "color") {
+                return true;
+            }
+        } else {
+            if (mode !== "color") {
+                return true;
+            }
+        }
+    }
+    return (
+        (style[mode] &&
+            style[mode] !== "inherit" &&
+            (!parent || style[mode] !== parent.style[mode])) ||
+        (classRegex.test(element.className) &&
+            (!parent || getComputedStyle(element)[mode] !== getComputedStyle(parent)[mode]))
+    );
+}
+
+/**
+ * Returns true if any given nodes has a visible color (fore- or
+ * -background depending on the given mode).
+ *
+ * @param {array} nodes
+ * @param {string} mode 'color' or 'backgroundColor'
+ * @returns {boolean}
+ */
+export function hasAnyNodesColor(nodes, mode) {
+    for (const node of nodes) {
+        if (hasColor(closestElement(node), mode)) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -151,6 +151,26 @@ test("selected text color is shown in the toolbar and update when clicking", asy
     await animationFrame();
     expect("i.fa-font").toHaveStyle({ borderBottomColor: "rgb(255, 0, 255)" });
 });
+test("selected text color is not shown in the toolbar after removeFormat", async () => {
+    const { el } = await setupEditor(
+        `<p>
+            <font style="color: rgb(255, 0, 0);">t[es]t</font>
+        </p>`
+    );
+
+    await waitFor(".o-we-toolbar");
+    expect(".o_font_color_selector").toHaveCount(0);
+    expect("i.fa-font").toHaveStyle({ borderBottomColor: "rgb(255, 0, 0)" });
+    click(".btn.fa-eraser");
+    await animationFrame();
+    expect(getContent(el)).toBe(`<p>
+            <font style="color: rgb(255, 0, 0);">t</font>[es]<font style="color: rgb(255, 0, 0);">t</font>
+        </p>`);
+    await animationFrame();
+    // rgb(73, 80, 87) is aparently the default body color in the Hoot unit test
+    // in community.
+    expect("i.fa-font").toHaveStyle({ borderBottomColor: "rgb(73, 80, 87)" });
+});
 
 test("collapsed selection color is shown in the permanent toolbar", async () => {
     await setupWysiwyg({
@@ -169,7 +189,10 @@ test("selected color is shown and updates when selection change", async () => {
     expect(".o_font_color_selector").toHaveCount(0);
     await animationFrame();
     expect("i.fa-font").toHaveStyle({ borderBottomColor: "rgb(150, 255, 0)" });
-    setContent(el, `<p><font style="color: rgb(255, 156, 0);">[test1]</font> <font style="color: rgb(150, 255, 0);">test2</font></p>`);
+    setContent(
+        el,
+        `<p><font style="color: rgb(255, 156, 0);">[test1]</font> <font style="color: rgb(150, 255, 0);">test2</font></p>`
+    );
     await animationFrame();
     expect("i.fa-font").toHaveStyle({ borderBottomColor: "rgb(255, 156, 0)" });
 });

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -1,5 +1,8 @@
-import { test } from "@odoo/hoot";
-import { testEditor } from "../_helpers/editor";
+import { describe, expect, test } from "@odoo/hoot";
+import { setupEditor, testEditor } from "../_helpers/editor";
+import { getContent } from "../_helpers/selection";
+import { click, waitFor } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
 
 test("should do nothing if no format is set", async () => {
     await testEditor({
@@ -370,7 +373,7 @@ test("should remove text color (5)", async () => {
         contentBefore: '<div>a<font style="color: rgb(255, 0, 0);">b[cd]e</font>f</div>',
         stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
         contentAfter:
-            '<div>a<font style="color: rgb(255, 0, 0);">b[</font>cd]<font style="color: rgb(255, 0, 0);">e</font>f</div>',
+            '<div>a<font style="color: rgb(255, 0, 0);">b</font>[cd]<font style="color: rgb(255, 0, 0);">e</font>f</div>',
     });
 });
 test("should remove text color (6)", async () => {
@@ -378,7 +381,7 @@ test("should remove text color (6)", async () => {
         contentBefore: '<div>a<font style="color: red">b[cd]e</font>f</div>',
         stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
         contentAfter:
-            '<div>a<font style="color: red">b[</font>cd]<font style="color: red">e</font>f</div>',
+            '<div>a<font style="color: red">b</font>[cd]<font style="color: red">e</font>f</div>',
     });
 });
 test("should remove text color (7)", async () => {
@@ -386,7 +389,7 @@ test("should remove text color (7)", async () => {
         contentBefore: '<div>a<font style="color: #ff0000">b[cd]e</font>f</div>',
         stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
         contentAfter:
-            '<div>a<font style="color: #ff0000">b[</font>cd]<font style="color: #ff0000">e</font>f</div>',
+            '<div>a<font style="color: #ff0000">b</font>[cd]<font style="color: #ff0000">e</font>f</div>',
     });
 });
 test("should remove text color (8)", async () => {
@@ -437,7 +440,7 @@ test("should remove background color (6)", async () => {
         contentBefore: '<div>a<font style="background: rgb(255, 0, 0);">b[cd]e</font>f</div>',
         stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
         contentAfter:
-            '<div>a<font style="background: rgb(255, 0, 0);">b[</font>cd]<font style="background: rgb(255, 0, 0);">e</font>f</div>',
+            '<div>a<font style="background: rgb(255, 0, 0);">b</font>[cd]<font style="background: rgb(255, 0, 0);">e</font>f</div>',
     });
 });
 test("should remove background color (7)", async () => {
@@ -445,7 +448,7 @@ test("should remove background color (7)", async () => {
         contentBefore: '<div>a<font style="background: red">b[cd]e</font>f</div>',
         stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
         contentAfter:
-            '<div>a<font style="background: red">b[</font>cd]<font style="background: red">e</font>f</div>',
+            '<div>a<font style="background: red">b</font>[cd]<font style="background: red">e</font>f</div>',
     });
 });
 test("should remove background color (8)", async () => {
@@ -453,7 +456,7 @@ test("should remove background color (8)", async () => {
         contentBefore: '<div>a<font style="background: #ff0000">b[cd]e</font>f</div>',
         stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
         contentAfter:
-            '<div>a<font style="background: #ff0000">b[</font>cd]<font style="background: #ff0000">e</font>f</div>',
+            '<div>a<font style="background: #ff0000">b</font>[cd]<font style="background: #ff0000">e</font>f</div>',
     });
 });
 test("should remove background color (9)", async () => {
@@ -461,7 +464,7 @@ test("should remove background color (9)", async () => {
         contentBefore: '<div>a<font style="background-color: #ff0000">b[cd]e</font>f</div>',
         stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
         contentAfter:
-            '<div>a<font style="background-color: #ff0000">b[</font>cd]<font style="background-color: #ff0000">e</font>f</div>',
+            '<div>a<font style="background-color: #ff0000">b</font>[cd]<font style="background-color: #ff0000">e</font>f</div>',
     });
 });
 test("should remove background color (10)", async () => {
@@ -480,16 +483,18 @@ test("should remove the background image when clear the format", async () => {
         contentAfter: "<div><p>[ab]</p></div>",
     });
 });
-test("should remove all the colors for the text separated by Shift+Enter when using removeFormat button", async () => {
+test("should remove all the colors for the text separated by Shift+Enter when using removeFormat button (1)", async () => {
     await testEditor({
         contentBefore: `<div><h1><font style="color: red">[ab</font><br><font style="color: red">cd</font><br><font style="color: red">ef]</font></h1></div>`,
         stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
         contentAfter: `<div><h1>[ab<br>cd<br>ef]</h1></div>`,
     });
+});
+test("should remove all the colors for the text separated by Shift+Enter when using removeFormat button (2)", async () => {
     await testEditor({
         contentBefore: `<div><h1><font style="color: red">[ab</font><br><font style="color: red">cd</font><br><font style="color: red">]ef</font></h1></div>`,
         stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
-        contentAfter: `<div><h1>[ab<br>cd]<br><font style="color: red">ef</font></h1></div>`,
+        contentAfter: `<div><h1>[ab<br>cd<br><font style="color: red">]ef</font></h1></div>`,
     });
 });
 test("should remove all the colors for the text separated by Enter when using removeFormat button", async () => {
@@ -562,7 +567,7 @@ test("should remove multiple color (5)", async () => {
         contentBefore:
             '<div>ab<font style="background: blue">c[d<font class="bg-o-color-1">ef]</font></font>gh</div>',
         stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
-        contentAfter: '<div>ab<font style="background: blue">c[</font>def]gh</div>',
+        contentAfter: '<div>ab<font style="background: blue">c</font>[def]gh</div>',
     });
 });
 // TODO: we should avoid <font> element into <font> element when possible
@@ -572,6 +577,77 @@ test.todo("should remove multiple color (6)", async () => {
             '<div>ab<font style="background: blue">c[d<font class="bg-o-color-1">e]f</font></font>gh</div>',
         stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
         contentAfter:
-            '<div>ab<font style="background: blue">c[</font>de]<font class="bg-o-color-1">f</font>gh</div>',
+            '<div>ab<font style="background: blue">c</font>[de]<font class="bg-o-color-1">f</font>gh</div>',
+    });
+});
+describe("Toolbar", () => {
+    async function removeFormatClick() {
+        await waitFor(".o-we-toolbar");
+        expect(".o-we-toolbar").toHaveCount(1); // toolbar open
+        expect(".btn.fa-eraser").toHaveCount(1); // remove format
+        expect(".btn.fa-eraser:not(.disabled)").toHaveCount(1); // remove format button should not be disabled
+
+        click(".btn.fa-eraser");
+        await animationFrame();
+        expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+        expect(".btn.fa-eraser.disabled").toHaveCount(1); // remove format button should be disabled
+    }
+
+    test("Should remove bold from selection", async () => {
+        const { el } = await setupEditor(`<p>this <b>is[ a ]UX</b> test.</p>`);
+        await removeFormatClick();
+        expect(getContent(el)).toBe(`<p>this <b>is</b>[ a ]<b>UX</b> test.</p>`);
+    });
+
+    test("Should remove color from selection", async () => {
+        const { el } = await setupEditor(
+            `<p>this <span style="color:red">is[ a ]UX</span> test.</p>`
+        );
+        await removeFormatClick();
+        expect(getContent(el)).toBe(
+            `<p>this <span style="color:red">is</span>[ a ]<span style="color:red">UX</span> test.</p>`
+        );
+        click(".btn.fa-eraser");
+        expect(getContent(el)).toBe(
+            `<p>this <span style="color:red">is</span>[ a ]<span style="color:red">UX</span> test.</p>`
+        );
+    });
+
+    test("Should remove background color from selection", async () => {
+        const { el } = await setupEditor(
+            `<p>this <span style="background:green">is[ a ]UX</span> test.</p>`
+        );
+        await removeFormatClick();
+        expect(getContent(el)).toBe(
+            `<p>this <span style="background:green">is</span>[ a ]<span style="background:green">UX</span> test.</p>`
+        );
+    });
+
+    test("Should remove background class color from selection", async () => {
+        const { el } = await setupEditor(
+            `<p>this <font class="text-o-color-1">is[ a ]UX</font> test.</p>`
+        );
+        await removeFormatClick();
+        expect(getContent(el)).toBe(
+            `<p>this <font class="text-o-color-1">is</font>[ a ]<font class="text-o-color-1">UX</font> test.</p>`
+        );
+    });
+
+    test("Should do nothing when no format in selection", async () => {
+        const { el } = await setupEditor(
+            `<p>this <span class="random-class">is[ a ]UX</span> test.</p>`
+        );
+        await waitFor(".o-we-toolbar");
+        expect(".o-we-toolbar").toHaveCount(1); // toolbar open
+        expect(".btn.fa-eraser").toHaveCount(1); // remove format
+        expect(".btn.fa-eraser.disabled").toHaveCount(1); // remove format button should be disabled when no format
+
+        click(".btn.fa-eraser");
+        await animationFrame();
+        expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+        expect(".btn.fa-eraser.disabled").toHaveCount(1); // remove format button should still be disabled
+        expect(getContent(el)).toBe(
+            `<p>this <span class="random-class">is[ a ]UX</span> test.</p>`
+        );
     });
 });


### PR DESCRIPTION
REF : Move some color related function from color_plugin.js into the color.js util

FIX : Fix a bug in the color_selector were it was sometimes showing the wrong color, The color of the previous element if the selection was like this : `<font style="color:red">ab[</font>cd]...`

ADD : Disable the remove format button in the toolbar if the current selected text is not formated

ADD : add some UX tests for remove format stuffs