### PR TITLE
[FIX] html_editor: wrong staged selecion on insertText

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -28,7 +28,6 @@ import {
 } from "../utils/dom_traversal";
 import { DIRECTIONS, childNodeIndex, leftPos, nodeSize, rightPos } from "../utils/position";
 import { CTYPES } from "../utils/content_types";
-import { isMacOS } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef {Object} RangeLike
@@ -55,6 +54,7 @@ export class DeletePlugin extends Plugin {
     static shared = ["deleteRange"];
     /** @type { (p: DeletePlugin) => Record<string, any> } */
     static resources = (p) => ({
+        onBeforeInput: p.onBeforeInput.bind(p),
         shortcuts: [
             { hotkey: "backspace", command: "DELETE_BACKWARD" },
             { hotkey: "delete", command: "DELETE_FORWARD" },
@@ -83,11 +83,6 @@ export class DeletePlugin extends Plugin {
             (element) => element.matches("[data-oe-type='monetary'] > span"),
         ],
     });
-
-    setup() {
-        this.addDomListener(this.editable, "beforeinput", this.onBeforeInput.bind(this));
-        this.addDomListener(this.editable, "keydown", this.onKeydown.bind(this));
-    }
 
     handleCommand(command, payload) {
         switch (command) {
@@ -1197,21 +1192,6 @@ export class DeletePlugin extends Plugin {
         if (command) {
             e.preventDefault();
             this.dispatch(command);
-        }
-    }
-    /**
-     * @param {KeyboardEvent} ev
-     */
-    onKeydown(ev) {
-        // If the pressed key has a printed representation, the returned value
-        // is a non-empty Unicode character string containing the printable
-        // representation of the key. In this case, call `deleteRange` before
-        // inserting the printed representation of the character.
-        if (/^.$/u.test(ev.key) && !ev.ctrlKey && !ev.metaKey && (isMacOS() || !ev.altKey)) {
-            const selection = this.shared.getEditableSelection();
-            if (selection && !selection.isCollapsed) {
-                this.deleteSelection(selection);
-            }
         }
     }
 

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -105,13 +105,11 @@ export class HistoryPlugin extends Plugin {
 
     setup() {
         this.renderingClasses = new Set(this.resources["history_rendering_classes"]);
-        this.addDomListener(this.editable, "input", () => this.addStep());
         this.addDomListener(this.editable, "pointerup", () => {
             this.stageSelection();
             this.stageNextSelection = true;
         });
         this.addDomListener(this.editable, "keydown", this.stageSelection);
-        this.addDomListener(this.editable, "beforeinput", this.stageSelection);
         this.observer = new MutationObserver(this.handleNewRecords.bind(this));
         this._cleanups.push(() => this.observer.disconnect());
         this.clean();

--- a/addons/html_editor/static/src/core/input_plugin.js
+++ b/addons/html_editor/static/src/core/input_plugin.js
@@ -1,0 +1,23 @@
+import { Plugin } from "../plugin";
+
+export class InputPlugin extends Plugin {
+    static name = "input";
+    setup() {
+        this.addDomListener(this.editable, "beforeinput", this.onBeforeInput);
+        this.addDomListener(this.editable, "input", this.onInput);
+    }
+
+    onBeforeInput(ev) {
+        this.dispatch("HISTORY_STAGE_SELECTION");
+        for (const handler of this.resources.onBeforeInput || []) {
+            handler(ev);
+        }
+    }
+
+    onInput(ev) {
+        this.dispatch("ADD_STEP");
+        for (const handler of this.resources.onInput || []) {
+            handler(ev);
+        }
+    }
+}

--- a/addons/html_editor/static/src/core/insert_text_plugin.js
+++ b/addons/html_editor/static/src/core/insert_text_plugin.js
@@ -1,0 +1,19 @@
+import { Plugin } from "../plugin";
+
+export class InsertTextPlugin extends Plugin {
+    static name = "insertText";
+    static dependencies = ["selection"];
+    static resources = (p) => ({
+        onBeforeInput: p.onBeforeInput.bind(p),
+    });
+
+    onBeforeInput(ev) {
+        if (ev.inputType === "insertText") {
+            const selection = this.shared.getEditableSelection();
+            if (!selection.isCollapsed) {
+                this.dispatch("DELETE_SELECTION");
+            }
+            // Default behavior: insert text and trigger input event
+        }
+    }
+}

--- a/addons/html_editor/static/src/core/line_break_plugin.js
+++ b/addons/html_editor/static/src/core/line_break_plugin.js
@@ -7,10 +7,11 @@ export class LineBreakPlugin extends Plugin {
     static dependencies = ["selection", "split"];
     static name = "line_break";
     static shared = ["insertLineBreakElement"];
+    /** @type { (p: LineBreakPlugin) => Record<string, any> } */
+    static resources = (p) => ({
+        onBeforeInput: p.onBeforeInput.bind(p),
+    });
 
-    setup() {
-        this.addDomListener(this.editable, "beforeinput", this.onBeforeInput.bind(this));
-    }
     handleCommand(command, payload) {
         switch (command) {
             case "INSERT_LINEBREAK":

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -17,14 +17,12 @@ export class SplitPlugin extends Plugin {
         "splitTextNode",
         "splitSelection",
     ];
-    static resources = () => ({
+    static resources = (p) => ({
         // @todo: get rules from separate plugins, get rid of isUnbreakable
         unsplittable: (block) => isUnbreakable(block),
+        onBeforeInput: p.onBeforeInput.bind(p),
     });
 
-    setup() {
-        this.addDomListener(this.editable, "beforeinput", this.onBeforeInput.bind(this));
-    }
     handleCommand(command, payload) {
         switch (command) {
             case "SPLIT_BLOCK":

--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -5,91 +5,92 @@ import { DIRECTIONS } from "@html_editor/utils/position";
 export class InlineCodePlugin extends Plugin {
     static name = "inline_code";
     static dependencies = ["selection", "split"];
+    static resources = (p) => ({
+        onInput: p.onInput.bind(p),
+    });
 
-    setup() {
-        this.addDomListener(this.editable, "input", (ev) => {
-            const selection = this.shared.getEditableSelection();
-            if (ev.data !== "`" || closestElement(selection.anchorNode, "code")) {
-                return;
-            }
-            // We just inserted a backtick, check if there was another
-            // one in the text.
-            let textNode = selection.startContainer;
-            let offset = selection.startOffset;
-            let sibling = textNode.previousSibling;
-            while (sibling && sibling.nodeType === Node.TEXT_NODE) {
-                offset += sibling.textContent.length;
-                sibling.textContent += textNode.textContent;
-                textNode.remove();
-                textNode = sibling;
-                sibling = textNode.previousSibling;
-            }
+    onInput(ev) {
+        const selection = this.shared.getEditableSelection();
+        if (ev.data !== "`" || closestElement(selection.anchorNode, "code")) {
+            return;
+        }
+        // We just inserted a backtick, check if there was another
+        // one in the text.
+        let textNode = selection.startContainer;
+        let offset = selection.startOffset;
+        let sibling = textNode.previousSibling;
+        while (sibling && sibling.nodeType === Node.TEXT_NODE) {
+            offset += sibling.textContent.length;
+            sibling.textContent += textNode.textContent;
+            textNode.remove();
+            textNode = sibling;
+            sibling = textNode.previousSibling;
+        }
+        sibling = textNode.nextSibling;
+        while (sibling && sibling.nodeType === Node.TEXT_NODE) {
+            textNode.textContent += sibling.textContent;
+            sibling.remove();
             sibling = textNode.nextSibling;
-            while (sibling && sibling.nodeType === Node.TEXT_NODE) {
-                textNode.textContent += sibling.textContent;
-                sibling.remove();
-                sibling = textNode.nextSibling;
-            }
-            this.shared.setSelection({ anchorNode: textNode, anchorOffset: offset });
-            const textHasTwoTicks = /`.*`/.test(textNode.textContent);
-            if (textHasTwoTicks) {
-                this.dispatch("ADD_STEP");
-                const insertedBacktickIndex = offset - 1;
-                const textBeforeInsertedBacktick = textNode.textContent.substring(
-                    0,
-                    insertedBacktickIndex - 1
-                );
-                let startOffset, endOffset;
-                const isClosingForward = textBeforeInsertedBacktick.includes("`");
-                if (isClosingForward) {
-                    // There is a backtick before the new backtick.
-                    startOffset = textBeforeInsertedBacktick.lastIndexOf("`");
-                    endOffset = insertedBacktickIndex;
-                } else {
-                    // There is a backtick after the new backtick.
-                    const textAfterInsertedBacktick = textNode.textContent.substring(offset);
-                    startOffset = insertedBacktickIndex;
-                    endOffset = offset + textAfterInsertedBacktick.indexOf("`");
-                }
-                // Split around the backticks if needed so text starts
-                // and ends with a backtick.
-                if (endOffset && endOffset < textNode.textContent.length) {
-                    this.shared.splitTextNode(textNode, endOffset + 1, DIRECTIONS.LEFT);
-                }
-                if (startOffset) {
-                    this.shared.splitTextNode(textNode, startOffset);
-                }
-                // Remove ticks.
-                textNode.textContent = textNode.textContent.substring(
-                    1,
-                    textNode.textContent.length - 1
-                );
-                // Insert code element.
-                const codeElement = this.document.createElement("code");
-                codeElement.classList.add("o_inline_code");
-                textNode.before(codeElement);
-                codeElement.append(textNode);
-                if (
-                    !codeElement.previousSibling ||
-                    codeElement.previousSibling.nodeType !== Node.TEXT_NODE
-                ) {
-                    codeElement.before(document.createTextNode("\u200B"));
-                }
-                if (isClosingForward) {
-                    // Move selection out of code element.
-                    codeElement.after(document.createTextNode("\u200B"));
-                    this.shared.setSelection({
-                        anchorNode: codeElement.nextSibling,
-                        anchorOffset: 1,
-                    });
-                } else {
-                    this.shared.setSelection({
-                        anchorNode: codeElement.firstChild,
-                        anchorOffset: 0,
-                    });
-                }
-            }
+        }
+        this.shared.setSelection({ anchorNode: textNode, anchorOffset: offset });
+        const textHasTwoTicks = /`.*`/.test(textNode.textContent);
+        if (textHasTwoTicks) {
             this.dispatch("ADD_STEP");
-        });
+            const insertedBacktickIndex = offset - 1;
+            const textBeforeInsertedBacktick = textNode.textContent.substring(
+                0,
+                insertedBacktickIndex - 1
+            );
+            let startOffset, endOffset;
+            const isClosingForward = textBeforeInsertedBacktick.includes("`");
+            if (isClosingForward) {
+                // There is a backtick before the new backtick.
+                startOffset = textBeforeInsertedBacktick.lastIndexOf("`");
+                endOffset = insertedBacktickIndex;
+            } else {
+                // There is a backtick after the new backtick.
+                const textAfterInsertedBacktick = textNode.textContent.substring(offset);
+                startOffset = insertedBacktickIndex;
+                endOffset = offset + textAfterInsertedBacktick.indexOf("`");
+            }
+            // Split around the backticks if needed so text starts
+            // and ends with a backtick.
+            if (endOffset && endOffset < textNode.textContent.length) {
+                this.shared.splitTextNode(textNode, endOffset + 1, DIRECTIONS.LEFT);
+            }
+            if (startOffset) {
+                this.shared.splitTextNode(textNode, startOffset);
+            }
+            // Remove ticks.
+            textNode.textContent = textNode.textContent.substring(
+                1,
+                textNode.textContent.length - 1
+            );
+            // Insert code element.
+            const codeElement = this.document.createElement("code");
+            codeElement.classList.add("o_inline_code");
+            textNode.before(codeElement);
+            codeElement.append(textNode);
+            if (
+                !codeElement.previousSibling ||
+                codeElement.previousSibling.nodeType !== Node.TEXT_NODE
+            ) {
+                codeElement.before(document.createTextNode("\u200B"));
+            }
+            if (isClosingForward) {
+                // Move selection out of code element.
+                codeElement.after(document.createTextNode("\u200B"));
+                this.shared.setSelection({
+                    anchorNode: codeElement.nextSibling,
+                    anchorOffset: 1,
+                });
+            } else {
+                this.shared.setSelection({
+                    anchorNode: codeElement.firstChild,
+                    anchorOffset: 0,
+                });
+            }
+        }
+        this.dispatch("ADD_STEP");
     }
 }

--- a/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
@@ -9,6 +9,10 @@ import { Plugin } from "../../plugin";
 export class SearchPowerboxPlugin extends Plugin {
     static name = "search_powerbox";
     static dependencies = ["powerbox", "selection", "history"];
+    static resources = (p) => ({
+        onBeforeInput: p.onBeforeInput.bind(p),
+        onInput: p.onInput.bind(p),
+    });
     setup() {
         const categoryIds = new Set();
         for (const category of this.resources.powerboxCategory) {
@@ -23,18 +27,6 @@ export class SearchPowerboxPlugin extends Plugin {
             categoryName: this.categories.find((category) => category.id === command.category).name,
         }));
 
-        this.addDomListener(this.editable, "beforeinput", (ev) => {
-            if (ev.data === "/") {
-                this.historySavePointRestore = this.shared.makeSavePoint();
-            }
-        });
-        this.addDomListener(this.editable, "input", (ev) => {
-            if (ev.data === "/") {
-                this.openPowerbox();
-            } else {
-                this.update();
-            }
-        });
         this.shouldUpdate = false;
     }
     handleCommand(command) {
@@ -45,6 +37,18 @@ export class SearchPowerboxPlugin extends Plugin {
             case "HISTORY_REDO":
                 this.update();
                 break;
+        }
+    }
+    onBeforeInput(ev) {
+        if (ev.data === "/") {
+            this.historySavePointRestore = this.shared.makeSavePoint();
+        }
+    }
+    onInput(ev) {
+        if (ev.data === "/") {
+            this.openPowerbox();
+        } else {
+            this.update();
         }
     }
     update() {

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -5,6 +5,8 @@ import { DeletePlugin } from "./core/delete_plugin";
 import { DomPlugin } from "./core/dom_plugin";
 import { FormatPlugin } from "./core/format_plugin";
 import { HistoryPlugin } from "./core/history_plugin";
+import { InputPlugin } from "./core/input_plugin";
+import { InsertTextPlugin } from "./core/insert_text_plugin";
 import { LineBreakPlugin } from "./core/line_break_plugin";
 import { OverlayPlugin } from "./core/overlay_plugin";
 import { ProtectedNodePlugin } from "./core/protected_node_plugin";
@@ -58,6 +60,8 @@ export const CORE_PLUGINS = [
     DomPlugin,
     FormatPlugin,
     HistoryPlugin,
+    InputPlugin,
+    InsertTextPlugin,
     LineBreakPlugin,
     OverlayPlugin,
     ProtectedNodePlugin,

--- a/addons/html_editor/static/tests/insert/text.test.js
+++ b/addons/html_editor/static/tests/insert/text.test.js
@@ -1,6 +1,7 @@
-import { describe, test } from "@odoo/hoot";
-import { testEditor } from "../_helpers/editor";
+import { describe, expect, test } from "@odoo/hoot";
+import { setupEditor, testEditor } from "../_helpers/editor";
 import { deleteBackward, insertText } from "../_helpers/user_actions";
+import { getContent } from "../_helpers/selection";
 
 describe("collapsed selection", () => {
     test("should insert a char into an empty span without removing the zws", async () => {
@@ -71,5 +72,13 @@ describe("not collapsed selection", () => {
             },
             contentAfter: `<p><strong>ab</strong>&nbsp;x[]</p>`,
         });
+    });
+
+    test("should replace text and be a undoable step", async () => {
+        const { editor, el } = await setupEditor("<p>[abc]def</p>");
+        insertText(editor, "x");
+        expect(getContent(el)).toBe("<p>x[]def</p>");
+        editor.dispatch("HISTORY_UNDO");
+        expect(getContent(el)).toBe("<p>[abc]def</p>");
     });
 });


### PR DESCRIPTION
Before this commit, inserting text over a non-collapsed selection was handled by the DeletePlugin by listening to the `keydown` event. It deleted the selected content and let the browser's default behavior take place.  This was problematic because on `beforeinput` (thus, after `keydown`), the History Plugin staged the selection, which was no longer the one at the beginning of the history step.

The logical solution was to handle text insertion on the `beforeinput` event instead.  Which brings us to second problem:

Different plugins added event listeners to the `beforeinput` and `input` events, which caused the order of execution to be unpredictable (dependent on Plugin instanciation order).

In particular, as mentioned above, the History Plugin staged the selection on `beforeinput`. Plugins that handled `beforeinput` could rely on the selection being staged before their handler was executed, as long as they were instantiated after the History Plugin.  That would not work for the DeletePlugin, which is instantiated before the History Plugin.  A similar problem could happen for plugins that handled `input`, that rely on the History Plugin to add step before their handler is executed.

This commit introduces two new plugins: InputPlugin and InsertTextPlugin.

The goal of the InputPlugin is to centralize the handling of the `beforeinput` event and make sure the history actions (stage selection on `beforeinput` and add step on `input`) are executed before any other plugin's handler.

The goal of the InsertTextPlugin is separation of concerns, leaving deletion to the DeletePlugin, and text insertion to a dedicated plugin, even though all it does (for now) is to delete the selection (via the DeletePlugin) and let the browser's default behavior take place.