### PR TITLE
[IMP] crm,mail,base cli/obfuscate: add a new parameter 'obfuscate' on field model (default=False).

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -103,7 +103,7 @@ class Lead(models.Model):
     # Description
     name = fields.Char(
         'Opportunity', index='trigram', required=True,
-        compute='_compute_name', readonly=False, store=True)
+        compute='_compute_name', readonly=False, store=True, obfuscate=True)
     user_id = fields.Many2one(
         'res.users', string='Salesperson', default=lambda self: self.env.user,
         domain="['&', ('share', '=', False), ('company_ids', 'in', user_company_ids)]",
@@ -122,7 +122,7 @@ class Lead(models.Model):
         'res.company', string='Company', index=True,
         compute='_compute_company_id', readonly=False, store=True)
     referred = fields.Char('Referred By')
-    description = fields.Html('Notes')
+    description = fields.Html('Notes', obfuscate=True)
     active = fields.Boolean('Active', default=True, tracking=True)
     type = fields.Selection([
         ('lead', 'Lead'), ('opportunity', 'Opportunity')], required=True, tracking=15, index=True,
@@ -174,27 +174,27 @@ class Lead(models.Model):
     partner_is_blacklisted = fields.Boolean('Partner is blacklisted', related='partner_id.is_blacklisted', readonly=True)
     contact_name = fields.Char(
         'Contact Name', tracking=30,
-        compute='_compute_contact_name', readonly=False, store=True)
+        compute='_compute_contact_name', readonly=False, store=True, obfuscate=True)
     partner_name = fields.Char(
         'Company Name', tracking=20,
-        compute='_compute_partner_name', readonly=False, store=True,
+        compute='_compute_partner_name', readonly=False, store=True, obfuscate=True,
         help='The name of the future partner company that will be created while converting the lead into opportunity')
     function = fields.Char('Job Position', compute='_compute_function', readonly=False, store=True)
-    title = fields.Many2one('res.partner.title', string='Title', compute='_compute_title', readonly=False, store=True)
+    title = fields.Many2one('res.partner.title', string='Title', compute='_compute_title', readonly=False, store=True, obfuscate=True)
     email_from = fields.Char(
         'Email', tracking=40, index='trigram',
-        compute='_compute_email_from', inverse='_inverse_email_from', readonly=False, store=True)
+        compute='_compute_email_from', inverse='_inverse_email_from', readonly=False, store=True, obfuscate=True)
     phone = fields.Char(
         'Phone', tracking=50,
-        compute='_compute_phone', inverse='_inverse_phone', readonly=False, store=True)
-    mobile = fields.Char('Mobile', compute='_compute_mobile', readonly=False, store=True)
+        compute='_compute_phone', inverse='_inverse_phone', readonly=False, store=True, obfuscate=True)
+    mobile = fields.Char('Mobile', compute='_compute_mobile', readonly=False, store=True, obfuscate=True)
     phone_state = fields.Selection([
         ('correct', 'Correct'),
         ('incorrect', 'Incorrect')], string='Phone Quality', compute="_compute_phone_state", store=True)
     email_state = fields.Selection([
         ('correct', 'Correct'),
         ('incorrect', 'Incorrect')], string='Email Quality', compute="_compute_email_state", store=True)
-    website = fields.Char('Website', help="Website of the contact", compute="_compute_website", readonly=False, store=True)
+    website = fields.Char('Website', help="Website of the contact", compute="_compute_website", readonly=False, store=True, obfuscate=True)
     lang_id = fields.Many2one(
         'res.lang', string='Language',
         compute='_compute_lang_id', readonly=False, store=True)

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -83,9 +83,9 @@ class Message(models.Model):
         return res
 
     # content
-    subject = fields.Char('Subject')
+    subject = fields.Char('Subject', obfuscate=True)
     date = fields.Datetime('Date', default=fields.Datetime.now)
-    body = fields.Html('Contents', default='', sanitize_style=True)
+    body = fields.Html('Contents', default='', sanitize_style=True, obfuscate=True)
     description = fields.Char(
         'Short description', compute="_compute_description",
         help='Message description: either the subject, or the beginning of the body')
@@ -122,7 +122,7 @@ class Message(models.Model):
         index=True, ondelete='set null')
     is_internal = fields.Boolean('Employee Only', help='Hide to public / portal users, independently from subtype configuration.')
     # origin
-    email_from = fields.Char('From', help="Email address of the sender. This field is set when no matching partner is found and replaces the author_id field in the chatter.")
+    email_from = fields.Char('From', obfuscate=True, help="Email address of the sender. This field is set when no matching partner is found and replaces the author_id field in the chatter.")
     author_id = fields.Many2one(
         'res.partner', 'Author', index=True, ondelete='set null',
         help="Author of the message. If not set, email_from may hold an email address that did not match any partner.")
@@ -163,7 +163,7 @@ class Message(models.Model):
         'No threading for answers',
         help='If true, answers do not go in the original document discussion thread. Instead, it will check for the reply_to in tracking message-id and redirected accordingly. This has an impact on the generated message-id.')
     message_id = fields.Char('Message-Id', help='Message unique identifier', index='btree', readonly=1, copy=False)
-    reply_to = fields.Char('Reply-To', help='Reply email address. Setting the reply_to bypasses the automatic thread creation.')
+    reply_to = fields.Char('Reply-To', obfuscate=True, help='Reply email address. Setting the reply_to bypasses the automatic thread creation.')
     mail_server_id = fields.Many2one('ir.mail_server', 'Outgoing mail server')
     # keep notification layout informations to be able to generate mail again
     email_layout_xmlid = fields.Char('Layout', copy=False)  # xml id of layout

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -20,15 +20,15 @@ class MailTracking(models.Model):
     old_value_integer = fields.Integer('Old Value Integer', readonly=1)
     old_value_float = fields.Float('Old Value Float', readonly=1)
     old_value_monetary = fields.Float('Old Value Monetary', readonly=1)
-    old_value_char = fields.Char('Old Value Char', readonly=1)
-    old_value_text = fields.Text('Old Value Text', readonly=1)
+    old_value_char = fields.Char('Old Value Char', readonly=1, obfuscate=True)
+    old_value_text = fields.Text('Old Value Text', readonly=1, obfuscate=True)
     old_value_datetime = fields.Datetime('Old Value DateTime', readonly=1)
 
     new_value_integer = fields.Integer('New Value Integer', readonly=1)
     new_value_float = fields.Float('New Value Float', readonly=1)
     new_value_monetary = fields.Float('New Value Monetary', readonly=1)
-    new_value_char = fields.Char('New Value Char', readonly=1)
-    new_value_text = fields.Text('New Value Text', readonly=1)
+    new_value_char = fields.Char('New Value Char', readonly=1, obfuscate=True)
+    new_value_text = fields.Text('New Value Text', readonly=1, obfuscate=True)
     new_value_datetime = fields.Datetime('New Value Datetime', readonly=1)
 
     currency_id = fields.Many2one('res.currency', 'Currency', readonly=True, ondelete='set null',

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -35,7 +35,7 @@ class Country(models.Model):
     _order = 'name'
 
     name = fields.Char(
-        string='Country Name', required=True, translate=True)
+        string='Country Name', required=True, translate=True, obfuscate=True)
     code = fields.Char(
         string='Country Code', size=2,
         help='The ISO country code in two chars. \nYou can use this field for quick search.')

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -197,8 +197,8 @@ class Partner(models.Model):
                 values['type'] = None
         return values
 
-    name = fields.Char(index=True, default_export_compatible=True)
-    display_name = fields.Char(compute='_compute_display_name', recursive=True, store=True, index=True)
+    name = fields.Char(index=True, default_export_compatible=True, obfuscate=True)
+    display_name = fields.Char(compute='_compute_display_name', recursive=True, store=True, index=True, obfuscate=True)
     translated_display_name = fields.Char(compute='_compute_translated_display_name')
     date = fields.Date(index=True)
     title = fields.Many2one('res.partner.title')
@@ -221,13 +221,13 @@ class Partner(models.Model):
         precompute=True,  # avoid queries post-create
         readonly=False, store=True,
         help='The internal user in charge of this contact.')
-    vat = fields.Char(string='Tax ID', index=True, help="The Tax Identification Number. Values here will be validated based on the country format. You can use '/' to indicate that the partner is not subject to tax.")
+    vat = fields.Char(string='Tax ID', index=True, obfuscate=True, help="The Tax Identification Number. Values here will be validated based on the country format. You can use '/' to indicate that the partner is not subject to tax.")
     same_vat_partner_id = fields.Many2one('res.partner', string='Partner with same Tax ID', compute='_compute_same_vat_partner_id', store=False)
     same_company_registry_partner_id = fields.Many2one('res.partner', string='Partner with same Company Registry', compute='_compute_same_vat_partner_id', store=False)
     company_registry = fields.Char(string="Company ID", compute='_compute_company_registry', store=True, readonly=False,
        help="The registry number of the company. Use it if it is different from the Tax ID. It must be unique across all partners of a same country")
     bank_ids = fields.One2many('res.partner.bank', 'partner_id', string='Banks')
-    website = fields.Char('Website Link')
+    website = fields.Char('Website Link', obfuscate=True)
     comment = fields.Html(string='Notes')
 
     category_id = fields.Many2many('res.partner.category', column1='partner_id',
@@ -249,21 +249,21 @@ class Partner(models.Model):
              "- Private: Private addresses are only visible by authorized users and contain sensitive data (employee home addresses, ...).\n"
              "- Other: Other address for the company (e.g. subsidiary, ...)")
     # address fields
-    street = fields.Char()
-    street2 = fields.Char()
-    zip = fields.Char(change_default=True)
-    city = fields.Char()
+    street = fields.Char(obfuscate=True)
+    street2 = fields.Char(obfuscate=True)
+    zip = fields.Char(change_default=True, obfuscate=True)
+    city = fields.Char(obfuscate=True)
     state_id = fields.Many2one("res.country.state", string='State', ondelete='restrict', domain="[('country_id', '=?', country_id)]")
     country_id = fields.Many2one('res.country', string='Country', ondelete='restrict')
     country_code = fields.Char(related='country_id.code', string="Country Code")
     partner_latitude = fields.Float(string='Geo Latitude', digits=(10, 7))
     partner_longitude = fields.Float(string='Geo Longitude', digits=(10, 7))
-    email = fields.Char()
+    email = fields.Char(obfuscate=True)
     email_formatted = fields.Char(
         'Formatted Email', compute='_compute_email_formatted',
         help='Format email address "Name <email@domain>"')
-    phone = fields.Char(unaccent=False)
-    mobile = fields.Char(unaccent=False)
+    phone = fields.Char(unaccent=False, obfuscate=True)
+    mobile = fields.Char(unaccent=False, obfuscate=True)
     is_company = fields.Boolean(string='Is a Company', default=False,
         help="Check if the contact is a company, otherwise it is a person")
     is_public = fields.Boolean(compute='_compute_is_public')

--- a/odoo/cli/obfuscate.py
+++ b/odoo/cli/obfuscate.py
@@ -157,37 +157,11 @@ class Obfuscate(Command):
                 self.cr = cr
                 self.begin()
                 if self.check_pwd(opt.pwd):
-                    fields = [
-                            ('mail_tracking_value', 'old_value_char'),
-                            ('mail_tracking_value', 'old_value_text'),
-                            ('mail_tracking_value', 'new_value_char'),
-                            ('mail_tracking_value', 'new_value_text'),
-                            ('res_partner', 'name'),
-                            ('res_partner', 'display_name'),
-                            ('res_partner', 'email'),
-                            ('res_partner', 'phone'),
-                            ('res_partner', 'mobile'),
-                            ('res_partner', 'street'),
-                            ('res_partner', 'street2'),
-                            ('res_partner', 'city'),
-                            ('res_partner', 'zip'),
-                            ('res_partner', 'vat'),
-                            ('res_partner', 'website'),
-                            ('res_country', 'name'),
-                            ('mail_message', 'subject'),
-                            ('mail_message', 'email_from'),
-                            ('mail_message', 'reply_to'),
-                            ('mail_message', 'body'),
-                            ('crm_lead', 'title'),
-                            ('crm_lead', 'name'),
-                            ('crm_lead', 'contact_name'),
-                            ('crm_lead', 'partner_name'),
-                            ('crm_lead', 'email_from'),
-                            ('crm_lead', 'phone'),
-                            ('crm_lead', 'mobile'),
-                            ('crm_lead', 'website'),
-                            ('crm_lead', 'description'),
-                        ]
+                    fields = []
+                    for model in self.registry.models.values():
+                        for field in model._fields.values():
+                            if field.obfuscate:
+                                fields.append((model._table, field.name))
 
                     if opt.fields:
                         if not opt.allfields:

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -332,6 +332,7 @@ class Field(MetaField('DummyField', (object,), {})):
 
     default_export_compatible = False   # whether the field must be exported by default in an import-compatible export
     exportable = True
+    obfuscate = False                   # whether the field is obfuscated by obfuscate cli tool
 
     def __init__(self, string=Default, **kwargs):
         kwargs['string'] = string


### PR DESCRIPTION
 If set to True, the field will be obfuscated when running the cli tool 'obfuscate'.

**Pro:**
- obfuscated fields are not hardcoded anymore.
- That design allows to change by code the default Odoo values. (some settings can be debatable, like ``res_country.name``.
- In custom modules that adds fields with sensitive data, it is possible to define the field as to be obfuscated by default.

See Comment : https://github.com/odoo/odoo/pull/156944#discussion_r1526275833

As asked by some people, the proposal doesn't change the db layout. (as the PR is against 16.0 stable version).

Original author : @nseinlet 
CC : Community contributors : @Yenthe666, @etobella, @simahawk, @moylop260
CC Odoo members :  @KangOl, @odony 

Thanks for your review.