### PR TITLE
[IMP] point_of_sale: color +/-, decimal, cancel/delete buttons

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -113,6 +113,12 @@ export class ProductScreen extends Component {
     }
 
     getNumpadButtons() {
+        const colorClassMap = {
+            [this.env.services.localization.decimalPoint]: "o_colorlist_item_color_transparent_6",
+            Backspace: "o_colorlist_item_color_transparent_1",
+            "-": "o_colorlist_item_color_transparent_3",
+        };
+
         return getButtons(DEFAULT_LAST_ROW, [
             { value: "quantity", text: _t("Qty") },
             { value: "discount", text: _t("% "), disabled: !this.pos.config.manual_discount },
@@ -124,7 +130,10 @@ export class ProductScreen extends Component {
             BACKSPACE,
         ]).map((button) => ({
             ...button,
-            class: this.pos.numpadMode === button.value ? "active" : "",
+            class: `
+                ${colorClassMap[button.value] || ""} 
+                ${this.pos.numpadMode === button.value ? "active" : ""}
+            `,
         }));
     }
     onNumpadClick(buttonValue) {


### PR DESCRIPTION
Color the +/-, decimal point (.), and cancel/delete buttons, similar to those on the payment page.

### Before
<img width="508" alt="Screenshot 2024-07-17 at 3 47 08 PM" src="https://github.com/user-attachments/assets/60be392c-97cb-460a-83f5-c99ff3a26f23">

### After
<img width="508" alt="Screenshot 2024-07-17 at 3 46 00 PM" src="https://github.com/user-attachments/assets/a41adaea-24ca-49d3-9b50-42ee0346cfed">

task-4045935