### PR TITLE
[FIX] pos_restaurant: mobile: added item notification

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
@@ -20,13 +20,16 @@ patch(ProductScreen.prototype, {
     get selectedOrderlineQuantity() {
         const order = this.pos.get_order();
         const orderline = order.get_selected_orderline();
-        if (this.pos.config.module_pos_restaurant && this.pos.orderPreparationCategories.size) {
-            let orderline_name = orderline.product_id.display_name;
-            if (orderline.description) {
-                orderline_name += " (" + orderline.description + ")";
-            }
+        const isForPreparation = orderline.product_id.pos_categ_ids
+            .map((categ) => categ.id)
+            .some((id) => this.pos.orderPreparationCategories.has(id));
+        if (
+            this.pos.config.module_pos_restaurant &&
+            this.pos.orderPreparationCategories.size &&
+            isForPreparation
+        ) {
             const changes = Object.values(this.pos.getOrderChanges().orderlines).find(
-                (change) => change.name == orderline_name
+                (change) => change.name == orderline.get_full_product_name()
             );
             return changes ? changes.quantity : false;
         }


### PR DESCRIPTION
When adding a "configured" product or a product that is not for preparation, the notification is showing the following text: "false Bacon Burger (Sweet potato fries) ..." instead of properly showing the quantity+name+price of the added item.

Steps to reproduce:

1. Start a session for the restaurant config in mobile view.
2. Add a Bacon Burger, configure it.
3. ISSUE: "false Bacon Burger (Sweet potato fries) ..." is shown.
4. Add a Coca-Cola (not for preparation).
5. ISSUE: "false Coca-Cola ..." is shown.

For the first issue, the configured product is not properly found in the list of changes. We should use the return of `get_full_product_name` because it's the one used as the name of the preparation change for that product.

For the second issue, we should call super for product that is not for preparation to use the default calculation.