### PR TITLE
[FIX] ctrl+k twice to create a link on selected text traceback

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -330,11 +330,9 @@ export class LinkPlugin extends Plugin {
             const link = this.document.createElement("a");
             if (!selection.isCollapsed) {
                 const content = this.shared.extractContent(selection);
-                if (!this.shared.getEditableSelection().inEditable) {
-                    const anchorNode = selection.anchorNode;
-                    const anchorOffset = selection.anchorOffset;
-                    this.shared.setSelection({ anchorNode, anchorOffset });
-                }
+                const anchorNode = selection.anchorNode;
+                const anchorOffset = selection.anchorOffset;
+                this.shared.setSelection({ anchorNode, anchorOffset });
                 link.append(content);
             }
             this.shared.domInsert(link);

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -485,21 +485,17 @@ describe("shortcut", () => {
             '<p><a href="http://test.com">test.com[]</a></p>'
         );
     });
-    // need to fix
-    test.todo(
-        "should be able to create link with ctrl+k , and should make link on two existing characters",
-        async () => {
-            const { el } = await setupEditor(`<p>H[el]lo</p>`);
+    test("should be able to create link with ctrl+k , and should make link on two existing characters", async () => {
+        const { el } = await setupEditor(`<p>H[el]lo</p>`);
 
-            press(["ctrl", "k"]);
-            await animationFrame();
-            press(["ctrl", "k"]);
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("test.com");
-            expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>H<a href="http://test.com">el</a>lo</p>'
-            );
-        }
-    );
+        press(["ctrl", "k"]);
+        await animationFrame();
+        press(["ctrl", "k"]);
+        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("test.com");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>H<a href="http://test.com">el[]</a>lo</p>'
+        );
+    });
     test("Press enter to apply when create a link", async () => {
         const { el } = await setupEditor(`<p><a>li[]nk</a></p>`);
 


### PR DESCRIPTION
reason: the selection is not properly updated after extract the content

fix: set the selection correctly after extracting the text so the link can be inserted at the right place