### PR TITLE
[FIX] html_editor: click on 'Emoji' command

### DIFF
--- a/addons/html_editor/static/src/main/emoji_plugin.js
+++ b/addons/html_editor/static/src/main/emoji_plugin.js
@@ -4,7 +4,7 @@ import { EmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { _t } from "@web/core/l10n/translation";
 
 class EditorEmojiPicker extends Component {
-    static template = xml`<div class="popover" t-on-click.stop="() => {}">
+    static template = xml`<div class="popover" t-on-mousedown.stop="() => {}">
             <EmojiPicker t-props="props"/>
         </div>`;
     static components = { EmojiPicker };
@@ -37,7 +37,7 @@ export class EmojiPlugin extends Plugin {
         this.overlay = this.shared.createOverlay(EditorEmojiPicker, {
             position: "bottom-start",
         });
-        this.addDomListener(this.document, "click", () => {
+        this.addDomListener(this.document, "mousedown", () => {
             this.overlay.close();
         });
     }

--- a/addons/html_editor/static/tests/emoji.test.js
+++ b/addons/html_editor/static/tests/emoji.test.js
@@ -1,5 +1,6 @@
 import { expect, test } from "@odoo/hoot";
 import { click, press, waitFor } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
 import { loadBundle } from "@web/core/assets";
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
@@ -19,6 +20,20 @@ test("add an emoji with powerbox", async () => {
 
     await click(".o-EmojiPicker .o-Emoji");
     expect(getContent(el)).toBe("<p>ab😀[]</p>");
+});
+
+test("click on emoji command to open emoji picker", async () => {
+    const { el, editor } = await setupEditor("<p>ab[]</p>");
+    await loadBundle("web.assets_emoji");
+
+    expect(".o-EmojiPicker").toHaveCount(0);
+    expect(getContent(el)).toBe("<p>ab[]</p>");
+
+    insertText(editor, "/emoji");
+    await animationFrame();
+    click(".active .o-we-command-name");
+    await waitFor(".o-EmojiPicker");
+    expect(".o-EmojiPicker").toHaveCount(1);
 });
 
 test("undo an emoji", async () => {


### PR DESCRIPTION
Before this commit, clicking on the "Emoji" command did not display the Emoji picker.