### PR TITLE
[IMP] knowledge: mount embedded component in the HtmlViewer

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -5,6 +5,7 @@ import {
     EMBEDDED_COMPONENT_PLUGINS,
 } from "@html_editor/plugin_sets";
 import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
+import { READONLY_MAIN_EMBEDDINGS } from "@html_editor/readonly/embedded_components/embedding_sets";
 import { Wysiwyg } from "@html_editor/wysiwyg";
 import { Component, useRef, useState } from "@odoo/owl";
 import { localization } from "@web/core/l10n/localization";
@@ -72,9 +73,7 @@ export class HtmlField extends Component {
         this.state = useState({
             key: 0,
             showCodeView: false,
-            containsComplexHTML: computeContainsComplexHTML(
-                this.props.record.data[this.props.name]
-            ),
+            containsComplexHTML: computeContainsComplexHTML(this.value),
         });
         this.lastValue = this.props.record.data[this.props.name].toString();
         useRecordObserver((record) => {
@@ -175,7 +174,7 @@ export class HtmlField extends Component {
 
     getConfig() {
         const config = {
-            content: this.props.record.data[this.props.name],
+            content: this.value,
             Plugins: [
                 ...MAIN_PLUGINS,
                 ...(this.props.isCollaborative ? COLLABORATION_PLUGINS : []),
@@ -234,6 +233,18 @@ export class HtmlField extends Component {
             (sanitize_tags || (sanitize_tags === undefined && sanitize))
         ) {
             config.disableVideo = true; // Tag-sanitized fields remove videos.
+        }
+        return config;
+    }
+
+    getReadonlyConfig() {
+        const config = {
+            value: this.value,
+            cssAssetId: this.props.cssReadonlyAssetId,
+            hasFullHtml: this.sandboxedPreview,
+        };
+        if (this.props.embeddedComponents) {
+            config.embeddedComponents = READONLY_MAIN_EMBEDDINGS;
         }
         return config;
     }

--- a/addons/html_editor/static/src/fields/html_field.xml
+++ b/addons/html_editor/static/src/fields/html_field.xml
@@ -2,9 +2,7 @@
     <t t-name="html_editor.HtmlField">
         <t t-if="this.displayReadonly">
             <HtmlViewer
-                value="this.value"
-                cssAssetId="props.cssReadonlyAssetId"
-                hasFullHtml="sandboxedPreview"/>
+                config="getReadonlyConfig()"/>
         </t>
         <div t-else="" class="h-100" t-att-class="{'o_show_codeview': state.showCodeView, 'o_field_translate': isTranslatable}">
             <t t-if="state.showCodeView">

--- a/addons/html_editor/static/src/fields/html_viewer.xml
+++ b/addons/html_editor/static/src/fields/html_viewer.xml
@@ -3,10 +3,10 @@
         <t t-if="this.showIframe">
             <iframe t-ref="iframe"
                 t-att-class="{'d-none': !this.state.iframeVisible, 'o_readonly': true}"
-                t-att-sandbox="props.hasFullHtml ? 'allow-same-origin allow-popups allow-popups-to-escape-sandbox' : false"/>
+                t-att-sandbox="props.config.hasFullHtml ? 'allow-same-origin allow-popups allow-popups-to-escape-sandbox' : false"/>
         </t>
         <t t-else="">
-            <div t-ref="readonlyContent"  class="o_readonly" t-out="props.value" />
+            <div t-ref="readonlyContent"  class="o_readonly" t-out="props.config.value" />
         </t>
     </t>
 </templates>

--- a/addons/html_editor/static/src/readonly/embedded_components/embedding_sets.js
+++ b/addons/html_editor/static/src/readonly/embedded_components/embedding_sets.js
@@ -1,0 +1,1 @@
+export const READONLY_MAIN_EMBEDDINGS = [];


### PR DESCRIPTION
Embedded components such as a table of contents should also be mounted to be used in readonly. This commit extracts the minimal mount logic from the embedded component plugin and put it in the HtmlViewer in order to do so.