### PR TITLE
[FIX] dom_plugin: insert table at the right spot

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -295,12 +295,7 @@ export class DomPlugin extends Plugin {
         if (node === this.editable) {
             return true;
         }
-        for (const callback of this.resources?.["is_edition_boundary"] || []) {
-            const res = callback(node);
-            if (res !== undefined) {
-                return res;
-            }
-        }
+        return node.hasAttribute("contenteditable");
     }
 
     copyAttributes(source, target) {

--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -25,7 +25,7 @@ import { Powerbox } from "./powerbox";
 
 function target(selection) {
     const node = selection.anchorNode;
-    const el = node instanceof Element ? node : node.parentElement;
+    const el = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
     return (el.tagName === "DIV" || el.tagName === "P") && isEmpty(el) && el;
 }
 

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -44,6 +44,13 @@ test.tags("iframe")("in iframe: should open the Powerbox on type `/`", async () 
     expect(".o-we-powerbox").toHaveCount(1);
 });
 
+test("should correctly hint in iframes", async () => {
+    const { el } = await setupEditor("<p>[]<br></p>", { props: { iframe: true } });
+    expect(getContent(el)).toBe(
+        `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+    );
+});
+
 test("should open the Powerbox on type `/`, but in an empty paragraph", async () => {
     const { el, editor } = await setupEditor("<p>[]<br></p>");
     expect(".o-we-powerbox").toHaveCount(0);


### PR DESCRIPTION
Try to insert a table inside a <p>, this <p> in unbreakable. P nodes cannot contain content that is not phrasing content. (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p) The algorithm of the DomPlugin takes this into account, but fails to find a suitable spot to insert the table in.

This commit proposes two things:
1. Continue to search for a place to put the table, possibly inside one of the ancestors of the targetted node
2. A new resource used by the DomPlugin `is_edition_boundary`. The canonical edition boundary is the editable itself, searching for elements cannot be done above it. This concept is somewhat modified to account for a complex edition use case where the manipulated DOM has subtrees that are self-consistent. In the case of the report editor, one actually edits the concatenation of many different Odoo views. Breaking out of the currently edited view just to find a suitable spot for adding elements would be incorrect. The new resource allows for this.