### PR TITLE
[FIX] html_editor: powerbox in mobile

### DIFF
--- a/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
@@ -16,8 +16,8 @@ export class SearchPowerboxPlugin extends Plugin {
             categoryName: this.categories.find((category) => category.id === command.category).name,
         }));
 
-        this.addDomListener(this.editable, "keydown", (ev) => {
-            if (ev.key === "/") {
+        this.addDomListener(this.editable, "beforeinput", (ev) => {
+            if (ev.data === "/") {
                 this.historySavePointRestore = this.shared.makeSavePoint();
             }
         });

--- a/addons/html_editor/static/tests/_helpers/user_actions.js
+++ b/addons/html_editor/static/tests/_helpers/user_actions.js
@@ -41,6 +41,10 @@ export function insertText(editor, text) {
         // KeyDownEvent is required to trigger deleteRange.
         manuallyDispatchProgrammaticEvent(editor.editable, "keydown", { key: char });
         // InputEvent is required to simulate the insert text.
+        manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
+            inputType: "insertText",
+            data: char,
+        });
         insertChar(char);
         manuallyDispatchProgrammaticEvent(editor.editable, "input", {
             inputType: "insertText",


### PR DESCRIPTION
Before this commit, performing a search in the mobile powerbox and then selecting a command did not remove the search from the dom.

Reason:
In mobile, when using a virtual keyboard, the keydown event contains the value "undefined" for its key.

Solution:
Use the "beforeinput" event to access the added value before it is in the dom.

How to reproduce:
- Being in mobile
- Type "/h
- Select a command

Before this commit:
    "/h" is still present in the dom

After this commit:
    "/h" is removed