### PR TITLE
[REF] html_editor: simplify unserialize node process

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -79,7 +79,7 @@ import { descendants, getCommonAncestor } from "../utils/dom_traversal";
 
 export class HistoryPlugin extends Plugin {
     static name = "history";
-    static dependencies = ["dom", "selection"];
+    static dependencies = ["dom", "selection", "sanitize"];
     static shared = [
         "reset",
         "canUndo",
@@ -917,10 +917,10 @@ export class HistoryPlugin extends Plugin {
      */
     unserializeNode(node) {
         let [unserializedNode, nodeMap] = this._unserializeNode(node);
-
-        for (const cb of this.resources["unserialize_node"] || []) {
-            unserializedNode = cb(unserializedNode);
-        }
+        const fakeNode = this.document.createElement("fake-el");
+        fakeNode.appendChild(unserializedNode);
+        this.shared.sanitize(fakeNode, { IN_PLACE: true });
+        unserializedNode = fakeNode.childNodes[0];
 
         if (unserializedNode) {
             // Only assing id to the remaining nodes, otherwise the removed

--- a/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
@@ -16,7 +16,6 @@ export class CollaborationPlugin extends Plugin {
     /** @type { (p: CollaborationPlugin) => Record<string, any> } */
     static resources = (p) => ({
         set_attribute: p.setAttribute.bind(p),
-        unserialize_node: p.unserializeNode.bind(p),
         process_history_step: p.processHistoryStep.bind(p),
         is_revertable_step: p.isRevertableStep.bind(p),
     });
@@ -315,16 +314,6 @@ export class CollaborationPlugin extends Plugin {
     onStepAdded(step) {
         step.peerId = this.peerId;
         this.dispatch("COLLABORATION_STEP_ADDED", step);
-    }
-    /**
-     * @param {Node} node
-     */
-    unserializeNode(node) {
-        const fakeNode = this.document.createElement("fake-el");
-        fakeNode.appendChild(node);
-        this.shared.sanitize(fakeNode, { IN_PLACE: true });
-        const sanitizedNode = fakeNode.childNodes[0];
-        return sanitizedNode;
     }
     /**
      * @param {import("../../core/history_plugin").HistoryStep} step

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -218,6 +218,6 @@ test("should not crash when changing attributes and removing a protecting anchor
     expect(lastStep.mutations[0].type).toBe("attributes");
     expect(lastStep.mutations[1].type).toBe("remove");
     expect(plugins.get("history").unserializeNode(lastStep.mutations[1].node).outerHTML).toBe(
-        `<div data-oe-protected="true" data-attr="other"><p>a</p></div>`
+        `<div data-attr="other" data-oe-protected="true"><p>a</p></div>`
     );
 });


### PR DESCRIPTION
Before this commit, the history plugin would call a resource defined by the collaboration plugin to sanitize the content of a node (coming from an external step). This is not really necessary and can be done directly instead. This also makes it clearer that the content coming from collaboration mutations is properly sanitized.