### PR TITLE
[FIX] html_editor: make vertical seperators of toolbar have same length 

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar.scss
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.scss
@@ -7,9 +7,13 @@
     .btn-group {
         padding: 0 2px;
         border-radius: 0;
-     
-        &:not(:first-child) {
-            border-left: 1px solid lightgrey;
-        }
+    }
+
+    .o-we-toolbar-vertical-seperator:not(:first-child) {
+        margin: unset;
+        padding: unset;
+        height: 70%;
+        border-left: 1px solid lightgrey;
+
     }
 }

--- a/addons/html_editor/static/src/main/toolbar/toolbar.xml
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.xml
@@ -2,6 +2,7 @@
     <t t-name="html_editor.Toolbar">
         <div class="o-we-toolbar bg-white d-flex align-items-center m-0"  t-att-class="props.class">
             <t t-foreach="this.getFilteredButtonGroups()" t-as="buttonGroup" t-key="buttonGroup.id">
+                <span class="o-we-toolbar-vertical-seperator"></span>
                 <div class="btn-group" t-att-name="buttonGroup.id">
                     <t t-foreach="buttonGroup.buttons" t-as="button" t-key="button.id">
                         <t t-if="button.Component">


### PR DESCRIPTION
Issue:
======
Vertical seperators doesn't have the same height in the toolbar.

Steps to reproduce the issue:
=============================
- Go to `to-do` app
- Add some text
- Select the text to show the toolbar
- Vertical seperators doesn't have the same height.

Reason behind the issue:
========================
The button groups doesnt have the same height and we use the
`border-left` to display the vertical seperator.

Solution:
=========
Use a span as a seperator so it won't depend anymore on the button group
styles.

Before: 
======
![before-toolbar](https://github.com/odoo-dev/odoo/assets/61123610/f3e82b0a-0a55-4152-8f56-af86755e84f8)

After:
====
![after-toolbar](https://github.com/odoo-dev/odoo/assets/61123610/a1b33cc0-e5fc-4fdb-8848-2e615ff32a3a)


