### PR TITLE
[IMP] html_editor: fill empty nested editable zone with P

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -470,10 +470,14 @@ export class DeletePlugin extends Plugin {
 
     fillShrunkBlocks(commonAncestor) {
         const fillBlock = (block) => {
-            if (block === this.editable) {
+            if (
+                block.matches("div[contenteditable='true']") &&
+                !block.parentElement.isContentEditable
+            ) {
+                // @todo: not sure we want this when allowInlineAtRoot is true
                 const p = this.document.createElement("p");
                 p.appendChild(this.document.createElement("br"));
-                this.editable.appendChild(p);
+                block.appendChild(p);
             } else {
                 block.appendChild(this.document.createElement("br"));
             }
@@ -1320,8 +1324,3 @@ export class DeletePlugin extends Plugin {
         return { startContainer, startOffset, endContainer, endOffset, commonAncestorContainer };
     }
 }
-
-// @todo @phoenix: handle this:
-// The first child element of a contenteditable="true" zone which
-// itself is contained in a contenteditable="false" zone can not be
-// removed if it is paragraph-like.

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -1836,5 +1836,37 @@ describe("Selection not collapsed", () => {
                         <p>before[]after</p>`),
             });
         });
+
+        test("should fill the inner editable with a P when all of its contents are removed", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <div contenteditable="false">
+                        <div contenteditable="true">[<p>abc</p>]</div>
+                    </div>`),
+                stepFunction: async (editor) => {
+                    deleteBackward(editor);
+                },
+                contentAfter: unformat(`
+                    <div contenteditable="false">
+                        <div contenteditable="true"><p>[]<br></p></div>
+                    </div>`),
+            });
+        });
+
+        test("should fill the inner editable with a P when all of its contents are removed (2)", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <div contenteditable="false">
+                        <div contenteditable="true">[<h1>abc</h1><p>def</p>]</div>
+                    </div>`),
+                stepFunction: async (editor) => {
+                    deleteBackward(editor);
+                },
+                contentAfter: unformat(`
+                    <div contenteditable="false">
+                        <div contenteditable="true"><p>[]<br></p></div>
+                    </div>`),
+            });
+        });
     });
 });


### PR DESCRIPTION
Currently, when the editable root is left empty after deleting its
contents, it gets filled with an empty paragraph.

This commit extends such behaviour to the root of a contenteditable=true
zone nested inside a contenteditable=false zone.