### PR TITLE
[REF] html_editor: make it safer

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -336,8 +336,10 @@ export class ClipboardPlugin extends Plugin {
      * @returns {DocumentFragment}
      */
     prepareClipboardData(clipboardData) {
+        const fragment = parseHTML(this.document, clipboardData);
+        this.shared.sanitize(fragment, { IN_PLACE: true });
         const container = this.document.createElement("fake-container");
-        container.append(parseHTML(this.document, clipboardData));
+        container.append(fragment);
 
         for (const tableElement of container.querySelectorAll("table")) {
             tableElement.classList.add("table", "table-bordered", "o_table");
@@ -372,25 +374,25 @@ export class ClipboardPlugin extends Plugin {
         // particular case in all of those functions. In fact, this case cannot
         // happen on a new document created using this editor, but will happen
         // instantly when editing a document that was created from Etherpad.
-        const fragment = this.document.createDocumentFragment();
+        const result = this.document.createDocumentFragment();
         let p = this.document.createElement("p");
         for (const child of [...container.childNodes]) {
             if (isBlock(child)) {
                 if (p.childNodes.length > 0) {
-                    fragment.appendChild(p);
+                    result.appendChild(p);
                     p = this.document.createElement("p");
                 }
-                fragment.appendChild(child);
+                result.appendChild(child);
             } else {
                 p.appendChild(child);
             }
 
             if (p.childNodes.length > 0) {
-                fragment.appendChild(p);
+                result.appendChild(p);
             }
 
             // Split elements containing <br> into seperate elements for each line.
-            const brs = fragment.querySelectorAll("br");
+            const brs = result.querySelectorAll("br");
             for (const br of brs) {
                 const block = closestBlock(br);
                 if (
@@ -409,7 +411,7 @@ export class ClipboardPlugin extends Plugin {
                 }
             }
         }
-        return fragment;
+        return result;
     }
     /**
      * Clean a node for safely pasting. Cleaning an element involves unwrapping

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -81,7 +81,7 @@ export class HistoryPlugin extends Plugin {
     static name = "history";
     static dependencies = ["dom", "selection"];
     static shared = [
-        "resetContent",
+        "reset",
         "canUndo",
         "canRedo",
         "makeSavePoint",
@@ -171,15 +171,6 @@ export class HistoryPlugin extends Plugin {
         this.clean();
         this.steps.push(this.makeSnapshotStep());
         this.dispatch("HISTORY_RESET", { content });
-    }
-    /**
-     * @param { string } [value]
-     */
-    resetContent(value) {
-        value = value || "<p><br></p>";
-        this.editable.innerHTML = value;
-        this.dispatch("NORMALIZE", { node: this.editable });
-        this.reset(value);
     }
     /**
      * @param { HistoryStep[] } steps

--- a/addons/html_editor/static/src/others/chatgpt/chatgpt_plugin.js
+++ b/addons/html_editor/static/src/others/chatgpt/chatgpt_plugin.js
@@ -6,7 +6,7 @@ import { ChatGPTAlternativesDialog } from "./chatgpt_alternatives_dialog";
 
 export class ChatGPTPlugin extends Plugin {
     static name = "chatgpt";
-    static dependencies = ["selection", "history", "dom"];
+    static dependencies = ["selection", "history", "dom", "sanitize"];
     static resources = (p) => ({
         toolbarGroup: {
             id: "ai",
@@ -90,8 +90,9 @@ export class ChatGPTPlugin extends Plugin {
             },
         };
         // collapse to end
+        const sanitize = this.shared.sanitize;
         if (selection.isCollapsed) {
-            this.services.dialog.add(ChatGPTPromptDialog, params, { onClose });
+            this.services.dialog.add(ChatGPTPromptDialog, { ...params, sanitize }, { onClose });
         } else {
             const range = new Range();
             range.setStart(selection.startContainer, selection.startOffset);
@@ -99,7 +100,7 @@ export class ChatGPTPlugin extends Plugin {
             const originalText = range.toString() || "";
             this.services.dialog.add(
                 ChatGPTAlternativesDialog,
-                { ...params, originalText },
+                { ...params, originalText, sanitize },
                 { onClose }
             );
         }

--- a/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
@@ -579,8 +579,7 @@ export class CollaborationOdooPlugin extends Plugin {
             return;
         }
 
-        const content =
-            record[this.config.collaboration.collaborationChannel.collaborationFieldName];
+        let content = record[this.config.collaboration.collaborationChannel.collaborationFieldName];
         const lastHistoryId = content && this.getLastHistoryStepId(content);
         // If a change was made in the document while retrieving it, the
         // lastHistoryId will be different if the odoo bus did not have time to
@@ -593,7 +592,11 @@ export class CollaborationOdooPlugin extends Plugin {
         }
 
         this.isDocumentStale = false;
-        this.shared.resetContent(content);
+        content = content || "<p><br></p>";
+        // content here is trusted
+        this.editable.innerHTML = content;
+        this.dispatch("NORMALIZE", { node: this.editable });
+        this.shared.reset(content);
 
         // After resetting from the server, try to resynchronise with a peer as
         // if it was the first time connecting to a peer in order to retrieve a

--- a/addons/html_editor/static/src/plugin.js
+++ b/addons/html_editor/static/src/plugin.js
@@ -17,7 +17,7 @@
  *
  * @typedef { Object } SharedMethods
  *
- * @property { HistoryPlugin['resetContent'] } resetContent
+ * @property { HistoryPlugin['reset'] } reset
  * @property { HistoryPlugin['makeSavePoint'] } makeSavePoint
  * @property { HistoryPlugin['makeSnapshotStep'] } makeSnapshotStep
  * @property { HistoryPlugin['disableObserver'] } disableObserver


### PR DESCRIPTION
Ideally, parseHtml should be called directly at the source of a trusted string, not later in a function. Also, this commit immediately sanitizes the data before putting it in the DOM.