### PR TITLE
[FIX] html_editor: save image in html_field with slow network

### DIFF
--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -214,12 +214,12 @@ export class MediaPlugin extends Plugin {
      * @param {number} resId
      */
     async saveB64Image(el, resModel, resId) {
-        el.classList.remove("o_b64_image_to_save");
         const imageData = el.getAttribute("src").split("base64,")[1];
         if (!imageData) {
             // Checks if the image is in base64 format for RPC call. Relying
             // only on the presence of the class "o_b64_image_to_save" is not
             // robust enough.
+            el.classList.remove("o_b64_image_to_save");
             return;
         }
         const attachment = await rpc("/web_editor/attachment/add_data", {
@@ -248,6 +248,7 @@ export class MediaPlugin extends Plugin {
             }
             el.setAttribute("src", src);
         }
+        el.classList.remove("o_b64_image_to_save");
     }
 
     /**


### PR DESCRIPTION
Before this commit, pasting an image into an html field and then saving it could cause several calls to add_data (converting the image into an attachment) when the network was slow. Similar problems occurred when switching pages.

Solution:
Add a mutex to ensure that each call to commitChanges is ordered and waits for changes in progress such as converting images to attachments before saving.

How to reproduce:
- go to a form view with an html field
- paste an image in b64
- click on the save button (or next page)

Before this commit:
- Several rpc add_data are made for the same image

After this commit:
- Only one rpc add_data is done