### PR TITLE
[REF] html_editor: rm unnecessary closestElement calls

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -195,7 +195,7 @@ export class FormatPlugin extends Plugin {
         // Get selected nodes within td to handle non-p elements like h1, h2...
         // Targeting <br> to ensure span stays inside its corresponding block node.
         const selectedNodesInTds = [...this.editable.querySelectorAll(".o_selected_td")].map(
-            (node) => closestElement(node).querySelector("br")
+            (node) => node.querySelector("br")
         );
         const selectedNodes = /** @type { Text[] } **/ (
             this.shared

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -128,7 +128,7 @@ export class ColorPlugin extends Plugin {
      */
     applyColor(color, mode) {
         const selectedTds = [...this.editable.querySelectorAll("td.o_selected_td")].filter(
-            (node) => closestElement(node).isContentEditable
+            (node) => node.isContentEditable
         );
         if (selectedTds.length && mode === "backgroundColor") {
             for (const td of selectedTds) {

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -429,7 +429,7 @@ export class LinkPlugin extends Plugin {
         let selection = this.shared.getEditableSelection();
         if (
             isHtmlContentSupported(selection.anchorNode) &&
-            !closestElement(selection.anchorNode).closest("a") &&
+            !closestElement(selection.anchorNode, "a") &&
             selection.anchorNode.nodeType === Node.TEXT_NODE
         ) {
             // Merge adjacent text nodes.

--- a/addons/html_editor/static/src/utils/selection.js
+++ b/addons/html_editor/static/src/utils/selection.js
@@ -75,7 +75,7 @@ export function normalizeNotEditableNode(node, offset, position = "right") {
     let closest = closestElement(node);
     while (closest && closest !== editable && !closest.isContentEditable) {
         [node, offset] = position === "right" ? rightPos(node) : leftPos(node);
-        closest = closestElement(node);
+        closest = node;
     }
     return [node, offset];
 }


### PR DESCRIPTION
The calls to closestElement removed by this commit were not necessary as:
- querySelectorAll returns HTMLElements
- rightPos and leftPos return an HTMLElement (and a number for the offset)

Additionally , `closestElement(selection.anchorNode).closest("a")` is equivalent to `closestElement(selection.anchorNode, "a")`, as long as `selection.anchorNode` is contained by the editable, which is guaranteed by `this.shared.getEditableSelection()`.