### PR TITLE
[REF] html_editor: joinFragments

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -1,6 +1,7 @@
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
 import {
+    isAllowedContent,
     isEmpty,
     isInPre,
     isNotEditableNode,
@@ -681,7 +682,13 @@ export class DeletePlugin extends Plugin {
             return false;
         }
 
-        left.append(...right.childNodes);
+        // Check if left block allows right block's content.
+        const rightChildNodes = childNodes(right);
+        if (!isAllowedContent(left, rightChildNodes)) {
+            return false;
+        }
+
+        left.append(...rightChildNodes);
         let toRemove = right;
         let parent = right.parentElement;
         // Propagate until commonAncestor, removing empty blocks

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -492,6 +492,44 @@ export function allowsParagraphRelatedElements(node) {
     return isBlock(node) && !paragraphRelatedElements.includes(node.nodeName);
 }
 
+const phrasingContent = new Set(["#text", ...phrasingTagNames]);
+const flowContent = new Set([...phrasingContent, ...paragraphRelatedElements, "DIV", "HR"]);
+const listItem = new Set(["LI"]);
+
+const allowedContent = {
+    BLOCKQUOTE: phrasingContent, // HTML spec: flow content
+    DIV: flowContent,
+    H1: phrasingContent,
+    H2: phrasingContent,
+    H3: phrasingContent,
+    H4: phrasingContent,
+    H5: phrasingContent,
+    H6: phrasingContent,
+    HR: new Set(),
+    LI: flowContent,
+    OL: listItem,
+    UL: listItem,
+    P: phrasingContent,
+    PRE: phrasingContent,
+    TD: flowContent,
+    TR: new Set(["TD"]),
+};
+
+/**
+ * @param {Element} parentBlock
+ * @param {Node[]} nodes
+ * @returns {boolean}
+ */
+export function isAllowedContent(parentBlock, nodes) {
+    const allowedContentSet = allowedContent[parentBlock.nodeName];
+    if (!allowedContentSet) {
+        // Spec: a block not listed in allowedContent allows anything.
+        // See "custom-block" in tests.
+        return true;
+    }
+    return nodes.every((node) => allowedContentSet.has(node.nodeName));
+}
+
 /**
  * Checks whether or not the given block has any visible content, except for
  * a placeholder BR.

--- a/addons/html_editor/static/src/utils/dom_traversal.js
+++ b/addons/html_editor/static/src/utils/dom_traversal.js
@@ -27,6 +27,22 @@ export function findNode(domPath, findCallback = () => true, stopCallback = () =
 }
 
 /**
+ * @param {Node} node
+ * @param {HTMLElement} limitAncestor - non inclusive limit ancestor to search for
+ * @param {Function} predicate
+ * @returns {Node|null}
+ */
+export function findUpTo(node, limitAncestor, predicate) {
+    while (node !== limitAncestor) {
+        if (predicate(node)) {
+            return node;
+        }
+        node = node.parentElement;
+    }
+    return null;
+}
+
+/**
  * Returns the closest HTMLElement of the provided Node. If the predicate is a
  * string, returns the closest HTMLElement that match the predicate selector. If
  * the predicate is a function, returns the closest element that matches the

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -423,4 +423,53 @@ describe("DELETE_SELECTION command", () => {
             });
         });
     });
+    describe("Allowed content mismatch on blocks merge", () => {
+        test("should not add H1 (flow content) to P (allows phrasing content only)", async () => {
+            await testEditor({
+                contentBefore: unformat(
+                    `<p>a[bc</p>
+                    <ul>
+                        <li>
+                            <h1>def</h1>]
+                            <h1>ghi</h1>
+                        </li>
+                    </ul>`
+                ),
+                stepFunction: deleteSelection,
+                contentAfter: unformat(
+                    `<p>a[]</p>
+                    <ul>
+                        <li>
+                            <h1>ghi</h1>
+                        </li>
+                    </ul>`
+                ),
+            });
+        });
+        test("should add P (flow content) to LI (allows flow content) ", async () => {
+            await testEditor({
+                contentBefore: unformat(
+                    `<ul>
+                        <li>
+                            <h1>abc</h1>
+                            [<h1>def</h1>
+                        </li>
+                        <li>
+                            <p>ghi</p>]
+                            <p>jkl</p>
+                        </li>
+                    </ul>`
+                ),
+                stepFunction: deleteSelection,
+                contentAfter: unformat(
+                    `<ul>
+                        <li>
+                            <h1>abc</h1>
+                            <p>[]jkl</p>
+                        </li>
+                    </ul>`
+                ),
+            });
+        });
+    });
 });


### PR DESCRIPTION
This commit aims to reduce complexity and inconsistencies from DeletePlugin's joinFragments method.

Before this commit, the check for whether elements could be merged was done outside the functions the perform the actual merge, even though it required knowledge about what such functions do. This commit avoids such situation and moves the check for mergeability to inside the join* functions, right before the actual merge/join takes place.

This commit also removes the check for mergeability for inlines, as it matters only for blocks.