### PR TITLE
[IMP] html_editor: powerbox command disabled

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -1,7 +1,11 @@
 import { Plugin } from "@html_editor/plugin";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { _t } from "@web/core/l10n/translation";
 
+function isDisabled(node) {
+    return !!closestElement(node, ".o_editor_banner");
+}
 export class BannerPlugin extends Plugin {
     static name = "banner";
     static dependencies = ["dom", "selection"];
@@ -14,6 +18,7 @@ export class BannerPlugin extends Plugin {
                 name: _t("Banner Info"),
                 description: _t("Insert an info banner"),
                 fontawesome: "fa-info-circle",
+                isDisabled,
                 action() {
                     p.insertBanner(_t("Banner Info"), "💡", "info");
                 },
@@ -23,6 +28,7 @@ export class BannerPlugin extends Plugin {
                 name: _t("Banner Success"),
                 description: _t("Insert an success banner"),
                 fontawesome: "fa-check-circle",
+                isDisabled,
                 action() {
                     p.insertBanner(_t("Banner Success"), "✅", "success");
                 },
@@ -32,6 +38,7 @@ export class BannerPlugin extends Plugin {
                 name: _t("Banner Warning"),
                 description: _t("Insert an warning banner"),
                 fontawesome: "fa-exclamation-triangle",
+                isDisabled,
                 action() {
                     p.insertBanner(_t("Banner Warning"), "⚠️", "warning");
                 },
@@ -41,6 +48,7 @@ export class BannerPlugin extends Plugin {
                 name: _t("Banner Danger"),
                 description: _t("Insert an danger banner"),
                 fontawesome: "fa-exclamation-circle",
+                isDisabled,
                 action() {
                     p.insertBanner(_t("Banner Danger"), "❌", "danger");
                 },

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -21,6 +21,13 @@ function isUnremovableColumn(element, root) {
     return !root.contains(closestColumnContainer);
 }
 
+function columnIsDisabled(numberOfColumns) {
+    return (node) => {
+        const row = closestElement(node, ".o_text_columns .row");
+        return row && row.childElementCount === numberOfColumns;
+    };
+}
+
 export class ColumnPlugin extends Plugin {
     static name = "column";
     static dependencies = ["selection"];
@@ -32,6 +39,7 @@ export class ColumnPlugin extends Plugin {
                 description: _t("Convert into 2 columns"),
                 category: "structure",
                 fontawesome: "fa-columns",
+                isDisabled: columnIsDisabled(2),
                 action(dispatch) {
                     dispatch("COLUMNIZE", { numberOfColumns: 2 });
                 },
@@ -41,6 +49,7 @@ export class ColumnPlugin extends Plugin {
                 description: _t("Convert into 3 columns"),
                 category: "structure",
                 fontawesome: "fa-columns",
+                isDisabled: columnIsDisabled(3),
                 action(dispatch) {
                     dispatch("COLUMNIZE", { numberOfColumns: 3 });
                 },
@@ -50,6 +59,7 @@ export class ColumnPlugin extends Plugin {
                 description: _t("Convert into 4 columns"),
                 category: "structure",
                 fontawesome: "fa-columns",
+                isDisabled: columnIsDisabled(4),
                 action(dispatch) {
                     dispatch("COLUMNIZE", { numberOfColumns: 4 });
                 },
@@ -59,6 +69,10 @@ export class ColumnPlugin extends Plugin {
                 description: _t("Back to one column"),
                 category: "structure",
                 fontawesome: "fa-columns",
+                isDisabled(node) {
+                    const row = closestElement(node, ".o_text_columns .row");
+                    return !row;
+                },
                 action(dispatch) {
                     dispatch("COLUMNIZE", { numberOfColumns: 0 });
                 },

--- a/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
@@ -52,7 +52,7 @@ export class SearchPowerboxPlugin extends Plugin {
         }
         const searchTerm = this.searchNode.nodeValue.slice(this.offset + 1, selection.endOffset);
         if (!searchTerm) {
-            this.shared.updatePowerbox(this.commands, this.categories);
+            this.shared.updatePowerbox(this.enabledCommands, this.categories);
             return;
         }
         if (searchTerm.includes(" ")) {
@@ -71,7 +71,7 @@ export class SearchPowerboxPlugin extends Plugin {
      * @param {string} searchTerm
      */
     filterCommands(searchTerm) {
-        return fuzzyLookup(searchTerm.toLowerCase(), this.commands, (cmd) =>
+        return fuzzyLookup(searchTerm.toLowerCase(), this.enabledCommands, (cmd) =>
             (cmd.name + cmd.description + cmd.categoryName).toLowerCase()
         );
     }
@@ -89,8 +89,11 @@ export class SearchPowerboxPlugin extends Plugin {
     openPowerbox() {
         const selection = this.shared.getEditableSelection();
         this.offset = selection.startOffset - 1;
+        this.enabledCommands = this.commands.filter(
+            (cmd) => !cmd.isDisabled?.(selection.anchorNode)
+        );
         this.shared.openPowerbox({
-            commands: this.commands,
+            commands: this.enabledCommands,
             categories: this.categories,
             onApplyCommand: this.historySavePointRestore,
             onClose: () => {

--- a/addons/html_editor/static/src/main/text_direction_plugin.js
+++ b/addons/html_editor/static/src/main/text_direction_plugin.js
@@ -5,7 +5,7 @@ import { closestElement } from "../utils/dom_traversal";
 
 export class TextDirectionPlugin extends Plugin {
     static name = "text_direction";
-    static dependencies = ["selection", "split", "format", "powerbox"];
+    static dependencies = ["selection", "split", "format"];
     /** @type { (p: TextDirectionPlugin) => Record<string, any> } */
     static resources = (p) => ({
         powerboxCommands: [

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -20,6 +20,16 @@ test("should insert a banner with focus inside followed by a paragraph", async (
                 </div>
             </div><p></p>`
     );
+
+    insertText(editor, "/");
+    await animationFrame();
+    expect(".o-we-powerbox").toHaveCount(1);
+
+    insertText(editor, "banner");
+    await animationFrame();
+    expect(".o-we-powerbox").toHaveCount(0, {
+        message: "shouldn't be possible to add a banner inside a banner",
+    });
 });
 
 test.todo(

--- a/addons/html_editor/static/tests/columnize.test.js
+++ b/addons/html_editor/static/tests/columnize.test.js
@@ -1,5 +1,8 @@
-import { describe, test } from "@odoo/hoot";
-import { testEditor } from "./_helpers/editor";
+import { describe, expect, test } from "@odoo/hoot";
+import { press, queryAllTexts } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { setupEditor, testEditor } from "./_helpers/editor";
+import { getContent } from "./_helpers/selection";
 import { insertText, redo, undo } from "./_helpers/user_actions";
 
 function columnsContainer(contents) {
@@ -95,6 +98,26 @@ describe("2 columns", () => {
             ),
         });
     });
+
+    test("apply '2 columns' powerbox command", async () => {
+        const { el, editor } = await setupEditor("<p>ab[]cd</p>");
+        insertText(editor, "/2columns");
+        await animationFrame();
+        expect(".active .o-we-command-name").toHaveText("2 columns");
+
+        press("enter");
+        expect(getContent(el)).toBe(
+            `<div class="container o_text_columns"><div class="row"><div class="col-6"><p>ab[]cd</p></div><div class="col-6"><p placeholder="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+        );
+
+        insertText(editor, "/columns");
+        await animationFrame();
+        expect(queryAllTexts(".o-we-command-name")).toEqual([
+            "3 columns",
+            "4 columns",
+            "Remove columns",
+        ]);
+    });
 });
 describe("3 columns", () => {
     test("should do nothing", async () => {
@@ -168,6 +191,26 @@ describe("3 columns", () => {
             ),
         });
     });
+
+    test("apply '3 columns' powerbox command", async () => {
+        const { el, editor } = await setupEditor("<p>ab[]cd</p>");
+        insertText(editor, "/3columns");
+        await animationFrame();
+        expect(".active .o-we-command-name").toHaveText("3 columns");
+
+        press("enter");
+        expect(getContent(el)).toBe(
+            `<div class="container o_text_columns"><div class="row"><div class="col-4"><p>ab[]cd</p></div><div class="col-4"><p placeholder="Empty column" class="o-we-hint"><br></p></div><div class="col-4"><p placeholder="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+        );
+
+        insertText(editor, "/columns");
+        await animationFrame();
+        expect(queryAllTexts(".o-we-command-name")).toEqual([
+            "2 columns",
+            "4 columns",
+            "Remove columns",
+        ]);
+    });
 });
 
 describe("4 columns", () => {
@@ -234,6 +277,26 @@ describe("4 columns", () => {
             ),
         });
     });
+
+    test("apply '4 columns' powerbox command", async () => {
+        const { el, editor } = await setupEditor("<p>ab[]cd</p>");
+        insertText(editor, "/4columns");
+        await animationFrame();
+        expect(".active .o-we-command-name").toHaveText("4 columns");
+
+        press("enter");
+        expect(getContent(el)).toBe(
+            `<div class="container o_text_columns"><div class="row"><div class="col-3"><p>ab[]cd</p></div><div class="col-3"><p placeholder="Empty column" class="o-we-hint"><br></p></div><div class="col-3"><p placeholder="Empty column" class="o-we-hint"><br></p></div><div class="col-3"><p placeholder="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+        );
+
+        insertText(editor, "/columns");
+        await animationFrame();
+        expect(queryAllTexts(".o-we-command-name")).toEqual([
+            "2 columns",
+            "3 columns",
+            "Remove columns",
+        ]);
+    });
 });
 
 describe("remove columns", () => {
@@ -278,6 +341,29 @@ describe("remove columns", () => {
             stepFunction: columnize(0),
             contentAfter: "<p>abcd</p><h1>ef</h1><ul><li>gh</li></ul><p>ij</p><p>[]<br></p>",
         });
+    });
+
+    test("apply 'remove columns' powerbox command", async () => {
+        const { el, editor } = await setupEditor("<p>ab[]cd</p>");
+        insertText(editor, "/columns");
+        await animationFrame();
+        expect(queryAllTexts(".o-we-command-name")).toEqual([
+            "2 columns",
+            "3 columns",
+            "4 columns",
+        ]);
+
+        // add 2 columns
+        press("enter");
+        expect(getContent(el)).toBe(
+            `<div class="container o_text_columns"><div class="row"><div class="col-6"><p>ab[]cd</p></div><div class="col-6"><p placeholder="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+        );
+
+        insertText(editor, "/removecolumns");
+        await animationFrame();
+        expect(".active .o-we-command-name").toHaveText("Remove columns");
+        press("enter");
+        expect(getContent(el)).toBe(`<p>ab[]cd</p><p><br></p><p><br></p>`);
     });
 });
 

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -68,7 +68,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(26);
+        expect(commandNames(el).length).toBe(25);
         insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -78,7 +78,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(26);
+        expect(commandNames(el).length).toBe(25);
         expect(".o-we-category").toHaveCount(7);
         expect(queryAllTexts(".o-we-category")).toEqual([
             "STRUCTURE",
@@ -100,7 +100,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>", { props: { iframe: true } });
         insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(26);
+        expect(commandNames(el).length).toBe(25);
         insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -149,7 +149,7 @@ describe("search", () => {
         insertText(editor, "/");
         await animationFrame();
         expect(".o-we-powerbox").toHaveCount(1);
-        expect(commandNames(el).length).toBe(26);
+        expect(commandNames(el).length).toBe(25);
 
         insertText(editor, "headx");
         await animationFrame();


### PR DESCRIPTION
The purpose of this commit is to introduce a mechanism for displaying or not displaying powerbox commands depending on the node in which the search is performed. Each command will therefore be able to define an "isDisabled" function if it wants to be optional depending on the selection.