### PR TITLE
[FIX] html_editor, mail: update code to last hoot changes

### DIFF
--- a/addons/html_editor/static/tests/editor.test.js
+++ b/addons/html_editor/static/tests/editor.test.js
@@ -47,9 +47,9 @@ test("plugin destruction is reverse of instantiation order", async () => {
     }
     const Plugins = [...MAIN_PLUGINS, makeTestPlugin("first"), makeTestPlugin("second", ["first"])];
     const { editor } = await setupEditor(`<p>[]</p>`, { config: { Plugins } });
-    expect(["setup: first", "setup: second"]).toVerifySteps();
+    expect.verifySteps(["setup: first", "setup: second"]);
     editor.destroy();
-    expect(["destroy: second", "destroy: first"]).toVerifySteps();
+    expect.verifySteps(["destroy: second", "destroy: first"]);
 });
 
 test("Remove odoo-editor-editable class after every plugin is destroyed", async () => {
@@ -65,5 +65,5 @@ test("Remove odoo-editor-editable class after every plugin is destroyed", async 
     const Plugins = [...MAIN_PLUGINS, TestPlugin];
     const { editor } = await setupEditor(`<div><p>a</p></div>`, { config: { Plugins } });
     editor.destroy();
-    expect(["operation"]).toVerifySteps();
+    expect.verifySteps(["operation"]);
 });

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -450,15 +450,15 @@ describe("shortcut", () => {
         const { editor } = await setupEditor(`<p>[]</p>`, {
             config: { onChange, resources },
         });
-        expect([]).toVerifySteps();
+        expect.verifySteps([]);
         insertText(editor, "a");
-        expect([
+        expect.verifySteps([
             "handleNewRecords",
             "CONTENT_UPDATED",
             "handleNewRecords",
             "CONTENT_UPDATED",
             "onchange",
-        ]).toVerifySteps();
+        ]);
     });
 });
 
@@ -496,9 +496,9 @@ describe("destroy", () => {
         // Ensure dispatch when plugins are alive.
         editor.shared.domInsert(parseHTML(editor.document, `<div class="test">destroyed</div>`));
         await animationFrame();
-        expect(["dispatch"]).toVerifySteps();
+        expect.verifySteps(["dispatch"]);
         editor.destroy();
         await animationFrame();
-        expect([]).toVerifySteps();
+        expect.verifySteps([]);
     });
 });

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -222,7 +222,7 @@ test("edit and save a html field", async () => {
     expect(".o_form_button_save").toBeVisible();
 
     await contains(".o_form_button_save").click();
-    expect(["web_save"]).toVerifySteps();
+    expect.verifySteps(["web_save"]);
     expect(".odoo-editor-editable p").toHaveText("testfirst");
     expect(`.o_form_button_save`).not.toBeVisible();
 });
@@ -279,13 +279,13 @@ test("edit html field and blur multiple time should apply 1 onchange", async () 
     expect("[name='txt'] .odoo-editor-editable").toHaveInnerHTML("<p>Hello first </p>");
 
     await contains("[name='name'] input").click();
-    expect(["onchange: <p>Hello first</p>"]).toVerifySteps();
+    expect.verifySteps(["onchange: <p>Hello first</p>"]);
 
     await contains("[name='txt'] .odoo-editor-editable").focus();
     await contains("[name='name'] input").click();
     def.resolve();
     await animationFrame();
-    expect([]).toVerifySteps();
+    expect.verifySteps([]);
 });
 
 test("edit an html field during an onchange", async () => {
@@ -315,7 +315,7 @@ test("edit an html field during an onchange", async () => {
     expect("[name='txt'] .odoo-editor-editable").toHaveInnerHTML("<p>Hello first </p>");
 
     await contains(".o_form_view").click();
-    expect(["onchange: <p>Hello first</p>"]).toVerifySteps();
+    expect.verifySteps(["onchange: <p>Hello first</p>"]);
 
     setSelectionInHtmlField();
     insertText(htmlEditor, "Yop ");
@@ -376,7 +376,7 @@ test("edit and switch page", async () => {
     await animationFrame();
     expect(".odoo-editor-editable p").toHaveText("second");
     expect(`.o_form_button_save`).not.toBeVisible();
-    expect(["web_save"]).toVerifySteps();
+    expect.verifySteps(["web_save"]);
 
     await contains(`.o_pager_previous`).click();
     expect(".odoo-editor-editable p").toHaveText("testfirst");
@@ -483,7 +483,7 @@ test("A new MediaDialog after switching record in a Form view should have the co
 
     press("Enter");
     await animationFrame();
-    expect(["partner : 2"]).toVerifySteps();
+    expect.verifySteps(["partner : 2"]);
 });
 
 test("Embed video by pasting video URL", async () => {
@@ -732,7 +732,7 @@ test("Pasted/dropped images are converted to attachments on save", async () => {
     await contains(".o_form_button_save").click();
     expect(img.getAttribute("src")).toBe("/test_image_url.png?access_token=1234");
     expect(img.classList.contains("o_b64_image_to_save")).not.toBe(true);
-    expect(["add_data: partner 1"]).toVerifySteps();
+    expect.verifySteps(["add_data: partner 1"]);
 });
 
 test("isDirty should be false when the content is being transformed by the editor", async () => {
@@ -1281,7 +1281,7 @@ describe("sandbox", () => {
         );
 
         await contains(".o_form_button_save").click();
-        expect(["web_save"]).toVerifySteps();
+        expect.verifySteps(["web_save"]);
     });
 
     test("switch page after editing html with code editor", async () => {
@@ -1331,7 +1331,7 @@ describe("sandbox", () => {
         );
 
         await contains(`.o_pager_next`).click();
-        expect(["web_save"]).toVerifySteps();
+        expect.verifySteps(["web_save"]);
         expect(`.o_form_button_save`).not.toBeVisible();
         expect('.o_field_html[name="txt"] textarea').toHaveValue(
             htmlDocumentTextTemplate("Bye", "green")
@@ -1505,7 +1505,7 @@ describe("sandbox", () => {
         expect(readonlyIframe.contentDocument.body).toHaveInnerHTML(
             `<div id="iframe_target"> <p> Hello </p> </div>`
         );
-        expect(["template.assets"]).toVerifySteps();
+        expect.verifySteps(["template.assets"]);
     });
 
     test("click on next/previous page when readonly with cssReadonly ", async () => {

--- a/addons/html_editor/static/tests/inline_components.test.js
+++ b/addons/html_editor/static/tests/inline_components.test.js
@@ -181,9 +181,9 @@ test("inline component plugin does not try to destroy the same app twice", async
         config: getConfig("counter", Test),
     });
     deleteBackward(editor);
-    expect(["destroy from plugin", "willdestroy"]).toVerifySteps();
+    expect.verifySteps(["destroy from plugin", "willdestroy"]);
     editor.destroy();
-    expect([]).toVerifySteps();
+    expect.verifySteps([]);
 });
 
 test("select content of a component shouldn't open the toolbar", async () => {
@@ -390,7 +390,7 @@ describe("Inline component Owl lifecycle editor integration", () => {
                 })),
             }
         );
-        expect(["willstart"]).toVerifySteps();
+        expect.verifySteps(["willstart"]);
         delayedWillStart.resolve();
         await animationFrame();
         expect(getContent(el)).toBe(
@@ -408,10 +408,10 @@ describe("Inline component Owl lifecycle editor integration", () => {
                 </div>
             `)
         );
-        expect([
+        expect.verifySteps([
             "html prop suppression",
             "html prop insertion",
             "minimal asynchronous time",
-        ]).toVerifySteps();
+        ]);
     });
 });

--- a/addons/html_editor/static/tests/qweb.test.js
+++ b/addons/html_editor/static/tests/qweb.test.js
@@ -44,7 +44,7 @@ describe("qweb picker", () => {
         await setupEditor(`<div><t t-if="test">yes</t><t t-else="">no</t></div>`, {
             config: { ...config, resources },
         });
-        expect([]).toVerifySteps();
+        expect.verifySteps([]);
     });
 
     test("switch selected value to the same value ", async () => {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -347,10 +347,10 @@ test("toolbar does not evaluate isFormatApplied when namespace does not match", 
             config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },
         }
     );
-    expect([]).toVerifySteps();
+    expect.verifySteps([]);
     click("img");
     await waitFor(".o-we-toolbar");
-    expect(["image format evaluated"]).toVerifySteps();
+    expect.verifySteps(["image format evaluated"]);
 });
 
 test("plugins can create buttons with text in toolbar", async () => {

--- a/addons/mail/static/tests/composer/html_composer_message_field.test.js
+++ b/addons/mail/static/tests/composer/html_composer_message_field.test.js
@@ -126,5 +126,5 @@ test("media dialog: upload", async function () {
     expect("[name='attachment_ids'] .o_attachment[title='test.jpg']").toHaveCount(1);
 
     await contains(".o_form_button_save").click();
-    expect(["web_save"]).toVerifySteps();
+    expect.verifySteps(["web_save"]);
 });

--- a/addons/mail/static/tests/inline/html_mail_field.test.js
+++ b/addons/mail/static/tests/inline/html_mail_field.test.js
@@ -73,7 +73,7 @@ test("HtmlMail save inline html", async function () {
     expect(".odoo-editor-editable").toHaveInnerHTML("<h1> first </h1>");
 
     await contains(".o_form_button_save").click();
-    expect(["web_save"]).toVerifySteps();
+    expect.verifySteps(["web_save"]);
 });
 
 test("HtmlMail don't have access to column commands", async function () {


### PR DESCRIPTION
hoot changed the syntax for toVerifySteps, which broke a bunch of tests. In this commit, we update the tests to the latest syntax.