### PR TITLE
[FIX] html_editor: fix getTraversedNodes with table cells selection

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -521,6 +521,7 @@ export class SelectionPlugin extends Plugin {
             edgeNodes = getUnselectedEdgeNodes(selection);
 
             if (
+                !(selectedTableCells.length && node === selectedTableCells[0]) &&
                 node.nodeType === Node.ELEMENT_NODE &&
                 selection.startOffset > 0 &&
                 node.childNodes[selection.startOffset - 1].nodeName === "BR"

--- a/addons/html_editor/static/tests/utils/selection.test.js
+++ b/addons/html_editor/static/tests/utils/selection.test.js
@@ -252,6 +252,40 @@ describe("getTraversedNodes", () => {
             },
         });
     });
+    test("selection within table cells 1", async () => {
+        await testEditor({
+            contentBefore: "<table><tbody><tr><td>abcd[e</td><td>f]g</td></tr></tbody></table>",
+            stepFunction: (editor) => {
+                const editable = editor.editable;
+                const tr = editable.firstChild.firstChild.firstChild;
+                const td1 = tr.firstChild;
+                const abcde = td1.firstChild;
+                const td2 = td1.nextSibling;
+                const fg = td2.firstChild;
+                const result = editor.shared.getTraversedNodes(editable);
+                expect(result).toEqual([td1, abcde, td2, fg]);
+            },
+        });
+    });
+    test("selection within table cells 2", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td>abcd<br>[<br>e</td><td>f]g</td></tr></tbody></table>",
+            stepFunction: (editor) => {
+                const editable = editor.editable;
+                const tr = editable.firstChild.firstChild.firstChild;
+                const td1 = tr.firstChild;
+                const abcd = td1.firstChild;
+                const br1 = abcd.nextSibling;
+                const br2 = br1.nextSibling;
+                const e = br2.nextSibling;
+                const td2 = td1.nextSibling;
+                const fg = td2.firstChild;
+                const result = editor.shared.getTraversedNodes(editable);
+                expect(result).toEqual([td1, abcd, br1, br2, e, td2, fg]);
+            },
+        });
+    });
 });
 
 describe("ensureFocus", () => {


### PR DESCRIPTION
Issue:
======
Traceback occurs when you select more than one table cell

Steps to reproduce the issue:
=============================
- Go to to-do
- Add a table 1row x 3cols
- Add some content with somewhat big length for example "abcde" in the first cell
- Add anything in the second cell
- Start the selection from the last character of the first cell
- Move the cursor to add selection from the second cell
- Traceback

Origin of the issue:
====================
When we have table cells selected, the first while loop stops at the `td` element and not the startContainer so we shouldn't enter in the if condition that handles the `br` elements