### PR TITLE
[FIX] website[_*]: fix unit tests mocked requests for Firefox

### DIFF
--- a/addons/website/static/tests/interactions/listing_layout.test.js
+++ b/addons/website/static/tests/interactions/listing_layout.test.js
@@ -39,8 +39,7 @@ test("listing_layout toggle to list mode", async () => {
         </div>
     `);
     MockServer.current.onRoute(["/website/save_session_layout_mode"], async (request) => {
-        const jsonResponse = await request.body.getReader().read();
-        const jsonParams = JSON.parse(new TextDecoder("utf-8").decode(jsonResponse.value)).params;
+        const jsonParams = JSON.parse(new TextDecoder("utf-8").decode(await request.arrayBuffer())).params;
         expect.step("rpc");
         expect(jsonParams.layout_mode).toBe("list");
         expect(jsonParams.view_id).toBe("123");
@@ -83,8 +82,7 @@ test("listing_layout toggle to grid mode", async () => {
         </div>
     `);
     MockServer.current.onRoute(["/website/save_session_layout_mode"], async (request) => {
-        const jsonResponse = await request.body.getReader().read();
-        const jsonParams = JSON.parse(new TextDecoder("utf-8").decode(jsonResponse.value)).params;
+        const jsonParams = JSON.parse(new TextDecoder("utf-8").decode(await request.arrayBuffer())).params;
         expect.step("rpc");
         expect(jsonParams.layout_mode).toBe("grid");
         expect(jsonParams.view_id).toBe("123");

--- a/addons/website/static/tests/interactions/snippets/dynamic_snippet.test.js
+++ b/addons/website/static/tests/interactions/snippets/dynamic_snippet.test.js
@@ -27,13 +27,11 @@ describe.current.tags("interaction_dev");
 
 test("dynamic snippet loads items and displays them through template", async () => {
     onRpc("/website/snippet/filters", async (args) => {
-        for await (const chunk of args.body) {
-            const json = JSON.parse(new TextDecoder().decode(chunk));
-            expect(json.params.filter_id).toBe(1);
-            expect(json.params.template_key).toBe("website.dynamic_filter_template_test_item");
-            expect(json.params.limit).toBe(16);
-            expect(json.params.search_domain).toEqual([]);
-        }
+        const json = JSON.parse(new TextDecoder().decode(await args.arrayBuffer()));
+        expect(json.params.filter_id).toBe(1);
+        expect(json.params.template_key).toBe("website.dynamic_filter_template_test_item");
+        expect(json.params.limit).toBe(16);
+        expect(json.params.search_domain).toEqual([]);
         return [
             `<div class="s_test_dynamic_item" data-test-param="test">Some test record </div>`,
             `<div class="s_test_dynamic_item" data-test-param="test2">Another test record</div>`,

--- a/addons/website/static/tests/interactions/snippets/dynamic_snippet_carousel.test.js
+++ b/addons/website/static/tests/interactions/snippets/dynamic_snippet_carousel.test.js
@@ -55,13 +55,11 @@ const testTemplate = `
 
 test.tags("desktop")("dynamic snippet carousel loads items and displays them through template (desktop)", async () => {
     onRpc("/website/snippet/filters", async (args) => {
-        for await (const chunk of args.body) {
-            const json = JSON.parse(new TextDecoder().decode(chunk));
-            expect(json.params.filter_id).toBe(1);
-            expect(json.params.template_key).toBe("website.dynamic_filter_template_test_item");
-            expect(json.params.limit).toBe(16);
-            expect(json.params.search_domain).toEqual([]);
-        }
+        const json = JSON.parse(new TextDecoder().decode(await args.arrayBuffer()));
+        expect(json.params.filter_id).toBe(1);
+        expect(json.params.template_key).toBe("website.dynamic_filter_template_test_item");
+        expect(json.params.limit).toBe(16);
+        expect(json.params.search_domain).toEqual([]);
         return [`<div class="s_test_dynamic_carousel_item" data-test-param="test1">Test Record 1</div>`,
             `<div class="s_test_dynamic_carousel_item" data-test-param="test2">Test Record 2</div>`,
             `<div class="s_test_dynamic_carousel_item" data-test-param="test3">Test Record 3</div>`,
@@ -102,13 +100,11 @@ test.tags("desktop")("dynamic snippet carousel loads items and displays them thr
 
 test.tags("mobile")("dynamic snippet carousel loads items and displays them through template (mobile)", async () => {
     onRpc("/website/snippet/filters", async (args) => {
-        for await (const chunk of args.body) {
-            const json = JSON.parse(new TextDecoder().decode(chunk));
-            expect(json.params.filter_id).toBe(1);
-            expect(json.params.template_key).toBe("website.dynamic_filter_template_test_item");
-            expect(json.params.limit).toBe(16);
-            expect(json.params.search_domain).toEqual([]);
-        }
+        const json = JSON.parse(new TextDecoder().decode(await args.arrayBuffer()));
+        expect(json.params.filter_id).toBe(1);
+        expect(json.params.template_key).toBe("website.dynamic_filter_template_test_item");
+        expect(json.params.limit).toBe(16);
+        expect(json.params.search_domain).toEqual([]);
         return [`<div class="s_test_dynamic_carousel_item" data-test-param="test1">Test Record 1</div>`,
             `<div class="s_test_dynamic_carousel_item" data-test-param="test2">Test Record 2</div>`,
             `<div class="s_test_dynamic_carousel_item" data-test-param="test3">Test Record 3</div>`,

--- a/addons/website/static/tests/interactions/snippets/search_bar.test.js
+++ b/addons/website/static/tests/interactions/snippets/search_bar.test.js
@@ -35,17 +35,15 @@ const searchTemplate = `
 
 function supportAutocomplete() {
     onRpc("/website/snippet/autocomplete", async (args) => {
-        for await (const chunk of args.body) {
-            const json = JSON.parse(new TextDecoder().decode(chunk));
-            expect(json.params.search_type).toBe("test");
-            expect(json.params.term).toBe("xyz");
-            expect(json.params.order).toBe("test desc");
-            expect(json.params.limit).toBe(3);
-            expect(json.params.options.displayImage).toBe("false");
-            expect(json.params.options.displayDescription).toBe("false");
-            expect(json.params.options.displayExtraLink).toBe("true");
-            expect(json.params.options.displayDetail).toBe("false");
-        }
+        const json = JSON.parse(new TextDecoder().decode(await args.arrayBuffer()));
+        expect(json.params.search_type).toBe("test");
+        expect(json.params.term).toBe("xyz");
+        expect(json.params.order).toBe("test desc");
+        expect(json.params.limit).toBe(3);
+        expect(json.params.options.displayImage).toBe("false");
+        expect(json.params.options.displayDescription).toBe("false");
+        expect(json.params.options.displayExtraLink).toBe("true");
+        expect(json.params.options.displayDetail).toBe("false");
         return {
             "results": [
                 {

--- a/addons/website_blog/static/tests/interactions/snippets/blog_posts.test.js
+++ b/addons/website_blog/static/tests/interactions/snippets/blog_posts.test.js
@@ -21,13 +21,11 @@ describe.current.tags("interaction_dev");
 
 test("dynamic snippet blog posts loads items and displays them through template", async () => {
     onRpc("/website/snippet/filters", async (args) => {
-        for await (const chunk of args.body) {
-            const json = JSON.parse(new TextDecoder().decode(chunk));
-            expect(json.params.filter_id).toBe(1);
-            expect(json.params.template_key).toBe("website_blog.dynamic_filter_template_blog_post_big_picture");
-            expect(json.params.limit).toBe(16);
-            expect(json.params.search_domain).toEqual([["blog_id", "=", 1]]);
-        }
+        const json = JSON.parse(new TextDecoder().decode(await args.arrayBuffer()));
+        expect(json.params.filter_id).toBe(1);
+        expect(json.params.template_key).toBe("website_blog.dynamic_filter_template_blog_post_big_picture");
+        expect(json.params.limit).toBe(16);
+        expect(json.params.search_domain).toEqual([["blog_id", "=", 1]]);
         return [`
             <div class="s_test_item" data-test-param="test">
                 Some test record

--- a/addons/website_event/static/tests/interactions/snippets/events.test.js
+++ b/addons/website_event/static/tests/interactions/snippets/events.test.js
@@ -21,13 +21,11 @@ setupInteractionWhiteList(["website_event.events", "website_event.test_events_it
 
 test("dynamic snippet loads items and displays them through template", async () => {
     onRpc("/website/snippet/filters", async (args) => {
-        for await (const chunk of args.body) {
-            const json = JSON.parse(new TextDecoder().decode(chunk));
-            expect(json.params.filter_id).toBe(1);
-            expect(json.params.template_key).toBe("website_event.dynamic_filter_template_event_event_picture");
-            expect(json.params.limit).toBe(3);
-            expect(json.params.search_domain).toEqual([["tag_ids", "in", [5]]]);
-        }
+        const json = JSON.parse(new TextDecoder().decode(await args.arrayBuffer()));
+        expect(json.params.filter_id).toBe(1);
+        expect(json.params.template_key).toBe("website_event.dynamic_filter_template_event_event_picture");
+        expect(json.params.limit).toBe(3);
+        expect(json.params.search_domain).toEqual([["tag_ids", "in", [5]]]);
         return [`
             <div class="s_test_item" data-test-param="test">
                 Some test record

--- a/addons/website_sale/static/tests/interactions/snippets/dynamic_snippet_products.test.js
+++ b/addons/website_sale/static/tests/interactions/snippets/dynamic_snippet_products.test.js
@@ -24,17 +24,15 @@ describe.current.tags("interaction_dev");
 test.tags("desktop")("dynamic snippet products loads items and displays them through template", async () => {
     document.querySelector("html").dataset.mainObject = "product.public.category(2,)";
     onRpc("/website/snippet/filters", async (args) => {
-        for await (const chunk of args.body) {
-            const json = JSON.parse(new TextDecoder().decode(chunk));
-            expect(json.params.filter_id).toBe(3);
-            expect(json.params.template_key).toBe("website_sale.dynamic_filter_template_product_product_borderless_1");
-            expect(json.params.limit).toBe(16);
-            expect(json.params.search_domain).toEqual([[
-                "public_categ_ids",
-                "child_of",
-                2,
-            ]]);
-        }
+        const json = JSON.parse(new TextDecoder().decode(await args.arrayBuffer()));
+        expect(json.params.filter_id).toBe(3);
+        expect(json.params.template_key).toBe("website_sale.dynamic_filter_template_product_product_borderless_1");
+        expect(json.params.limit).toBe(16);
+        expect(json.params.search_domain).toEqual([[
+            "public_categ_ids",
+            "child_of",
+            2,
+        ]]);
         return [`
             <div class="s_test_item" data-test-param="test">
                 Some test record


### PR DESCRIPTION
*: blog, event, sale

HOOT's `MockRequest` constructs a new Request, but the `body` parameter isn't supported on Firefox, and therefore shouldn't be used in tests.