### PR TITLE
[IMP] point_of_sale, pos_restaurant: show customer/actions buttons when cart is empty on mobile

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
@@ -1,34 +1,26 @@
 import { usePos } from "@point_of_sale/app/store/pos_hook";
-import { Component, useState } from "@odoo/owl";
+import { Component, useState, useEffect } from "@odoo/owl";
 import { SelectPartnerButton } from "@point_of_sale/app/screens/product_screen/control_buttons/select_partner_button/select_partner_button";
 import { useService } from "@web/core/utils/hooks";
+import { BackButton } from "@point_of_sale/app/screens/product_screen/action_pad/back_button/back_button";
 
 export class ActionpadWidget extends Component {
     static template = "point_of_sale.ActionpadWidget";
-    static components = { SelectPartnerButton };
+    static components = { SelectPartnerButton, BackButton };
     static props = {
         partner: { type: [Object, { value: null }], optional: true },
-        actionName: Object,
-        actionType: String,
-        isActionButtonHighlighted: { type: Boolean, optional: true },
         onClickMore: { type: Function, optional: true },
-        actionToTrigger: { type: Function, optional: true },
+        actionName: String,
+        actionToTrigger: Function,
+        showActionButton: { type: Boolean, optional: true },
+        slots: { type: Object, optional: true },
     };
     static defaultProps = {
-        actionToTrigger: null,
-        isActionButtonHighlighted: true,
+        showActionButton: true,
     };
 
     setup() {
         this.pos = usePos();
         this.ui = useState(useService("ui"));
-    }
-
-    get isLongName() {
-        return this.props.partner && this.props.partner.name.length > 10;
-    }
-
-    getMainButtonClasses() {
-        return "button btn btn-lg d-flex align-items-center w-50";
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -4,22 +4,18 @@
     <t t-name="point_of_sale.ActionpadWidget">
         <div class="actionpad d-flex flex-column gap-2">
             <div t-if="ui.isSmall" class="d-flex gap-2">
+                <BackButton t-if="!props.showActionButton and pos.showBackButton()" onClick="() => pos.onClickBackButton()"/>
                 <SelectPartnerButton partner="props.partner"/>
                 <button class="button mobile-more-button btn btn-light btn-lg flex-fill" t-if="props.onClickMore" t-on-click="props.onClickMore">
                     <span>Actions</span>
                 </button>
             </div>
-            <div class="d-flex flex-row-reverse gap-2">
-                <button class="pay validation pay-order-button justify-content-center lh-lg flex-fill py-3"
-                    t-attf-class="{{getMainButtonClasses()}}"
-                    t-att-class="{'btn-primary py-3': !props.isActionButtonHighlighted, 'btn-primary': props.isActionButtonHighlighted, 'with-more-button': props.onClickMore and ui.isSmall}"
-                    t-on-click="props.actionToTrigger ? this.props.actionToTrigger : () => pos.pay()">
-                    <t t-esc="props.actionName" />
-                </button>
-                <button t-if="pos.showBackButton()" class="back-button btn btn-light btn-lg lh-lg" t-on-click="
-                () => pos.onClickBackButton()">
-                    <i class="oi oi-chevron-left fa-fw" role="img" aria-label="Go Back" title="Go Back" />
-                </button>
+            <div t-if="props.showActionButton" class="d-flex gap-2">
+                <BackButton t-if="pos.showBackButton()" onClick="() => pos.onClickBackButton()"/>
+                <button class="pay pay-order-button validation button btn btn-primary btn-lg py-3 d-flex align-items-center justify-content-center flex-fill"
+                    t-on-click="props.actionToTrigger"
+                    t-esc="props.actionName"
+                />
             </div>
         </div>
     </t>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/back_button/back_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/back_button/back_button.js
@@ -1,0 +1,8 @@
+import { Component } from "@odoo/owl";
+
+export class BackButton extends Component {
+    static template = "point_of_sale.BackButton";
+    static props = {
+        onClick: { type: Function },
+    };
+}

--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/back_button/back_button.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/back_button/back_button.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="point_of_sale.BackButton">
+        <button class="back-button btn btn-light btn-lg lh-lg" t-on-click="props.onClick">
+            <i class="oi oi-chevron-left fa-fw" role="img" aria-label="Go Back" title="Go Back" />
+        </button>
+    </t>
+
+</templates>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -41,7 +41,6 @@ export class ProductScreen extends Component {
         ProductCard,
         CameraBarcodeScanner,
     };
-    static numpadActionName = _t("Payment");
     static props = {};
 
     setup() {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
@@ -27,3 +27,8 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
 }
+
+
+.pay-order-button {
+    min-height: 70px;
+}

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -10,14 +10,14 @@
                         <ControlButtons t-if="!ui.isSmall" onClickMore.bind="displayAllControlPopup"/>
                     </div>
                     <div class="subpads d-flex flex-column gap-2">
-                        <t t-if="currentOrder.lines.length != 0">
-                            <Numpad t-if="pos.get_order().uiState.selected_orderline_uuid" class="'d-grid m-n1'" buttons="getNumpadButtons()" onClick.bind="onNumpadClick"/>
-                            <ActionpadWidget
-                                partner="currentOrder?.get_partner()"
-                                actionName="constructor.numpadActionName"
-                                actionType="'payment'"
-                                onClickMore.bind="displayAllControlPopup" />
-                        </t>
+                        <Numpad t-if="!currentOrder.is_empty() and pos.get_order().uiState.selected_orderline_uuid" class="'d-grid m-n1'" buttons="getNumpadButtons()" onClick.bind="onNumpadClick"/>
+                        <ActionpadWidget 
+                            partner="currentOrder?.get_partner()" 
+                            onClickMore.bind="displayAllControlPopup"
+                            actionName="'Payment'"
+                            actionToTrigger="() => pos.pay()"
+                            showActionButton="!currentOrder.is_empty()"
+                        />
                     </div>
                 </div>
             </div>

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -5,6 +5,7 @@ import { parseFloat } from "@web/views/fields/parsers";
 import { _t } from "@web/core/l10n/translation";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { ActionpadWidget } from "@point_of_sale/app/screens/product_screen/action_pad/action_pad";
+import { BackButton } from "@point_of_sale/app/screens/product_screen/action_pad/back_button/back_button";
 import { InvoiceButton } from "@point_of_sale/app/screens/ticket_screen/invoice_button/invoice_button";
 import { Orderline } from "@point_of_sale/app/generic_components/orderline/orderline";
 import { OrderWidget } from "@point_of_sale/app/generic_components/order_widget/order_widget";
@@ -39,6 +40,7 @@ export class TicketScreen extends Component {
         ReprintReceiptButton,
         SearchBar,
         Numpad,
+        BackButton
     };
     static props = {
         destinationOrder: { type: Object, optional: true },
@@ -54,7 +56,6 @@ export class TicketScreen extends Component {
         reuseSavedUIState: false,
         ui: {},
     };
-    static numpadActionName = _t("Refund");
     static searchPlaceholder = _t("Search Orders...");
 
     setup() {

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -162,15 +162,15 @@
                                 </div>
                                 <div class="subpads d-flex flex-column">
                                     <Numpad class="'pb-2'" buttons="getNumpadButtons()"/>
-                                    <ActionpadWidget
+                                    <ActionpadWidget 
                                         partner="getSelectedOrder()?.get_partner()"
-                                        actionName="constructor.numpadActionName"
-                                        actionType="'refund'"
+                                        actionName="'Refund'"
                                         actionToTrigger.bind="onDoRefund"
-                                        isActionButtonHighlighted="getHasItemsToRefund()" />
+                                    />
                                 </div>
                             </t>
-                            <div t-else="" class="pads border-top" >
+                            <div t-else="" class="pads border-top d-flex gap-2" >
+                                <BackButton onClick="() => pos.onClickBackButton()"/>
                                 <button class="button validation load-order-button w-100 btn btn-lg btn-primary py-3" t-on-click="() => this._setOrder(_selectedSyncedOrder)">
                                     <span class="d-block">Load Order</span>
                                 </button>

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1563,14 +1563,19 @@ export class PosStore extends Reactive {
     }
 
     showBackButton() {
-        const screenWoBackBtnMobile = [ProductScreen, TicketScreen];
         return (
-            (this.ui.isSmall && !screenWoBackBtnMobile.includes(this.mainScreen.component)) ||
+            (this.ui.isSmall && this.mainScreen.component !== ProductScreen) ||
             (this.mobile_pane === "left" && this.mainScreen.component === ProductScreen)
         );
     }
     async onClickBackButton() {
-        if (
+        if (this.mainScreen.component === TicketScreen) {
+            if (this.ticket_screen_mobile_pane == "left") {
+                this.closeScreen();
+            } else {
+                this.ticket_screen_mobile_pane = "left";
+            }
+        } else if (
             this.mobile_pane == "left" ||
             this.mainScreen.component === PaymentScreen
         ) {

--- a/addons/point_of_sale/static/tests/tours/utils/common.js
+++ b/addons/point_of_sale/static/tests/tours/utils/common.js
@@ -1,7 +1,7 @@
 export function back() {
     return {
         content: "go back to the products",
-        trigger: ".pos-topheader .back-button",
+        trigger: ".actionpad .back-button",
         run: "click",
     };
 }

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
@@ -1,6 +1,7 @@
 import { patch } from "@web/core/utils/patch";
 import { ActionpadWidget } from "@point_of_sale/app/screens/product_screen/action_pad/action_pad";
 import { useState } from "@odoo/owl";
+import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
 /**
  * @props partner
  */
@@ -13,7 +14,7 @@ patch(ActionpadWidget.prototype, {
         });
     },
     get swapButton() {
-        return this.props.actionType === "payment" && this.pos.config.module_pos_restaurant;
+        return this.pos.config.module_pos_restaurant && this.pos.mainScreen.component !== TicketScreen;
     },
     get currentOrder() {
         return this.pos.get_order();

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.xml
@@ -1,48 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.ActionpadWidget" t-inherit="point_of_sale.ActionpadWidget" t-inherit-mode="extension">
+        <xpath expr="//button[hasclass('validation')]" position="attributes">
+            <attribute name="t-if">!this.swapButton</attribute>
+        </xpath>
         <!-- Replace the payment button by the order button -->
         <xpath expr="//button[hasclass('validation')]" position="after">
-            <button
-                t-if="this.swapButton"
-                t-attf-class="submit-order h-100 {{getMainButtonClasses()}} position-relative px-3"
-                t-att-class="swapButtonClasses"
-                t-on-click="submitOrder">
-                <div t-if="this.uiState.clicked and displayCategoryCount.length" class="h-100 w-100 position-absolute top-0 start-0 d-flex align-items-center justify-content-center" style="backdrop-filter: blur(7px);">
-                    <img src="/web/static/img/spin.svg" style="height:35px; width:35px" alt="Loading..."/>
-                </div>
-                <t t-if="!(displayCategoryCount.length > 2)">Order</t>
-                <div t-attf-class="{{ !(displayCategoryCount.length > 2) ? 'd-flex flex-column align-items-end gap-1' : 'row row-cols-2 g-1 gx-2' }} {{ isCategoryCountOverflow ? 'mt-n3' : ''}}">
-                    <t t-if="displayCategoryCount.length">
-                        <t t-foreach="displayCategoryCount" t-as="categoryCountLine"  t-key="categoryCountLine_index">
-                            <div class="d-flex align-items-center justify-content-between small" t-att-class="{ 'gap-2' : !(displayCategoryCount.length > 2) }">
-                                <label class="text-truncate"><t t-esc="categoryCountLine.name"/></label>
-                                <label class="rounded px-2 py-0" style="background-color:rgba(0, 0, 0, 0.3);"><t t-esc="categoryCountLine.count"/></label>
-                            </div>
-                        </t>
-                    </t>
-                    <t t-if="isCategoryCountOverflow">
-                        <div class="position-absolute bottom-0 start-50 translate-middle-x">...</div>
-                    </t>
-                </div>
-            </button>
-        </xpath>
-        <xpath expr="//button[hasclass('validation')]" position="attributes">
-            <attribute name="t-if">!this.swapButton</attribute>
-        </xpath>
-
-        <!-- Replace the customer button by the payment button, the customer button will be added in the control buttons -->
-        <xpath expr="//button[hasclass('validation')]" position="before">
-            <button t-if="this.swapButton"
-                t-on-click="() => pos.pay()" 
-                class="button pay-order-button btn btn-lg w-50"
-                t-attf-class="{{ this.highlightPay ? 'highlight btn-primary' : 'btn-light' }}" 
+            <div t-if="this.swapButton" class="d-flex gap-2 flex-fill">
+                <button
+                    class="submit-order h-100 button btn btn-lg d-flex align-items-center w-50 position-relative px-3"
+                    t-att-class="swapButtonClasses"
+                    t-on-click="submitOrder"
                 >
-                Payment
-            </button>
-        </xpath>
-        <xpath expr="//button[hasclass('validation')]" position="attributes">
-            <attribute name="t-if">!this.swapButton</attribute>
+                    <div t-if="this.uiState.clicked and displayCategoryCount.length" class="h-100 w-100 position-absolute top-0 start-0 d-flex align-items-center justify-content-center" style="backdrop-filter: blur(7px);">
+                        <img src="/web/static/img/spin.svg" style="height:35px; width:35px" alt="Loading..."/>
+                    </div>
+                    <t t-if="!(displayCategoryCount.length > 2)">Order</t>
+                    <div t-attf-class="{{ !(displayCategoryCount.length > 2) ? 'd-flex flex-column align-items-end gap-1' : 'row row-cols-2 g-1 gx-2' }} {{ isCategoryCountOverflow ? 'mt-n3' : ''}}">
+                        <t t-if="displayCategoryCount.length">
+                            <t t-foreach="displayCategoryCount" t-as="categoryCountLine"  t-key="categoryCountLine_index">
+                                <div class="d-flex align-items-center justify-content-between small" t-att-class="{ 'gap-2' : !(displayCategoryCount.length > 2) }">
+                                    <label class="text-truncate"><t t-esc="categoryCountLine.name"/></label>
+                                    <label class="rounded px-2 py-0" style="background-color:rgba(0, 0, 0, 0.3);"><t t-esc="categoryCountLine.count"/></label>
+                                </div>
+                            </t>
+                        </t>
+                        <t t-if="isCategoryCountOverflow">
+                            <div class="position-absolute bottom-0 start-50 translate-middle-x">...</div>
+                        </t>
+                    </div>
+                </button>
+                <button t-on-click="() => pos.pay()" 
+                    class="button pay-order-button btn btn-lg w-50"
+                    t-attf-class="{{ this.highlightPay ? 'highlight btn-primary' : 'btn-light' }}" 
+                >
+                    Payment
+                </button>
+            </div>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
### in mobile view:
- show customer/actions button
- show the back button when not available in the screen at the footer

### Screenshots
- show the back button next to the payment button when the cart is not empty
<img width="412" alt="Screenshot 2024-08-06 at 11 05 14 AM" src="https://github.com/user-attachments/assets/fd33a73b-160f-48c4-beee-b3ee10dfbc56">

- show the back button next to the control buttons (Customer/Actions) when the cart is empty
<img width="412" alt="Screenshot 2024-08-06 at 11 07 24 AM" src="https://github.com/user-attachments/assets/a0f2936f-b54d-4b5c-a8f0-3a0f5c24ed0c">

- show the back button next to the load order button
<img width="412" alt="Screenshot 2024-08-06 at 11 08 20 AM" src="https://github.com/user-attachments/assets/9a03b85b-4a62-433a-b455-e7107ec28836">

- show the back button next to the refund button
<img width="412" alt="Screenshot 2024-08-06 at 11 59 13 AM" src="https://github.com/user-attachments/assets/59d9edf2-48b0-4862-9429-1443aab50605">