### PR TITLE
[IMP] (website_)sale, web: improve product configurator modal in frond-end

### DIFF
--- a/addons/sale/static/src/js/badge_extra_price/badge_extra_price.xml
+++ b/addons/sale/static/src/js/badge_extra_price/badge_extra_price.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.BadgeExtraPrice">
-        <span class="badge ms-1 ps-1 text-bg-info rounded-pill">
+        <span class="badge rounded-pill border ps-1 text-bg-light">
             <span t-out="this.props.price > 0 ? '+' : '-'" class="me-1"/>
             <i t-out="getFormattedPrice()"/>
         </span>

--- a/addons/sale/static/src/js/product/product.scss
+++ b/addons/sale/static/src/js/product/product.scss
@@ -9,12 +9,16 @@
 }
 
 .o_sale_product_configurator_img {
-    width: 120px;
+    width: 40px;
     max-height: 240px;
+
+    @include media-breakpoint-up(md) {
+        width: 120px;
+    }
 }
 
 .o_sale_product_configurator_qty {
-    width: 160px;
+    width: 64px;
 
     input {
         max-width: 4rem;
@@ -29,8 +33,16 @@
             -moz-appearance: textfield;
         }
     }
+
+    @include media-breakpoint-up(md) {
+        width: 160px;
+    }
 }
 
 .o_sale_product_configurator_price {
-    width: 160px;
+    width: 100px;
+
+    @include media-breakpoint-up(md) {
+        width: 160px;
+    }
 }

--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -32,7 +32,7 @@
             <t t-if="!this.props.optional">
                 <div
                     name="sale_product_configurator_quantity_buttons"
-                    class="input-group justify-content-end">
+                    class="input-group justify-content-center">
                     <button
                         class="btn btn-secondary d-none d-md-inline-block"
                         aria-label="Remove one"

--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -15,7 +15,7 @@
         </td>
         <td class="p-3" t-att-colspan="this.props.optional ? 2:false">
             <div class="mb-4 text-break" name="o_sale_product_configurator_name">
-                <h5 t-out="this.props.display_name"/>
+                <span class="h5" t-out="this.props.display_name"/>
                 <div
                     t-if="this.props.description_sale"
                     t-out="this.props.description_sale"
@@ -40,7 +40,7 @@
                         <i class="fa fa-minus"/>
                     </button>
                     <input
-                        class="form-control quantity border-bottom border-top text-center"
+                        class="form-control quantity text-center"
                         name="product_quantity"
                         type="number"
                         t-att-value="this.props.quantity"
@@ -74,14 +74,14 @@
                     class="btn btn-secondary"
                     t-att-class="{'disabled': !this.env.isPossibleCombination(this.props)}"
                     t-on-click="() => this.env.addProduct(this.props.product_tmpl_id)">
-                    <i class="fa fa-plus"/> Add
+                    <i class="fa fa-plus d-none d-md-inline" role="img"/> Add
                 </button>
             </t>
         </td>
     </t>
 
     <t t-name="sale.product_price">
-        <h5 class="text-nowrap" t-out="getFormattedPrice()"/>
+        <span class="h5 text-nowrap" t-out="getFormattedPrice()"/>
         <span t-if="this.props.price_info" t-out="this.props.price_info" class="text-muted"/>
     </t>
 </templates>

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.ProductConfiguratorDialog">
-        <Dialog size="size" title="title" contentClass="this.state.optionalProducts.length ? 'h-sm-75' : ''">
+        <Dialog size="size" title="title" contentClass="'o_sale_product_configurator_dialog'">
             <ProductList t-if="this.state.products.length" products="this.state.products"/>
             <ProductList
                 t-if="this.state.optionalProducts.length"

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.ProductConfiguratorDialog">
-        <Dialog size="size" title="title" contentClass="this.state.optionalProducts.length ? 'h-75' : ''">
+        <Dialog size="size" title="title" contentClass="this.state.optionalProducts.length ? 'h-sm-75' : ''">
             <ProductList t-if="this.state.products.length" products="this.state.products"/>
             <ProductList
                 t-if="this.state.optionalProducts.length"

--- a/addons/sale/static/src/js/product_list/product_list.xml
+++ b/addons/sale/static/src/js/product_list/product_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.ProductList">
-        <h4 class="mt-4 mb-3" t-if="this.props.areProductsOptional" t-out="optionalProductsTitle"/>
+        <span class="d-inline-block mt-4 mb-3 h4" t-if="this.props.areProductsOptional" t-out="optionalProductsTitle"/>
         <table class="o_sale_product_configurator_table table table-sm position-relative mb-0" t-att-class="{'o_sale_product_configurator_table_optional': this.props.areProductsOptional}">
             <thead t-if="!this.props.areProductsOptional">
                 <tr>
@@ -16,7 +16,7 @@
                 </tr>
                 <tr t-if="!this.props.areProductsOptional">
                     <td colspan="4" class="border-bottom-0 text-end">
-                        <h4>Total: <span t-out="getFormattedTotal()"/></h4>
+                        <span class="h4">Total: <span t-out="getFormattedTotal()"/></span>
                     </td>
                 </tr>
             </tbody>

--- a/addons/sale/static/src/js/product_list/product_list.xml
+++ b/addons/sale/static/src/js/product_list/product_list.xml
@@ -6,7 +6,7 @@
             <thead t-if="!this.props.areProductsOptional">
                 <tr>
                     <th class="px-0 border-bottom-0" colspan="2">Product</th>
-                    <th class="px-0 text-end border-bottom-0">Quantity</th>
+                    <th class="px-0 text-center border-bottom-0">Quantity</th>
                     <th class="px-0 text-end border-bottom-0">Price</th>
                 </tr>
             </thead>

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.scss
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.scss
@@ -1,3 +1,15 @@
+.o_sale_product_configurator_table {
+    div[name="ptal"] > div {
+        @include media-breakpoint-up(lg) {
+            align-items: center;
+        }
+
+        &:has(.form-check) {
+            align-items: flex-start;
+        }
+    }
+}
+
 .o_sale_product_configurator_ptav_color {
     border: 5px solid $border-color;
     transition: $input-transition;

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -16,7 +16,7 @@
                 <t t-if="showValuesChoice" t-call="{{getPTAVTemplate()}}"/>
             </div>
             <input
-                class="o_input w-75 mb-4 ms-lg-auto"
+                class="o_input w-lg-75 mb-4 ms-lg-auto"
                 type="text"
                 placeholder="Enter a customized value"
                 t-if="hasPTAVCustom &amp;&amp; isSelectedPTAVCustom()"
@@ -27,7 +27,7 @@
     </t>
     <!-- Attributes value templates -->
     <t t-name="sale.ptav_select">
-        <select class="o_input w-50 flex-grow-1"
+        <select class="o_input w-lg-50 flex-grow-1"
             t-on-change="updateSelectedPTAV"
             t-att-name="'ptal-' + this.props.id">
             <option
@@ -46,10 +46,10 @@
                 class="mb-2">
                 <div class="form-check">
                     <label
-                        class="form-check-label d-inline-flex align-items-center"
+                        class="form-check-label d-inline-flex align-items-center flex-wrap"
                         t-att-class="{ 'css_not_available': ptav.excluded }"
                         t-attf-for="ptav-{{ptav.id}}-input">
-                        <span t-out="ptav.name"/>
+                        <span class="me-1" t-out="ptav.name"/>
                         <BadgeExtraPrice
                             t-if="ptav.price_extra"
                             price="ptav.price_extra"

--- a/addons/website_sale/static/src/js/product/product.xml
+++ b/addons/website_sale/static/src/js/product/product.xml
@@ -3,12 +3,20 @@
     <t t-inherit="sale.Product" t-inherit-mode="extension">
         <div name="sale_product_configurator_quantity_buttons" position="attributes">
             <attribute name="t-if">this.props.can_be_sold</attribute>
+            <attribute name="class" add="css_quantity" separator=" "/>
         </div>
+        <xpath expr="//div[@name='sale_product_configurator_quantity_buttons']//button[1]" position="attributes">
+            <attribute name="class" remove="btn-secondary" add="btn-light" separator=" "/>
+        </xpath>
+        <xpath expr="//div[@name='sale_product_configurator_quantity_buttons']//button[2]" position="attributes">
+            <attribute name="class" remove="btn-secondary" add="btn-light" separator=" "/>
+        </xpath>
         <div name="sale_product_configurator_quantity_buttons" position="after">
             <t t-call="website_sale.not_for_sale"/>
         </div>
         <button name="sale_product_configurator_add_button" position="attributes">
             <attribute name="t-if">this.props.can_be_sold</attribute>
+            <attribute name="class" remove="btn-secondary" add="btn-light" separator=" "/>
         </button>
         <button name="sale_product_configurator_add_button" position="after">
             <t t-call="website_sale.not_for_sale"/>
@@ -19,6 +27,15 @@
         <t name="sale_product_configurator_optional_price" position="before">
             <t t-call="website_sale.strikethrough_product_price"/>
         </t>
+        <xpath expr="//span[hasclass('h5')]" position="attributes">
+            <attribute name="class" remove="h5" add="h6" separator=" "/>
+        </xpath>
+    </t>
+
+    <t t-inherit="sale.product_price" t-inherit-mode="extension">
+        <xpath expr="//span[hasclass('h5')]" position="attributes">
+            <attribute name="class" remove="h5" add="h6" separator=" "/>
+        </xpath>
     </t>
 
     <t t-name="website_sale.not_for_sale">

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.scss
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.scss
@@ -1,0 +1,5 @@
+.o_sale_product_configurator_dialog {
+    // Ensure a minimal border regardless by the theme options
+    --modal-header-border-width: #{$border-width};
+    --modal-footer-border-width: #{$border-width};
+}

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -25,4 +25,13 @@
             </t>
         </xpath>
     </t>
+
+    <t t-inherit="sale.ProductList" t-inherit-mode="extension">
+        <xpath expr="//span[hasclass('h4')]" position="attributes">
+            <attribute name="class" remove="h4" add="h5" separator=" "/>
+        </xpath>
+        <xpath expr="//span[hasclass('h4')][1]" position="attributes">
+            <attribute name="class" remove="h4" add="h5" separator=" "/>
+        </xpath>
+    </t>
 </templates>

--- a/addons/website_sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/website_sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -12,5 +12,14 @@
                 <div t-out="getReadOnlyPtal()" class="text-muted small"/>
             </t>
         </div>
+        <xpath expr="//div[@name='ptal']" position="attributes">
+            <attribute name="class" remove="o_input" separator=" "/>
+        </xpath>
+    </t>
+
+    <t t-inherit="sale.ptav_select" t-inherit-mode="extension">
+        <xpath expr="//select" position="attributes">
+            <attribute name="class" add="form-select" separator=" "/>
+        </xpath>
     </t>
 </templates>


### PR DESCRIPTION
`ProductConfiguratorDialog` component is now shared between front-end and back-end. This causes some visual discrepancies, as we obviously don't use the same design in both environments.

This PR adapts `ProductConfiguratorDialog` to make it more visually appealing and usable in the front-end by:

- Reducing font size of text (`font-size` in back-end being `14px` and
`16px` in front-end).
- Improving the responsiveness of columns in the table, tweaking their
and their content's sizes.
- Changing button colors with `btn-light` to be more consistent with
the rest of the front-end.

task-3916399