### PR TITLE
[FIX] html_editor: undo remove format command

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -134,8 +134,12 @@ export class FormatPlugin extends Plugin {
             if (!formatsSpecs[format].removeStyle || !this.hasSelectionFormat(format)) {
                 continue;
             }
-            this.formatSelection(format, { applyStyle: false });
+            this._formatSelection(format, { applyStyle: false });
         }
+        for (const callback of this.resources["removeFormat"] || []) {
+            callback();
+        }
+        this.dispatch("ADD_STEP");
     }
 
     /**
@@ -169,7 +173,13 @@ export class FormatPlugin extends Plugin {
         return selectedNodes.length && selectedNodes.every((n) => isFormatted(n, this.editable));
     }
 
-    formatSelection(formatName, { applyStyle, formatProps } = {}) {
+    formatSelection(...args) {
+        if (this._formatSelection(...args)) {
+            this.dispatch("ADD_STEP");
+        }
+    }
+
+    _formatSelection(formatName, { applyStyle, formatProps } = {}) {
         // note: does it work if selection is in opposite direction?
         const selection = this.shared.splitSelection();
         if (typeof applyStyle === "undefined") {
@@ -331,7 +341,7 @@ export class FormatPlugin extends Plugin {
                 };
             }
             this.shared.setSelection(newSelection, { normalize: false });
-            this.dispatch("ADD_STEP");
+            return true;
         }
     }
 }

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -43,6 +43,7 @@ export class ColorPlugin extends Plugin {
             ],
         },
         onSelectionChange: p.updateSelectedColor.bind(p),
+        removeFormat: p.removeAllColor.bind(p),
     });
 
     setup() {
@@ -87,9 +88,6 @@ export class ColorPlugin extends Plugin {
             case "COLOR_RESET_PREVIEW":
                 this.previewableApplyColor.revert();
                 this.updateSelectedColor();
-                break;
-            case "FORMAT_REMOVE_FORMAT":
-                this.removeAllColor();
                 break;
         }
     }

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -580,6 +580,18 @@ test.todo("should remove multiple color (6)", async () => {
             '<div>ab<font style="background: blue">c</font>[de]<font class="bg-o-color-1">f</font>gh</div>',
     });
 });
+test("undo remove format should return the element to it's original state", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><strong><em><u><s><font style="color: rgb(0, 255, 0); background: rgb(0, 0, 255);">[sdsdsdsds]</font></s></u></em></strong></p>',
+        stepFunction: (editor) => {
+            editor.dispatch("FORMAT_REMOVE_FORMAT");
+            editor.dispatch("HISTORY_UNDO");
+        },
+        contentAfter:
+            '<p><strong><em><u><s><font style="color: rgb(0, 255, 0); background: rgb(0, 0, 255);">[sdsdsdsds]</font></s></u></em></strong></p>',
+    });
+});
 describe("Toolbar", () => {
     async function removeFormatClick() {
         await waitFor(".o-we-toolbar");


### PR DESCRIPTION
Issue:
======
The content isn't back to it's original state when we undo remove format when we have more than one format type applied.

Steps to reproduce the issue:
=============================
- Add italic + bold -> remove format -> undo -> doesn't have the same original state
- Add some colors -> remove format -> undo -> the color isn't applied anymore

Origin of the issue:
====================
- The first issue is because we call `formatSelection` which calls ADD_STEP at each removed format.
- The second issue is because we don't have any ADD_STEP after we remove the colors.