### PR TITLE
[FIX] html_editor: misc styling issues

### DIFF
--- a/addons/html_editor/models/ir_attachment.py
+++ b/addons/html_editor/models/ir_attachment.py
@@ -3,6 +3,7 @@
 from werkzeug.urls import url_quote
 
 from odoo import api, models, fields, tools
+from odoo.exceptions import UserError
 
 SUPPORTED_IMAGE_MIMETYPES = {
     'image/gif': '.gif',
@@ -66,7 +67,7 @@ class IrAttachment(models.Model):
                 image = tools.base64_to_image(attachment.datas)
                 attachment.image_width = image.width
                 attachment.image_height = image.height
-            except Exception:
+            except UserError:
                 attachment.image_width = 0
                 attachment.image_height = 0
 

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -18,7 +18,7 @@
                                 </t>
                             </t>
                         </select>
-                        <div id="o_link_dialog_button_opts_collapse" t-if="state.type !== 'custom' and state.type !==  ''" class="input-group md-3">
+                        <div t-if="state.type !== 'custom' and state.type !==  ''" class="input-group md-3">
                                 <select name="link_style_size" class="form-select link-style" t-on-change="(ev)=>this.state.buttonSize = ev.target.value">
                                     <t t-foreach="this.buttonSizesData" t-as="buttonSizesData" t-key="buttonSizesData.size">
                                         <option t-att-value="buttonSizesData.size" t-att-selected="state.buttonSize === buttonSizesData.size">
@@ -34,7 +34,7 @@
                                     </t>
                                 </select>
                         </div>
-                        <div class="input-group-append">
+                        <div>
                             <button class="o_we_apply_link btn btn-primary m-1" t-on-click="onClickApply">Apply</button>
                         </div>
                     </div>


### PR DESCRIPTION
The linter was unhappy about some obsolete classes, or some bad practice. This commit remove the offending code