### PR TITLE
[FIX] html_editor: QwebPlugin cleans up contenteditable

### DIFF
--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -49,7 +49,7 @@ export class QWebPlugin extends Plugin {
                 for (const element of payload.root.querySelectorAll(
                     "[t-esc], [t-raw], [t-out], [t-field]"
                 )) {
-                    element.setAttribute("contenteditable", "false");
+                    element.removeAttribute("contenteditable");
                 }
                 break;
         }

--- a/addons/html_editor/static/tests/qweb.test.js
+++ b/addons/html_editor/static/tests/qweb.test.js
@@ -264,3 +264,33 @@ test("select text inside t-field", async () => {
         `<div>[<t t-field="test" data-oe-t-inline="true" contenteditable="false">Hello</t>]</div>`
     );
 });
+
+test("cleaning removes content editable", async () => {
+    const { el, editor } = await setupEditor(
+        `
+        <div>
+            <t t-field="test">Hello</t>
+            <t t-out="test">Hello</t>
+            <t t-esc="test">Hello</t>
+            <t t-raw="test">Hello</t>
+        </div>`,
+        {
+            config,
+        }
+    );
+    expect(getContent(el)).toBe(`
+        <div>
+            <t t-field="test" data-oe-t-inline="true" contenteditable="false">Hello</t>
+            <t t-out="test" data-oe-t-inline="true" contenteditable="false">Hello</t>
+            <t t-esc="test" data-oe-t-inline="true" contenteditable="false">Hello</t>
+            <t t-raw="test" data-oe-t-inline="true" contenteditable="false">Hello</t>
+        </div>`);
+
+    expect(editor.getContent()).toBe(`
+        <div>
+            <t t-field="test">Hello</t>
+            <t t-out="test">Hello</t>
+            <t t-esc="test">Hello</t>
+            <t t-raw="test">Hello</t>
+        </div>`);
+});


### PR DESCRIPTION
When editing, the QwebPlugin adds the contenteditable="false" attribute on nodes of the form `<t t-[field|raw|out|esc]="expr">default qweb content</t>`.

This is fine because those instructions are processed by the python which puts the right dynamic content, so editing it makes no sense.

But at clean time (for saving the edition to the server), that attribute should be removed as it is not relevant at all for the python, and will probably mess up the qweb template if saved.