### PR TITLE
[FIX] html_editor{_playground}: fix table picker in rtl 

### DIFF
--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -11,6 +11,7 @@ export class TableMenu extends Component {
         overlay: Object,
         dropdownState: Object,
         target: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
+        direction: String,
     };
     static components = { Dropdown, DropdownItem };
 
@@ -32,29 +33,31 @@ export class TableMenu extends Component {
     }
 
     colItems() {
+        const beforeLabel = this.props.direction === "ltr" ? "left" : "right";
+        const afterLabel = this.props.direction === "ltr" ? "right" : "left";
         return [
             !this.isFirst && {
                 name: "move_left",
                 icon: "fa-chevron-left disabled",
-                text: _t("Move left"),
+                text: _t(`Move ${beforeLabel}`),
                 action: this.moveColumn.bind(this, "left"),
             },
             !this.isLast && {
                 name: "move_right",
                 icon: "fa-chevron-right",
-                text: _t("Move right"),
+                text: _t(`Move ${afterLabel}`),
                 action: this.moveColumn.bind(this, "right"),
             },
             {
                 name: "insert_left",
                 icon: "fa-plus",
-                text: _t("Insert left"),
+                text: _t(`Insert ${beforeLabel}`),
                 action: this.insertColumn.bind(this, "before"),
             },
             {
                 name: "insert_right",
                 icon: "fa-plus",
-                text: _t("Insert right"),
+                text: _t(`Insert ${afterLabel}`),
                 action: this.insertColumn.bind(this, "after"),
             },
             {

--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -33,31 +33,31 @@ export class TableMenu extends Component {
     }
 
     colItems() {
-        const beforeLabel = this.props.direction === "ltr" ? "left" : "right";
-        const afterLabel = this.props.direction === "ltr" ? "right" : "left";
+        const beforeLabel = this.props.direction === "ltr" ? _t("left") : _t("right");
+        const afterLabel = this.props.direction === "ltr" ? _t("right") : _t("left");
         return [
             !this.isFirst && {
                 name: "move_left",
                 icon: "fa-chevron-left disabled",
-                text: _t(`Move ${beforeLabel}`),
+                text: _t("Move %s", beforeLabel),
                 action: this.moveColumn.bind(this, "left"),
             },
             !this.isLast && {
                 name: "move_right",
                 icon: "fa-chevron-right",
-                text: _t(`Move ${afterLabel}`),
+                text: _t("Move %s", afterLabel),
                 action: this.moveColumn.bind(this, "right"),
             },
             {
                 name: "insert_left",
                 icon: "fa-plus",
-                text: _t(`Insert ${beforeLabel}`),
+                text: _t("Insert %s", beforeLabel),
                 action: this.insertColumn.bind(this, "before"),
             },
             {
                 name: "insert_right",
                 icon: "fa-plus",
-                text: _t(`Insert ${afterLabel}`),
+                text: _t("Insert %s", afterLabel),
                 action: this.insertColumn.bind(this, "after"),
             },
             {

--- a/addons/html_editor/static/src/main/table/table_picker.js
+++ b/addons/html_editor/static/src/main/table/table_picker.js
@@ -8,6 +8,7 @@ export class TablePicker extends Component {
             validate: (el) => el.nodeType === Node.ELEMENT_NODE,
         },
         overlay: Object,
+        direction: String,
     };
 
     setup() {
@@ -21,6 +22,7 @@ export class TablePicker extends Component {
         });
         useExternalListener(this.props.editable, "keydown", (ev) => {
             const key = ev.key;
+            const isRTL = this.props.direction === "rtl";
             switch (key) {
                 case "Escape":
                     this.props.overlay.close();
@@ -41,13 +43,23 @@ export class TablePicker extends Component {
                     break;
                 case "ArrowLeft":
                     ev.preventDefault();
-                    if (this.state.cols > 1) {
-                        this.state.cols -= 1;
+                    if (isRTL) {
+                        this.state.cols += 1;
+                    } else {
+                        if (this.state.cols > 1) {
+                            this.state.cols -= 1;
+                        }
                     }
                     break;
                 case "ArrowRight":
-                    this.state.cols += 1;
                     ev.preventDefault();
+                    if (isRTL) {
+                        if (this.state.cols > 1) {
+                            this.state.cols -= 1;
+                        }
+                    } else {
+                        this.state.cols += 1;
+                    }
                     break;
             }
         });

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -35,6 +35,20 @@ export class TableUIPlugin extends Plugin {
         /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
         this.picker = this.shared.createOverlay(TablePicker, {
             position: "bottom-start",
+            onPositioned: (picker, position) => {
+                const popperRect = picker.getBoundingClientRect();
+                const { left } = position;
+                if (this.config.direction === "rtl") {
+                    // position from the right instead of the left as it is needed
+                    // to ensure the expand animation is properly done
+                    if (left < 0) {
+                        picker.style.right = `${-popperRect.width - left}px`;
+                    } else {
+                        picker.style.right = `${window.innerWidth - left - popperRect.width}px`;
+                    }
+                    picker.style.removeProperty("left");
+                }
+            },
         });
 
         this.activeTd = null;
@@ -79,6 +93,7 @@ export class TableUIPlugin extends Plugin {
                 dispatch: this.dispatch,
                 editable: this.editable,
                 overlay: this.picker,
+                direction: this.config.direction,
             },
         });
     }
@@ -152,6 +167,7 @@ export class TableUIPlugin extends Plugin {
                     overlay: this.colMenu,
                     target: td,
                     dropdownState: this.createDropdownState(this.rowMenu),
+                    direction: this.config.direction,
                 },
             });
         }

--- a/addons/html_editor_playground/static/src/playground.js
+++ b/addons/html_editor_playground/static/src/playground.js
@@ -6,6 +6,7 @@ import { MAIN_PLUGINS, CORE_PLUGINS, EXTRA_PLUGINS } from "@html_editor/plugin_s
 import { counter } from "./counter";
 import { card } from "./card";
 import { useService } from "@web/core/utils/hooks";
+import { localization } from "@web/core/l10n/localization";
 
 const testHtml = `Hello Phoenix editor!
 <p>this is a paragraph</p>
@@ -141,7 +142,8 @@ export class Playground extends Component {
                     collaborationResId: 1,
                 },
                 peerId: this.generateId(),
-            }
+            },
+            direction: localization.direction,
         };
     }
     generateId() {


### PR DESCRIPTION
Spec:
=====
- When `direction='rtl'` we need `ArrowLeft` to add columns and ArrowRight` to remove columns in the `TablePicker`.
- Expand the tablepicker to the left when adding columns.
- Show correct label in `rtl`  lang