### PR TITLE
[REF] html_editor: avoid computing selection content if possible

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -190,7 +190,7 @@ export class ClipboardPlugin extends Plugin {
         const dataHtmlElement = this.document.createElement("data");
         dataHtmlElement.append(clonedContents);
         const odooHtml = dataHtmlElement.innerHTML;
-        const odooText = selection.textContent;
+        const odooText = selection.textContent();
         ev.clipboardData.setData("text/plain", odooText);
         ev.clipboardData.setData("text/html", odooHtml);
         ev.clipboardData.setData("application/vnd.odoo.odoo-editor", odooHtml);

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -232,7 +232,7 @@ export class SelectionPlugin extends Plugin {
                 commonAncestorContainer: this.editable,
                 isCollapsed: true,
                 direction: DIRECTIONS.RIGHT,
-                textContent: "",
+                textContent: () => "",
                 inEditable,
             };
         } else {
@@ -274,7 +274,7 @@ export class SelectionPlugin extends Plugin {
                 commonAncestorContainer: range.commonAncestorContainer,
                 isCollapsed: range.collapsed,
                 direction,
-                textContent: range.collapsed ? "" : selection.toString(),
+                textContent: () => range.collapsed ? "" : selection.toString(),
                 inEditable,
             };
         }

--- a/addons/html_editor/static/src/main/link/link_paste_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_paste_plugin.js
@@ -101,7 +101,7 @@ export class LinkPastePlugin extends Plugin {
     removeFullySelectedLink(selection) {
         // Replace entire link if its label is fully selected.
         const link = closestElement(selection.anchorNode, "a");
-        if (link && cleanZWChars(selection.textContent) === cleanZWChars(link.innerText)) {
+        if (link && cleanZWChars(selection.textContent()) === cleanZWChars(link.innerText)) {
             const start = leftPos(link);
             link.remove();
             // @doto @phoenix do we still want normalize:false?


### PR DESCRIPTION
Before this commit, the selection plugin would always compute the content of the selection. But this is possibly an expansive operation with a large document, and it is even worse since the selection is computed many times in normal operations. With this commit, we only compute the text content when we actually need it.