### PR TITLE
[IMP] html_editor: some more performance improvements

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -2,7 +2,7 @@ import { isUnbreakable, paragraphRelatedElements } from "../utils/dom_info";
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
 import { unwrapContents } from "../utils/dom";
-import { ancestors, closestElement } from "../utils/dom_traversal";
+import { ancestors, childNodes, closestElement } from "../utils/dom_traversal";
 import { parseHTML } from "../utils/html";
 
 /**
@@ -363,8 +363,7 @@ export class ClipboardPlugin extends Plugin {
                 }
             }
         }
-
-        for (const child of [...container.childNodes]) {
+        for (const child of childNodes(container)) {
             this.cleanForPaste(child);
         }
         // Force inline nodes at the root of the container into separate P
@@ -376,7 +375,7 @@ export class ClipboardPlugin extends Plugin {
         // instantly when editing a document that was created from Etherpad.
         const result = this.document.createDocumentFragment();
         let p = this.document.createElement("p");
-        for (const child of [...container.childNodes]) {
+        for (const child of childNodes(container)) {
             if (isBlock(child)) {
                 if (p.hasChildNodes()) {
                     result.appendChild(p);

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -9,6 +9,7 @@ import { prepareUpdate } from "./dom_state";
 import { boundariesOut, leftPos, nodeSize, rightPos } from "./position";
 import { callbacksForCursorUpdate } from "./selection";
 import { isEmptyBlock, isPhrasingContent } from "../utils/dom_info";
+import { childNodes } from "./dom_traversal";
 
 /** @typedef {import("@html_editor/core/selection_plugin").Cursors} Cursors */
 
@@ -105,7 +106,7 @@ export function wrapInlinesInBlocks(element, cursors = { update: () => {} }) {
 }
 
 export function unwrapContents(node) {
-    const contents = [...node.childNodes];
+    const contents = childNodes(node);
     for (const child of contents) {
         node.parentNode.insertBefore(child, node);
     }
@@ -208,9 +209,9 @@ export function fillShrunkPhrasingParent(el) {
  */
 export function cleanTrailingBR(el) {
     let br;
-    if (!isEmptyBlock(el) && el.hasChildNodes()) {
-        const candidate = el.lastChild;
-        if (candidate.tagName === "BR" && candidate.previousSibling?.tagName !== "BR") {
+    const candidate = el.lastChild;
+    if (candidate && candidate.tagName === "BR" && !isEmptyBlock(el)) {
+        if (candidate.previousSibling?.tagName !== "BR") {
             br = candidate;
             candidate.remove();
         }


### PR DESCRIPTION
Use of childnodes function, which is faster than element.chilnodes, and changing the logic of cleanTrailingBR to only call isEmpty if last child is a BR.