### PR TITLE
[FIX] revamp ui: mobile: edit buttons in one line

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -89,6 +89,7 @@ export class FloorScreen extends Component {
     setup() {
         this.pos = usePos();
         this.dialog = useService("dialog");
+        this.ui = useService("ui");
         const floor = this.pos.currentFloor;
         this.state = useState({
             selectedFloorId: floor ? floor.id : null,

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -20,7 +20,7 @@
                     </button>
                 </div>
                 <!-- Right Side Div -->
-                <div t-if="pos.isEditMode" class="edit-buttons d-flex flex-wrap gap-2 m-2 overflow-x-auto">
+                <div t-if="pos.isEditMode" class="edit-buttons d-flex gap-2 m-2 overflow-x-auto" t-att-class="{'mx-auto': ui.isSmall}">
                     <div class="d-flex gap-1 p-1 rounded-3 bg-200">
                         <t t-if="hasSelectedTable">
                             <span class="mx-2 align-self-center text-uppercase smaller fw-bolder">Table <t t-esc="firstSelectedTable.table_number" /></span>
@@ -73,12 +73,13 @@
                             <i class="fa fa-trash fa-fw" role="img" aria-label="Delete" title="Delete"/>
                         </button>
                     </div>
-                    <button t-attf-class="btn btn-outline-secondary btn-lg d-flex align-items-center lh-lg " t-on-click.stop="createTable">
-                        <i class="fa fa-plus-circle me-2" role="img" aria-label="Add Table" title="Add Table"/>
-                        Table
+                    <button t-attf-class="btn btn-outline-secondary btn-lg d-flex align-items-center justify-content-center gap-2 lh-lg " t-on-click.stop="createTable">
+                        <i class="fa fa-plus-circle" role="img" aria-label="Add Table" title="Add Table"/>
+                        <t t-if="!ui.isSmall">Table</t>
                     </button>
                     <button t-attf-class="btn btn-primary btn-lg" t-on-click.stop="closeEditMode">
-                        Save
+                        <t t-if="!ui.isSmall">Save</t>
+                        <i t-else="" class="fa fa-floppy-o" role="img" aria-label="Save" title="Save"/>
                     </button>
                 </div>
                 <div t-if="pos.orderToTransferUuid" class="d-flex align-items-center justify-content-between px-3 gap-2 border-bottom bg-view overflow-x-auto">


### PR DESCRIPTION
With table selected:

<img width="400" alt="Screenshot 2024-08-06 at 16 54 31" src="https://github.com/user-attachments/assets/f524a747-219a-4db6-92d5-e5461b9b1e59">

Without table selected:

<img width="401" alt="Screenshot 2024-08-06 at 16 54 37" src="https://github.com/user-attachments/assets/55bcf454-c033-4e4d-b0b3-862951914343">
