### PR TITLE
[FIX] html_editor: SET_TAG on selected content node

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -325,7 +325,7 @@ export class DomPlugin extends Plugin {
     setTag({ tagName, extraClass = "" }) {
         tagName = tagName.toUpperCase();
         const selection = this.shared.getEditableSelection();
-        const selectedBlocks = [...new Set(this.shared.getTraversedNodes().map(closestBlock))];
+        const selectedBlocks = [...this.shared.getTraversedBlocks()];
         const deepestSelectedBlocks = selectedBlocks.filter(
             (block) =>
                 !descendants(block).some((descendant) => selectedBlocks.includes(descendant)) &&

--- a/addons/html_editor/static/tests/list/indent.test.js
+++ b/addons/html_editor/static/tests/list/indent.test.js
@@ -1034,7 +1034,7 @@ describe("with selection", () => {
                         [b
                     </li><li class="oe-nested">
                         <ol>
-                            <li>]c</li>
+                            <li>c]</li>
                         </ol>
                     </li>
                 </ul>`),
@@ -1051,9 +1051,36 @@ describe("with selection", () => {
                             </li>
                             <li class="oe-nested">
                                 <ol>
-                                    <li>]c</li>
+                                    <li>c]</li>
                                 </ol>
                             </li>
+                        </ol>
+                    </li>
+                </ul>`),
+        });
+    });
+
+    test("should only indent elements with selected content (mix lists)", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <ul>
+                    <li>a</li>
+                    <li>
+                        [b
+                    </li><li class="oe-nested">
+                        <ol>
+                            <li>]c</li>
+                        </ol>
+                    </li>
+                </ul>`),
+            stepFunction: keydownTab,
+            contentAfter: unformat(`
+                <ul>
+                    <li>a</li>
+                    <li class="oe-nested">
+                        <ol>
+                            <li>[b</li>
+                            <li>]c</li>
                         </ol>
                     </li>
                 </ul>`),

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -122,6 +122,14 @@ describe("to heading 1", () => {
         });
     });
 
+    test("should just turn the paragraph with selected content into a heading 1", async () => {
+        await testEditor({
+            contentBefore: "<p>[ab</p><p>]cd</p>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<h1>[ab</h1><p>]cd</p>",
+        });
+    });
+
     test("should turn a paragraph, a heading 1 and a heading 2 into three headings 1", async () => {
         await testEditor({
             contentBefore: "<p>a[b</p><h1>cd</h1><h2>e]f</h2>",


### PR DESCRIPTION
The goal of this commit is to apply SET_TAG only
to nodes with selected content.

Before this commit, when we placed the start of the selection at the end of a node or the end of the selection at the start of an element, SET_TAG also converted these noeds even though no content was selected in them.