### PR TITLE
[FIX] html_editor: remove correctTripleClick in delete_plugin

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -9,7 +9,6 @@ import {
     isShrunkBlock,
     isTangible,
     isUnbreakable,
-    isVisibleTextNode,
     isWhitespace,
     isZWS,
     nextLeaf,
@@ -129,7 +128,6 @@ export class DeletePlugin extends Plugin {
         }
 
         let range = this.adjustRange(selection, [
-            this.correctTripleClick,
             this.expandRangeToIncludeNonEditables,
             this.includeEndOrStartBlock,
             this.fullyIncludeLinks,
@@ -906,33 +904,6 @@ export class DeletePlugin extends Plugin {
             startContainer.textContent[startOffset - 1] === "\u200B"
         ) {
             range.setStart(startContainer, startOffset - 1);
-        }
-        return range;
-    }
-
-    // @phoenix @todo: triple click correction is now done by the selection
-    // plugin, and this is no longer necessary. Adapt tests that rely on it and
-    // remove this method.
-    /**
-     * @param {Range} range
-     * @returns {Range}
-     */
-    correctTripleClick(range) {
-        const { startContainer, startOffset, endContainer, endOffset } = range;
-        const endLeaf = firstLeaf(endContainer);
-        const beforeEnd = endLeaf.previousSibling;
-        if (
-            !endOffset &&
-            (startContainer !== endContainer || startOffset !== endOffset) &&
-            (!beforeEnd ||
-                (beforeEnd.nodeType === Node.TEXT_NODE &&
-                    !isVisibleTextNode(beforeEnd) &&
-                    !isZWS(beforeEnd)))
-        ) {
-            const previous = previousLeaf(endLeaf, this.editable, true);
-            if (previous && closestElement(previous).isContentEditable) {
-                range.setEnd(previous, nodeSize(previous));
-            }
         }
         return range;
     }

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -1789,6 +1789,24 @@ describe("Selection not collapsed", () => {
         });
     });
 
+    test("should do nothing with selection before table and start of middle cell", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `[<table><tbody>
+                    <tr><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td>]<br></td></tr>
+                </tbody></table>`
+            ),
+            stepFunction: deleteBackward,
+            contentAfter: unformat(
+                `<table><tbody>
+                    <tr><td>[]<br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td></tr>
+                </tbody></table>`
+            ),
+        });
+    });
+
     test("should empty an inline unremovable but remain in it", async () => {
         await testEditor({
             contentBefore: '<p>ab<b class="oe_unremovable">[cd]</b>ef</p>',


### PR DESCRIPTION
Issue:
======
Traceback raised when delete_backward

Steps to reproduce the issue:
=============================
- Put the cursor in a cell in the middle of the table
- Press shift and arrow left/up until you have the selection outside of the table
- Delete backward

Origin of the issue:
====================
`correctTripleClick` moves the endContainer to be  the `br` element in the cell just before where we put the cursor. Since we remove fake brs in deleteRange and then we removeNodes, we have the endContainer is not connected anymore and raises an error when we want to get it's `childNodeIndex`.

It's safe to remove the function `correctTripleClick` since the
correction is now handled by `selection_plugin`.