### PR TITLE
[REF] html_editor: refactor toolbar context strategy

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_crop_plugin.js
@@ -13,7 +13,7 @@ export class ImageCropPlugin extends Plugin {
             toolbarGroup: [
                 {
                     id: "image_crop",
-                    namespace: "IMG",
+                    namespace: "image",
                     sequence: 27,
                     buttons: [
                         {

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -18,12 +18,19 @@ export class ImagePlugin extends Plugin {
         return {
             handle_paste_url: p.handlePasteUrl.bind(p),
             onSelectionChange: p.onSelectionChange.bind(p),
-
+            toolbarNamespace: [
+                {
+                    id: "image",
+                    isApplied: (traversedNodes) => {
+                        return traversedNodes.at(-1)?.tagName === "IMG";
+                    },
+                },
+            ],
             toolbarGroup: [
                 {
                     id: "image_preview",
                     sequence: 23,
-                    namespace: "IMG",
+                    namespace: "image",
                     buttons: [
                         {
                             id: "image_preview",
@@ -38,7 +45,7 @@ export class ImagePlugin extends Plugin {
                 {
                     id: "image_description",
                     sequence: 24,
-                    namespace: "IMG",
+                    namespace: "image",
                     buttons: [
                         {
                             id: "image_description",
@@ -53,7 +60,7 @@ export class ImagePlugin extends Plugin {
                 {
                     id: "image_shape",
                     sequence: 25,
-                    namespace: "IMG",
+                    namespace: "image",
                     buttons: [
                         {
                             id: "shape_rounded",
@@ -96,7 +103,7 @@ export class ImagePlugin extends Plugin {
                 {
                     id: "image_padding",
                     sequence: 26,
-                    namespace: "IMG",
+                    namespace: "image",
                     buttons: [
                         {
                             id: "image_padding",
@@ -108,7 +115,7 @@ export class ImagePlugin extends Plugin {
                 {
                     id: "image_size",
                     sequence: 26,
-                    namespace: "IMG",
+                    namespace: "image",
                     buttons: [
                         {
                             id: "resize_default",
@@ -151,7 +158,7 @@ export class ImagePlugin extends Plugin {
                 {
                     id: "image_transform",
                     sequence: 26,
-                    namespace: "IMG",
+                    namespace: "image",
                     buttons: [
                         {
                             id: "image_transform",
@@ -167,7 +174,7 @@ export class ImagePlugin extends Plugin {
                 {
                     id: "image_delete",
                     sequence: 30,
-                    namespace: "IMG",
+                    namespace: "image",
                     buttons: [
                         {
                             id: "image_delete",

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -52,7 +52,7 @@ export class MediaPlugin extends Plugin {
             toolbarGroup: {
                 id: "replace_image",
                 sequence: 29,
-                namespace: "IMG",
+                namespace: "image",
                 buttons: [
                     {
                         id: "replace_image",

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -53,14 +53,16 @@ export class ToolbarPlugin extends Plugin {
     handleSelectionChange(selection) {
         this.updateToolbarVisibility(selection);
         if (this.overlay.isOpen || this.config.disableFloatingToolbar) {
-            const selectedNodes = this.shared.getSelectedNodes();
-            if (
-                selectedNodes.length &&
-                selectedNodes[0].tagName &&
-                selectedNodes.every((el) => el.tagName === selectedNodes[0].tagName)
-            ) {
-                this.state.namespace = selectedNodes[0].tagName;
-            } else {
+            const selectedNodes = this.shared.getTraversedNodes();
+            let foundNamespace = false;
+            for (let i = 0; i < this.resources.toolbarNamespace.length && !foundNamespace; i++) {
+                const namespace = this.resources.toolbarNamespace[i];
+                if (namespace.isApplied(selectedNodes)) {
+                    this.state.namespace = namespace.id;
+                    foundNamespace = true;
+                }
+            }
+            if (!foundNamespace) {
                 this.state.namespace = undefined;
             }
             this.updateButtonsStates(selection);

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -294,3 +294,13 @@ test("Can delete an image", async () => {
     await animationFrame();
     expect(".test-image").toHaveCount(0);
 });
+
+test("Toolbar detect image namespace even if it is the only child of a p", async () => {
+    await setupEditor(`
+        <p><img class="img-fluid test-image" src="${base64Img}"></p>
+    `);
+    expect(".test-image").toHaveCount(1);
+    click("img");
+    await waitFor(".o-we-toolbar");
+    expect("button[name='image_delete']").toHaveCount(1);
+});


### PR DESCRIPTION
Previously, we introduced the namespace system for the toolbar. The selection of a user determined the toolbar namespace, if all the selected nodes tag were the same then the namespace of the toolbar is set to this tagName.

This system were not flexible enough:
- Selecting an image can lead to multiple selected nodes. For example, when the image is the only child of a p (`<p><img ...></p>`) then the selected nodes are `['p', 'img']`. We therefore need special computation to distinguish if the user selected an image.
- An icon is not necessarily an `i` tag, it can be an `a` tag with icon classes. To support this usecases we need the extra flexibility introduced by this commit.

This commit introduces the `toolbarContext` resources in which plugin can specify new contexts and the condition in which they are applied.