### PR TITLE
[REF] html_editor: rename renderingclasses to mutationFilteredClasses

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -104,7 +104,7 @@ export class HistoryPlugin extends Plugin {
     });
 
     setup() {
-        this.renderingClasses = new Set(this.resources["history_rendering_classes"]);
+        this.mutationFilteredClasses = new Set(this.resources["mutation_filtered_classes"]);
         this.addDomListener(this.editable, "pointerup", () => {
             this.stageSelection();
             this.stageNextSelection = true;
@@ -297,7 +297,7 @@ export class HistoryPlugin extends Plugin {
                 }
                 // @todo @phoenix test attributeCache
                 attributeCache.set(record.target, attributeCache.get(record.target) || {});
-                // @todo @phoenix add test for renderingClasses.
+                // @todo @phoenix add test for mutationFilteredClasses.
                 if (record.attributeName === "class") {
                     const classBefore = (record.oldValue && record.oldValue.split(" ")) || [];
                     const classAfter =
@@ -318,7 +318,7 @@ export class HistoryPlugin extends Plugin {
                     }
                     if (
                         excludedClasses.length &&
-                        excludedClasses.every((c) => this.renderingClasses.has(c))
+                        excludedClasses.every((c) => this.mutationFilteredClasses.has(c))
                     ) {
                         continue;
                     }
@@ -901,7 +901,7 @@ export class HistoryPlugin extends Plugin {
         if (typeof value === "string" && attributeName === "class") {
             value = value
                 .split(" ")
-                .filter((c) => !this.renderingClasses.has(c))
+                .filter((c) => !this.mutationFilteredClasses.has(c))
                 .join(" ");
         }
         return value;

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -23,7 +23,7 @@ export class HintPlugin extends Plugin {
     /** @type { (p: HintPlugin) => Record<string, any> } */
     static resources = (p) => {
         const resources = {
-            history_rendering_classes: ["o-we-hint"],
+            mutation_filtered_classes: ["o-we-hint"],
             is_mutation_record_savable: isMutationRecordSavable,
             onSelectionChange: p.updateTempHint.bind(p),
             onExternalHistorySteps: p.updateHints.bind(p),

--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -52,7 +52,7 @@ export class LinkSelectionPlugin extends Plugin {
     static dependencies = ["selection"];
     /** @type { (p: LinkSelectionPlugin) => Record<string, any> } */
     static resources = (p) => ({
-        history_rendering_classes: ["o_link_in_selection"],
+        mutation_filtered_classes: ["o_link_in_selection"],
         link_ignore_classes: ["o_link_in_selection"],
         onSelectionChange: p.resetLinkInSelection.bind(p),
     });

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -234,15 +234,15 @@ describe("step", () => {
     });
 });
 
-describe("prevent renderingClasses to be set from history", () => {
-    class TestRenderingClassesPlugin extends Plugin {
+describe("prevent mutationFilteredClasses to be set from history", () => {
+    class TestMutationFilteredClassesPlugin extends Plugin {
         static name = "testRenderClasses";
         static resources = () => ({
-            history_rendering_classes: ["x"],
+            mutation_filtered_classes: ["x"],
         });
     }
-    const Plugins = [...MAIN_PLUGINS, TestRenderingClassesPlugin];
-    test("should prevent renderingClasses to be added", async () => {
+    const Plugins = [...MAIN_PLUGINS, TestMutationFilteredClassesPlugin];
+    test("should prevent mutationFilteredClasses to be added", async () => {
         await testEditor({
             contentBefore: `<p>a</p>`,
             stepFunction: async (editor) => {
@@ -256,7 +256,7 @@ describe("prevent renderingClasses to be set from history", () => {
         });
     });
 
-    test("should prevent renderingClasses to be added when adding 2 classes", async () => {
+    test("should prevent mutationFilteredClasses to be added when adding 2 classes", async () => {
         await testEditor({
             contentBefore: `<p>a</p>`,
             stepFunction: async (editor) => {
@@ -271,7 +271,7 @@ describe("prevent renderingClasses to be set from history", () => {
         });
     });
 
-    test("should prevent renderingClasses to be added in historyApply", async () => {
+    test("should prevent mutationFilteredClasses to be added in historyApply", async () => {
         const { el, editor } = await setupEditor(`<p>a</p>`, { config: { Plugins } });
         /** @type import("../src/core/history_plugin").HistoryPlugin") */
         const historyPlugin = editor.plugins.find((p) => p.constructor.name === "history");


### PR DESCRIPTION
Make the terminology clearer and more specific for the classes that are filtered out of the mutations.