### PR TITLE
[FIX] html_editor: paste image and save in html_field

### DIFF
--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -254,9 +254,11 @@ export class MediaPlugin extends Plugin {
             if (!attachment.public) {
                 let accessToken = attachment.access_token;
                 if (!accessToken) {
-                    [accessToken] = await this.orm.call("ir.attachment", "generate_access_token", [
-                        attachment.id,
-                    ]);
+                    [accessToken] = await this.services.orm.call(
+                        "ir.attachment",
+                        "generate_access_token",
+                        [attachment.id]
+                    );
                 }
                 src += `?access_token=${encodeURIComponent(accessToken)}`;
             }


### PR DESCRIPTION
Before this commit, pasting an image and then saving it could displayed an error.

Reason:
When converting the attachment to an image using "add_data", if no "access_token" is returned it must be created using "generate_access_token". The "orm" service used for this call is in "this.services" and not directly on the "this".