### PR TITLE
[FIX] html_editor: ctrl+a inside banner

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -125,7 +125,7 @@ export class SelectionPlugin extends Plugin {
                     let [anchorNode, anchorOffset] = startPos(container);
                     if (
                         anchorNode.firstChild &&
-                        anchorNode.firstChild.getAttribute("contenteditable") === "false"
+                        anchorNode.firstChild.isContentEditable === false
                     ) {
                         anchorNode = anchorNode.firstChild.nextSibling;
                         anchorOffset = 0;

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -32,6 +32,26 @@ test("should insert a banner with focus inside followed by a paragraph", async (
     });
 });
 
+test("press 'ctrl+a' inside a banner should select all the banner content", async () => {
+    const { el, editor } = await setupEditor("<p>Test[]</p>");
+    insertText(editor, "/bannerinfo");
+    press("enter");
+    insertText(editor, "Test1");
+    manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
+        inputType: "insertParagraph",
+    });
+    insertText(editor, "Test2");
+    press(["ctrl", "a"]);
+    expect(getContent(el)).toBe(
+        `<p>Test</p><div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
+                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+                <div class="w-100 ms-3" contenteditable="true">[
+                    <p>Test1</p><p>Test2<br></p>
+                ]</div>
+            </div><p></p>`
+    );
+});
+
 test.todo(
     "remove all content should preserves the first paragraph tag inside the banner",
     async () => {


### PR DESCRIPTION
Before this commit, pressing "ctrl+a" in a banner caused a crash. Pressing "ctrl+a" should select the all banner content.