### PR TITLE
[IMP] html_editor: normalize list items

### DIFF
--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -72,6 +72,7 @@ export class HintPlugin extends Plugin {
     makeEmptyBlockHints(root) {
         for (const { selector, hint } of this.resources.emptyBlockHints) {
             for (const el of selectElements(root, selector)) {
+                // @todo: consider using isEmptyBlock instead.
                 if (isEmpty(el) && !isProtected(el)) {
                     this.makeHint(el, hint);
                 }

--- a/addons/html_editor/static/src/utils/sanitize.js
+++ b/addons/html_editor/static/src/utils/sanitize.js
@@ -1,5 +1,7 @@
 import { isBlock } from "./blocks";
 
+// @todo @phoenix: consider using the wrapInlinesInParagraphs utils instead.
+
 export function initElementForEdition(element, options = {}) {
     const document = element.ownerDocument;
     // Detect if the editable base element contain orphan inline nodes. If

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -57,22 +57,22 @@ test("should not normalize protected elements children (true)", async () => {
         contentBefore: unformat(`
                 <div>
                     <p><i class="fa"></i></p>
-                    <ul><li><p><br></p></li></ul>
+                    <ul><li>abc<p><br></p></li></ul>
                 </div>
                 <div data-oe-protected="true">
                     <p><i class="fa"></i></p>
-                    <ul><li><p><br></p></li></ul>
+                    <ul><li>abc<p><br></p></li></ul>
                 </div>
                 `),
         stepFunction: async (editor) => editor.dispatch("NORMALIZE", { node: editor.editable }),
         contentAfterEdit: unformat(`
                 <div>
                     <p><i class="fa" contenteditable="false">\u200B</i></p>
-                    <ul><li placeholder="List" class="o-we-hint"><br></li></ul>
+                    <ul><li><p>abc</p><p><br></p></li></ul>
                 </div>
                 <div data-oe-protected="true">
                     <p><i class="fa"></i></p>
-                    <ul><li><p><br></p></li></ul>
+                    <ul><li>abc<p><br></p></li></ul>
                 </div>
                 `),
     });
@@ -83,10 +83,10 @@ test("should normalize unprotected elements children (false)", async () => {
         contentBefore: unformat(`
                 <div data-oe-protected="true">
                     <p><i class="fa"></i></p>
-                    <ul><li><p><br></p></li></ul>
+                    <ul><li>abc<p><br></p></li></ul>
                     <div data-oe-protected="false">
                         <p><i class="fa"></i></p>
-                        <ul><li><p><br></p></li></ul>
+                        <ul><li>abc<p><br></p></li></ul>
                     </div>
                 </div>
                 `),
@@ -94,10 +94,10 @@ test("should normalize unprotected elements children (false)", async () => {
         contentAfterEdit: unformat(`
                 <div data-oe-protected="true">
                     <p><i class="fa"></i></p>
-                    <ul><li><p><br></p></li></ul>
+                    <ul><li>abc<p><br></p></li></ul>
                     <div data-oe-protected="false">
                         <p><i class="fa" contenteditable="false">\u200B</i></p>
-                        <ul><li placeholder="List" class="o-we-hint"><br></li></ul>
+                        <ul><li><p>abc</p><p><br></p></li></ul>
                     </div>
                 </div>
                 `),

--- a/addons/html_editor/static/tests/initialization.test.js
+++ b/addons/html_editor/static/tests/initialization.test.js
@@ -152,12 +152,23 @@ describe("sanitize spans/fonts", () => {
     });
 });
 
-describe("sanitize should modify p within li", () => {
-    test("should convert p into span if p has classes", async () => {
+describe("list normalization", () => {
+    test("should keep P in LI (regardless of class)", async () => {
         await testEditor({
-            contentBefore: '<ul><li><p class="class-1">abc</p><p class="class-2">def</p></li></ul>',
-            contentAfter:
-                '<ul><li><span class="class-1">abc</span><span class="class-2">def</span></li></ul>',
+            contentBefore: '<ul><li><p class="class-1">abc</p><p>def</p></li></ul>',
+            contentAfter: '<ul><li><p class="class-1">abc</p><p>def</p></li></ul>',
+        });
+    });
+    test("should keep inlines in LI", async () => {
+        await testEditor({
+            contentBefore: "<ul><li>abc<strong>def</strong></li></ul>",
+            contentAfter: "<ul><li>abc<strong>def</strong></li></ul>",
+        });
+    });
+    test("should wrap inlines in P to prevent mixing block and inline in LI", async () => {
+        await testEditor({
+            contentBefore: "<ul><li>abc<strong>def</strong><p>ghi</p></li></ul>",
+            contentAfter: "<ul><li><p>abc<strong>def</strong></p><p>ghi</p></li></ul>",
         });
     });
 });

--- a/addons/html_editor/static/tests/list/delete_backward.test.js
+++ b/addons/html_editor/static/tests/list/delete_backward.test.js
@@ -54,8 +54,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: "<ol><li><p>a[]</p></li></ol>",
                     stepFunction: deleteBackward,
-                    // Paragraphs in list items are treated as nonsense.
-                    contentAfter: "<ol><li>[]<br></li></ol>",
+                    contentAfter: "<ol><li><p>[]<br></p></li></ol>",
                 });
             });
 
@@ -414,8 +413,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: "<ul><li><p>a[]</p></li></ul>",
                     stepFunction: deleteBackward,
-                    // Paragraphs in list items are treated as nonsense.
-                    contentAfter: "<ul><li>[]<br></li></ul>",
+                    contentAfter: "<ul><li><p>[]<br></p></li></ul>",
                 });
             });
 
@@ -803,8 +801,8 @@ describe("Selection collapsed", () => {
                     contentBefore:
                         '<ul class="o_checklist"><li class="o_checked"><p>a[]</p></li></ul>',
                     stepFunction: deleteBackward,
-                    // Paragraphs in list items are treated as nonsense.
-                    contentAfter: '<ul class="o_checklist"><li class="o_checked">[]<br></li></ul>',
+                    contentAfter:
+                        '<ul class="o_checklist"><li class="o_checked"><p>[]<br></p></li></ul>',
                 });
             });
 
@@ -1341,7 +1339,7 @@ describe("Selection collapsed", () => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ul><li>a[]b</li></ul>",
+                    contentAfter: "<ul><li><p>a[]b</p></li></ul>",
                 });
                 await testEditor({
                     contentBefore: "<ul><li><p>a</p></li></ul><ol><li><p>[]b</p></li></ol>",
@@ -1349,7 +1347,7 @@ describe("Selection collapsed", () => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ul><li>a[]b</li></ul>",
+                    contentAfter: "<ul><li><p>a[]b</p></li></ul>",
                 });
             });
 
@@ -1451,7 +1449,7 @@ describe("Selection collapsed", () => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ol><li>a[]b</li></ol>",
+                    contentAfter: "<ol><li><p>a[]b</p></li></ol>",
                 });
                 await testEditor({
                     contentBefore: "<ol><li><p>a</p></li></ol><ul><li><p>[]b</p></li></ul>",
@@ -1459,7 +1457,7 @@ describe("Selection collapsed", () => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ol><li>a[]b</li></ol>",
+                    contentAfter: "<ol><li><p>a[]b</p></li></ol>",
                 });
             });
 
@@ -1581,7 +1579,7 @@ describe("Selection collapsed", () => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ul><li>a[]b</li></ul>",
+                    contentAfter: "<ul><li><p>a[]b</p></li></ul>",
                 });
                 await testEditor({
                     contentBefore:
@@ -1590,7 +1588,7 @@ describe("Selection collapsed", () => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ul><li>a[]b</li></ul>",
+                    contentAfter: "<ul><li><p>a[]b</p></li></ul>",
                 });
             });
 
@@ -1702,7 +1700,8 @@ describe("Selection collapsed", () => {
                         deleteBackward(editor);
                     },
                     // Paragraphs in list items are kept unless empty
-                    contentAfter: '<ul class="o_checklist"><li class="o_checked">a[]b</li></ul>',
+                    contentAfter:
+                        '<ul class="o_checklist"><li class="o_checked"><p>a[]b</p></li></ul>',
                 });
                 await testEditor({
                     contentBefore:
@@ -1712,7 +1711,8 @@ describe("Selection collapsed", () => {
                         deleteBackward(editor);
                     },
                     // Paragraphs in list items are kept unless empty
-                    contentAfter: '<ul class="o_checklist"><li class="o_checked">a[]b</li></ul>',
+                    contentAfter:
+                        '<ul class="o_checklist"><li class="o_checked"><p>a[]b</p></li></ul>',
                 });
             });
 

--- a/addons/html_editor/static/tests/list/delete_forward.test.js
+++ b/addons/html_editor/static/tests/list/delete_forward.test.js
@@ -63,8 +63,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<ul><li><p>[]a</p></li></ul>",
                 stepFunction: deleteForward,
-                // Paragraphs in list items are treated as nonsense.
-                contentAfter: "<ul><li>[]<br></li></ul>",
+                contentAfter: "<ul><li><p>[]<br></p></li></ul>",
             });
         });
 
@@ -261,8 +260,8 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: '<ul class="o_checklist"><li class="o_checked"><p>[]a</p></li></ul>',
                 stepFunction: deleteForward,
-                // Paragraphs in list items are treated as nonsense.
-                contentAfter: '<ul class="o_checklist"><li class="o_checked">[]<br></li></ul>',
+                contentAfter:
+                    '<ul class="o_checklist"><li class="o_checked"><p>[]<br></p></li></ul>',
             });
         });
 

--- a/addons/html_editor/static/tests/list/indent.test.js
+++ b/addons/html_editor/static/tests/list/indent.test.js
@@ -355,11 +355,20 @@ describe("with selection collapsed", () => {
                         </ul>
                     </li>
                 </ul>`),
+            contentBeforeEdit: unformat(`
+                <ul>
+                    <li>
+                        <p>a</p>
+                        <ul>
+                            <li>[]b</li>
+                        </ul>
+                    </li>
+                </ul>`),
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
                     <li>
-                        a
+                        <p>a</p>
                         <ul>
                             <li class="oe-nested">
                                 <ul>

--- a/addons/html_editor/static/tests/list/normalization.test.js
+++ b/addons/html_editor/static/tests/list/normalization.test.js
@@ -2,18 +2,91 @@ import { describe, test } from "@odoo/hoot";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 
-describe("Paragraph in list item", () => {
-    test("should unwrap paragraph preserving selection", async () => {
+describe("Inlines and blocks in list item", () => {
+    test("should allow paragraphs in list item", async () => {
         await testEditor({
             contentBefore: unformat(`
                 <ul>
                     <li>
-                        <h1>abc</h1>
-                        <p>abc[<i>def</i>]</p>
+                        <p>abc</p>
                     </li>
                 </ul>
             `),
             contentAfter: unformat(`
+                  <ul>
+                    <li>
+                        <p>abc</p>
+                    </li>
+                </ul>
+            `),
+        });
+    });
+    test("should allow inlines in list item, when there are no blocks", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <ul>
+                    <li>
+                        abc<strong>def</strong>
+                    </li>
+                </ul>
+            `),
+            contentAfter: unformat(`
+                  <ul>
+                    <li>
+                        abc<strong>def</strong>
+                    </li>
+                </ul>
+            `),
+        });
+    });
+    test("should wrap inlines in Ps when there are blocks in the list item", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <ul>
+                    <li>
+                        abc
+                        <p>paragraph</p>
+                        <strong>def</strong>
+                    </li>
+                </ul>
+            `),
+            contentAfter: unformat(`
+                  <ul>
+                    <li>
+                        <p>abc</p>
+                        <p>paragraph</p>
+                        <p><strong>def</strong></p>
+                    </li>
+                </ul>
+            `),
+        });
+    });
+
+    test("should wrap inlines in Ps when there are blocks in the list item (2)", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <ul>
+                    <li>
+                        abc<br>def
+                        <h1>ghi</h1>
+                    </li>
+                </ul>
+            `),
+            contentAfter: unformat(`
+                  <ul>
+                    <li>
+                        <p>abc</p>
+                        <p>def</p>
+                        <h1>ghi</h1>
+                    </li>
+                </ul>
+            `),
+        });
+    });
+
+    test("should wrap inlines in paragraph preserving selection", async () => {
+        await testEditor({
+            contentBefore: unformat(`
                 <ul>
                     <li>
                         <h1>abc</h1>
@@ -21,19 +94,19 @@ describe("Paragraph in list item", () => {
                     </li>
                 </ul>
             `),
-        });
-    });
-    test("should unwrap paragraph preserving selection (2)", async () => {
-        await testEditor({
-            contentBefore: unformat(`
+            contentAfter: unformat(`
                 <ul>
                     <li>
-                        <p>abc<i>def</i></p>
-                        [<h1>abc</h1>]
+                        <h1>abc</h1>
+                        <p>abc[<i>def</i></p>]
                     </li>
                 </ul>
             `),
-            contentAfter: unformat(`
+        });
+    });
+    test("should wrap inlines in paragraph preserving selection (2)", async () => {
+        await testEditor({
+            contentBefore: unformat(`
                 <ul>
                     <li>
                         abc<i>def</i>
@@ -41,10 +114,14 @@ describe("Paragraph in list item", () => {
                     </li>
                 </ul>
             `),
+            contentAfter: unformat(`
+                <ul>
+                    <li>
+                        <p>abc<i>def</i></p>
+                        [<h1>abc</h1>]
+                    </li>
+                </ul>
+            `),
         });
     });
 });
-
-// @todo @phoenix: write other tests about list normalization + preserve selection:
-// - paragraph with class converted to span
-// - empty paragraph gets removed

--- a/addons/html_editor/static/tests/list/outdent.test.js
+++ b/addons/html_editor/static/tests/list/outdent.test.js
@@ -527,10 +527,23 @@ describe("with selection", () => {
                             d
                         </li>
                     </ul>`),
+            contentBeforeEdit: unformat(`
+                        <ul>
+                            <li>
+                                <p>a</p>
+                                <ul>
+                                    <li>[b</li>
+                                    <li>c]</li>
+                                </ul>
+                            </li>
+                            <li>
+                                d
+                            </li>
+                        </ul>`),
             stepFunction: keydownShiftTab,
             contentAfter: unformat(`
                     <ul>
-                        <li>a</li>
+                        <li><p>a</p></li>
                         <li>[b</li>
                         <li>c]</li>
                         <li>d</li>

--- a/addons/html_editor/static/tests/list/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/list/paragraph_break.test.js
@@ -107,9 +107,6 @@ describe("Selection collapsed", () => {
                 });
             });
 
-            // @misleading
-            // This test is misleading. Removal of P and B happens on normalize
-            // on start, it has nothing to do with the splitBlock.
             test("should remove a list with p", async () => {
                 await testEditor({
                     contentBefore: "<ol><li><p>[]<br></p></li></ol>",
@@ -118,12 +115,11 @@ describe("Selection collapsed", () => {
                 });
             });
 
-            // @misleading
             test("should remove a list set to bold", async () => {
                 await testEditor({
                     contentBefore: "<ol><li><p><b>[]<br></b></p></li></ol>",
                     stepFunction: splitBlock,
-                    contentAfter: "<p>[]<br></p>",
+                    contentAfter: "<p><b>[]<br></b></p>",
                 });
             });
         });
@@ -293,12 +289,11 @@ describe("Selection collapsed", () => {
                 });
             });
 
-            // @misleading
             test("should remove a list set to bold", async () => {
                 await testEditor({
                     contentBefore: "<ul><li><p><b>[]<br></b></p></li></ul>",
                     stepFunction: splitBlock,
-                    contentAfter: "<p>[]<br></p>",
+                    contentAfter: "<p><b>[]<br></b></p>",
                 });
             });
         });
@@ -512,13 +507,12 @@ describe("Selection collapsed", () => {
                 });
             });
 
-            // @misleading
             test("should remove a checklist set to bold", async () => {
                 await testEditor({
                     contentBefore:
                         '<ul class="o_checklist"><li class="o_checked"><p><b>[]<br></b></p></li></ul>',
                     stepFunction: splitBlock,
-                    contentAfter: "<p>[]<br></p>",
+                    contentAfter: "<p><b>[]<br></b></p>",
                 });
             });
         });

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -122,7 +122,7 @@ describe("Html Paste cleaning - whitelist", () => {
         });
     });
 
-    test("should remove unwanted b tag and p tag with unwanted styles when pasting list from gdocs", async () => {
+    test("should remove b, keep p, and remove unwanted styles when pasting list from gdocs", async () => {
         await testEditor({
             contentBefore: "<p>[]<br></p>",
             stepFunction: async (editor) => {
@@ -131,7 +131,8 @@ describe("Html Paste cleaning - whitelist", () => {
                     '<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-5d8bcf85-7fff-ebec-8604-eedd96f2d601"><ul style="margin-top:0;margin-bottom:0;padding-inline-start:48px;"><li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Google</span></p></li><li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Test</span></p></li><li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">test2</span></p></li></ul></b>'
                 );
             },
-            contentAfter: "<ul><li>Google</li><li>Test</li><li>test2</li></ul><p>[]<br></p>",
+            contentAfter:
+                "<ul><li><p>Google</p></li><li><p>Test</p></li><li><p>test2</p></li></ul><p>[]<br></p>",
         });
     });
 


### PR DESCRIPTION
This commit implements a new spec for list normalization.

Now, paragraphs are allowed in a list item.
In case a list item contains both inline and block elements as children, inlines are wrapped in paragraphs. A list item containing only inline nodes is kept unchanged.