### PR TITLE
[IMP] mail: add a static method to inline editor content

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/html_mail_field.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/html_mail_field.js
@@ -6,14 +6,23 @@ import { ColumnPlugin } from "@html_editor/main/column_plugin";
 const cssRulesByElement = new WeakMap();
 
 export class HtmlMailField extends HtmlField {
-    async getEditorContent() {
-        if (!cssRulesByElement.has(this.editor.editable)) {
-            cssRulesByElement.set(this.editor.editable, getCSSRules(this.editor.document));
+    /**
+     * @param {WeakMap} cssRulesByElement
+     * @param {Editor} editor
+     * @param {HTMLElement} el
+     */
+    static async getInlinedEditorContent(cssRulesByElement, editor, el) {
+        if (!cssRulesByElement.has(editor.editable)) {
+            cssRulesByElement.set(editor.editable, getCSSRules(editor.document));
         }
-        const cssRules = cssRulesByElement.get(this.editor.editable);
-        const el = await super.getEditorContent();
+        const cssRules = cssRulesByElement.get(editor.editable);
         el.classList.remove("odoo-editor-editable");
         await toInline(el, cssRules);
+    }
+
+    async getEditorContent() {
+        const el = await super.getEditorContent();
+        await HtmlMailField.getInlinedEditorContent(cssRulesByElement, this.editor, el);
         return el;
     }
 


### PR DESCRIPTION
This commit updates the HtmlMailField Component from the mail addon:

We put the part responsible for converting the editor content to an Html element compatible with email clients (inline CSS style) into a static method.
Thus, the same code can be reused in the member invite component of the documents permission panel.

task-4014624