### PR TITLE
[FIX] html_editor: properly translate table menu text

### DIFF
--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -34,31 +34,30 @@ export class TableMenu extends Component {
     }
 
     colItems() {
-        const beforeLabel = this.props.direction === "ltr" ? "left" : "right";
-        const afterLabel = this.props.direction === "ltr" ? "right" : "left";
+        const ltr = this.props.direction === "ltr";
         return [
             !this.isFirst && {
                 name: "move_left",
                 icon: "fa-chevron-left disabled",
-                text: _t(`Move ${beforeLabel}`),
+                text: ltr ? _t("Move left") : _t("Move right"),
                 action: this.moveColumn.bind(this, "left"),
             },
             !this.isLast && {
                 name: "move_right",
                 icon: "fa-chevron-right",
-                text: _t(`Move ${afterLabel}`),
+                text: ltr ? _t("Move right") : _t("Move left"),
                 action: this.moveColumn.bind(this, "right"),
             },
             {
                 name: "insert_left",
                 icon: "fa-plus",
-                text: _t(`Insert ${beforeLabel}`),
+                text: ltr ? _t("Insert left") : _t("Insert right"),
                 action: this.insertColumn.bind(this, "before"),
             },
             {
                 name: "insert_right",
                 icon: "fa-plus",
-                text: _t(`Insert ${afterLabel}`),
+                text: ltr ? _t("Insert right") : _t("Insert left"),
                 action: this.insertColumn.bind(this, "after"),
             },
             {


### PR DESCRIPTION
Before this commit, the code would translate some strings using a template string, which does not work.