### PR TITLE
[FIX] html_editor: reposition powerbox when resize

### DIFF
--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -1,4 +1,4 @@
-import { Component, useExternalListener, xml } from "@odoo/owl";
+import { Component, useEffect, useExternalListener, useRef, xml } from "@odoo/owl";
 import { usePosition } from "@web/core/position/position_hook";
 
 export class EditorOverlay extends Component {
@@ -28,6 +28,21 @@ export class EditorOverlay extends Component {
             });
             getTarget = this.getCurrentRect.bind(this);
         }
+
+        const rootRef = useRef("root");
+        const resizeObserver = new ResizeObserver(() => {
+            position.unlock();
+        });
+        useEffect(
+            (root) => {
+                resizeObserver.observe(root);
+                return () => {
+                    resizeObserver.unobserve(root);
+                };
+            },
+            () => [rootRef.el]
+        );
+
         position = usePosition("root", getTarget, this.props.config);
     }
 


### PR DESCRIPTION
The goal of this commit is to ensure that the position of the powerbox is always correct. It is expected that the powerbox will always be attached to the text of the current search.

Before this commit, the powerbox could be moved away from the current search when the number of orders displayed changed.

Reason:
The recalculation of the position of the powerbox (and all overlays) does not take into account changes in the size of the component. In the case of the powerbox, the rendering of the powerbox does not have time to finish before calculating its new position. This causes positionning errors.

Solution:
Recalculate the position of overlays each time their size changes.