### PR TITLE
[FIX] html_editor: image_crop: allow opening in Iframe

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -20,7 +20,7 @@ import { scrollTo } from "@web/core/utils/scrolling";
 export class ImageCrop extends Component {
     static template = "html_editor.ImageCrop";
     static props = {
-        document: { type: Document },
+        document: { validate: (p) => p.nodeType === Node.DOCUMENT_NODE },
         media: { optional: true },
         mimetype: { type: String, optional: true },
         onClose: { type: Function, optional: true },


### PR DESCRIPTION
In an iframe the classes object are different from the main window's. So, validating elements on the basis of the class (instanceof) will endup crashing when the editor is in an iframe.

This was the case for the imageCrop component.

This commit allows for the imageCrop Component to be spawn onto a document that is in an Iframe