### PR TITLE
[FIX] html_editor: correctly positions overlays taking focus

### DIFF
--- a/addons/html_editor/static/src/core/overlay_plugin.js
+++ b/addons/html_editor/static/src/core/overlay_plugin.js
@@ -48,6 +48,14 @@ export class Overlay {
             this.updatePosition();
         } else {
             this.isOpen = true;
+            const selection = this.plugin.editable.ownerDocument.getSelection();
+            let initialSelection;
+            if (selection && selection.type !== "None") {
+                initialSelection = {
+                    range: selection.getRangeAt(0),
+                    focusNode: selection.focusNode,
+                };
+            }
             this._remove = this.plugin.services.overlay.add(
                 EditorOverlay,
                 markRaw({
@@ -56,6 +64,7 @@ export class Overlay {
                     editable: this.plugin.editable,
                     props,
                     target,
+                    initialSelection,
                     bus: this.bus,
                 }),
                 {

--- a/addons/html_editor/static/src/main/emoji_plugin.js
+++ b/addons/html_editor/static/src/main/emoji_plugin.js
@@ -1,5 +1,4 @@
 import { Plugin } from "@html_editor/plugin";
-import { closestBlock } from "@html_editor/utils/blocks";
 import { Component, xml } from "@odoo/owl";
 import { EmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { _t } from "@web/core/l10n/translation";
@@ -45,7 +44,6 @@ export class EmojiPlugin extends Plugin {
 
     showEmojiPicker() {
         this.overlay.open({
-            target: closestBlock(this.shared.getEditableSelection().anchorNode),
             props: {
                 close: () => {
                     this.overlay.close();

--- a/addons/html_editor/static/src/main/emoji_plugin.js
+++ b/addons/html_editor/static/src/main/emoji_plugin.js
@@ -52,6 +52,7 @@ export class EmojiPlugin extends Plugin {
                 },
                 onSelect: (str) => {
                     this.shared.domInsert(str);
+                    this.dispatch("ADD_STEP");
                 },
             },
         });

--- a/addons/html_editor/static/src/main/signature_plugin.js
+++ b/addons/html_editor/static/src/main/signature_plugin.js
@@ -30,6 +30,7 @@ export class SignaturePlugin extends Plugin {
         );
         if (currentUser && currentUser.signature) {
             this.shared.domInsert(parseHTML(this.document, currentUser.signature));
+            this.dispatch("ADD_STEP");
         }
     }
 }

--- a/addons/html_editor/static/tests/emoji.test.js
+++ b/addons/html_editor/static/tests/emoji.test.js
@@ -3,7 +3,7 @@ import { click, press, waitFor } from "@odoo/hoot-dom";
 import { loadBundle } from "@web/core/assets";
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
-import { insertText } from "./_helpers/user_actions";
+import { insertText, undo } from "./_helpers/user_actions";
 
 test("add an emoji with powerbox", async () => {
     const { el, editor } = await setupEditor("<p>ab[]</p>");
@@ -19,4 +19,20 @@ test("add an emoji with powerbox", async () => {
 
     await click(".o-EmojiPicker .o-Emoji");
     expect(getContent(el)).toBe("<p>ab😀[]</p>");
+});
+
+test("undo an emoji", async () => {
+    const { el, editor } = await setupEditor("<p>ab[]</p>");
+    await loadBundle("web.assets_emoji");
+    expect(getContent(el)).toBe("<p>ab[]</p>");
+
+    insertText(editor, "test");
+    insertText(editor, "/emoji");
+    press("enter");
+    await waitFor(".o-EmojiPicker");
+    await click(".o-EmojiPicker .o-Emoji");
+    expect(getContent(el)).toBe("<p>abtest😀[]</p>");
+
+    undo(editor);
+    expect(getContent(el)).toBe("<p>abtest[]</p>");
 });

--- a/addons/html_editor/static/tests/signature.test.js
+++ b/addons/html_editor/static/tests/signature.test.js
@@ -4,7 +4,7 @@ import { animationFrame, tick } from "@odoo/hoot-mock";
 import { defineModels, fields, models, serverState } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
-import { insertText } from "./_helpers/user_actions";
+import { insertText, undo } from "./_helpers/user_actions";
 class ResUsers extends models.Model {
     _name = "res.users";
 
@@ -27,4 +27,16 @@ test("apply 'Signature' command", async () => {
     press("enter");
     await tick();
     expect(getContent(el)).toBe("<p>ab</p><h1>Hello</h1><p>[]cd</p>");
+});
+
+test("undo a 'Signature' command", async () => {
+    const { el, editor } = await setupEditor("<p>ab[]cd</p>");
+    insertText(editor, "test");
+    insertText(editor, "/signature");
+    press("enter");
+    await tick();
+    expect(getContent(el)).toBe("<p>abtest</p><h1>Hello</h1><p>[]cd</p>");
+
+    undo(editor);
+    expect(getContent(el)).toBe("<p>abtest[]cd</p>");
 });


### PR DESCRIPTION
Before this commit, in the html editor, opening an overlay containing a component that takes the focus didn't work correctly. The position of the overlay was outside the screen because it was calculated on the selection in the overlay and not the one in the editor.