### PR TITLE
[IMP] html_editor: deletion around link

### DIFF
--- a/addons/html_editor/static/tests/link/delete.test.js
+++ b/addons/html_editor/static/tests/link/delete.test.js
@@ -1,0 +1,83 @@
+import { describe, test } from "@odoo/hoot";
+import { deleteBackward } from "../_helpers/user_actions";
+import { testEditor } from "../_helpers/editor";
+
+describe("delete selection involving links", () => {
+    test("should remove link", async () => {
+        await testEditor({
+            contentBefore: '<p><a href="#">[abc</a>d]ef</p>',
+            contentBeforeEdit: '<p>\ufeff<a href="#">\ufeff[abc\ufeff</a>\ufeffd]ef</p>',
+            stepFunction: deleteBackward,
+            contentAfterEdit: "<p>[]ef</p>",
+            contentAfter: "<p>[]ef</p>",
+        });
+    });
+    test("should remove link (2)", async () => {
+        await testEditor({
+            contentBefore: '<p>ab[c<a href="#">def]</a></p>',
+            contentBeforeEdit: '<p>ab[c\ufeff<a href="#">\ufeffdef]\ufeff</a>\ufeff</p>',
+            stepFunction: deleteBackward,
+            contentAfterEdit: "<p>ab[]</p>",
+            contentAfter: "<p>ab[]</p>",
+        });
+    });
+    test("should not remove link (only after clean)", async () => {
+        await testEditor({
+            contentBefore: '<p><a href="#">[abc]</a>def</p>',
+            contentBeforeEdit:
+                '<p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[abc]\ufeff</a>\ufeffdef</p>',
+            stepFunction: deleteBackward,
+            contentAfterEdit:
+                '<p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffdef</p>',
+            contentAfter: "<p>[]def</p>",
+        });
+    });
+});
+
+describe("empty list items, starting and ending with links", () => {
+    // Since we introduce \ufeff characters in and around links, we
+    // can enter situations where the links aren't technically fully
+    // selected but should be treated as if they were. These tests
+    // are there to ensure that is the case. They represent four
+    // variations of the same situation, and have the same expected
+    // result.
+    const tests = [
+        // (1) <a>[...</a>...<a>...]</a>
+        '<ul><li>ab</li><li><a href="#">[cd</a></li><li>ef</li><li><a href="#a">gh]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
+        // (2) [<a>...</a>...<a>...]</a>
+        '<ul><li>ab</li><li>[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
+        // (3) <a>[...</a>...<a>...</a>]
+        '<ul><li>ab</li><li><a href="#">[cd</a></li><li>ef</li><li><a href="#a">gh</a>]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
+        // (4) [<a>...</a>...<a>...</a>]
+        '<ul><li>ab</li><li>[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
+        '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
+    ];
+    let testIndex = 1;
+    for (const contentBefore of tests) {
+        test(`should empty list items, starting and ending with links (${testIndex})`, async () => {
+            await testEditor({
+                contentBefore,
+                stepFunction: deleteBackward,
+                contentAfterEdit:
+                    '<ul><li>ab</li><li placeholder="List" class="o-we-hint">[]<br></li><li>ij</li></ul>',
+                contentAfter: "<ul><li>ab</li><li>[]<br></li><li>ij</li></ul>",
+            });
+        });
+        testIndex += 1;
+    }
+});

--- a/addons/html_editor/static/tests/list/delete_backward.test.js
+++ b/addons/html_editor/static/tests/list/delete_backward.test.js
@@ -2232,9 +2232,8 @@ describe("Selection not collapsed", () => {
                 contentBefore:
                     '<ul class="o_checklist"><li>ab</li><li class="o_checked"><a href="#">[cd</a></li><li>ef]</li><li>gh</li></ul>',
                 stepFunction: deleteBackward,
-                // @todo:
-                // contentAfterEdit:
-                // '<ul class="o_checklist"><li>ab</li><li placeholder="List" class="oe-hint">[]<br></li><li>gh</li></ul>',
+                contentAfterEdit:
+                    '<ul class="o_checklist"><li>ab</li><li placeholder="List" class="o-we-hint">[]<br></li><li>gh</li></ul>',
                 contentAfter: '<ul class="o_checklist"><li>ab</li><li>[]<br></li><li>gh</li></ul>',
             });
         });

--- a/addons/html_editor/static/tests/unbreakable/delete.test.js
+++ b/addons/html_editor/static/tests/unbreakable/delete.test.js
@@ -550,56 +550,5 @@ describe("list", () => {
                         </ol>`),
             });
         });
-
-        describe("empty list items, starting and ending with links", () => {
-            // Since we introduce \ufeff characters in and around links, we
-            // can enter situations where the links aren't technically fully
-            // selected but should be treated as if they were. These tests
-            // are there to ensure that is the case. They represent four
-            // variations of the same situation, and have the same expected
-            // result.
-            const tests = [
-                // (1) <a>[...</a>...<a>...]</a>
-                '<ul><li>ab</li><li><a href="#">[cd</a></li><li>ef</li><li><a href="#a">gh]</a></li><li>ij</li></ul>',
-                '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
-                '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
-                '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
-                '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
-                // (2) [<a>...</a>...<a>...]</a>
-                '<ul><li>ab</li><li>[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh]</a></li><li>ij</li></ul>',
-                '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
-                '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh\ufeff]</a></li><li>ij</li></ul>',
-                '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
-                '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh]\ufeff</a></li><li>ij</li></ul>',
-                // (3) <a>[...</a>...<a>...</a>]
-                '<ul><li>ab</li><li><a href="#">[cd</a></li><li>ef</li><li><a href="#a">gh</a>]</li><li>ij</li></ul>',
-                '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
-                '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
-                '<ul><li>ab</li><li><a href="#">[\ufeffcd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
-                '<ul><li>ab</li><li><a href="#">\ufeff[cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
-                // (4) [<a>...</a>...<a>...</a>]
-                '<ul><li>ab</li><li>[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>]</li><li>ij</li></ul>',
-                '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
-                '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>\ufeff]</li><li>ij</li></ul>',
-                '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
-                '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
-            ];
-            let testIndex = 1;
-            for (const contentBefore of tests) {
-                test.todo(
-                    `should empty list items, starting and ending with links (${testIndex})`,
-                    async () => {
-                        await testEditor({
-                            contentBefore,
-                            stepFunction: deleteBackward,
-                            contentAfterEdit:
-                                '<ul><li>ab</li><li placeholder="List" class="oe-hint">[]<br></li><li>ij</li></ul>',
-                            contentAfter: "<ul><li>ab</li><li>[]<br></li><li>ij</li></ul>",
-                        });
-                    }
-                );
-                testIndex += 1;
-            }
-        });
     });
 });


### PR DESCRIPTION
This commits implements the existing spec described for links in lists, and extends it to the general case: when deleting a range that includes the whole content of a link and some content outside of it, the link (anchor) element gets removed from the DOM.

This commit also takes the opportunity to move the related tests out of the "unbreakable" test suite to a more suitable one.