### PR TITLE
[FIX] website: fix headers unit tests for Firefox and better output

### DIFF
--- a/addons/website/static/tests/interactions/header/header_disappears.test.js
+++ b/addons/website/static/tests/interactions/header/header_disappears.test.js
@@ -24,91 +24,91 @@ test("header_disappears is started when there is an element header.o_header_disa
 
 const behaviorWithout = [{
     visibility: true,
-    paddingTop: "",
-    transform: "",
-    classList: "o_header_disappears,o_top_fixed_element",
+    paddingTop: "0px",
+    transform: "none",
+    classList: "o_header_disappears o_top_fixed_element",
 }, {
     visibility: true,
     paddingTop: "50px",
-    transform: "translate(0px, 0px)",
-    classList: "o_header_affixed,o_header_disappears,o_header_is_scrolled,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
+    classList: "o_header_affixed o_header_disappears o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: false,
     paddingTop: "50px",
-    transform: "translate(0px, -100%)",
-    classList: "o_header_affixed,o_header_disappears,o_header_is_scrolled",
+    transform: "matrix(1, 0, 0, 1, 0, -50)",
+    classList: "o_header_affixed o_header_disappears o_header_is_scrolled",
 }];
 
 test("[scroll] Template without o_header_hide_on_scroll", async () => {
     const { core, el } = await startInteractions(getTemplateWithoutHideOnScroll("o_header_disappears"));
     const wrapwrap = el.querySelector("#wrapwrap");
     const header = el.querySelector("header");
-    const main = el.querySelector("main")
+    const main = el.querySelector("main");
     await setupTest(core, wrapwrap);
-    expect(checkHeader(header, main, core, behaviorWithout[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[0]);
     await customScroll(wrapwrap, 0, 10);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 10, 60);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 60, 190);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 190, 210);
-    expect(checkHeader(header, main, core, behaviorWithout[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[2]);
     await customScroll(wrapwrap, 210, 400);
-    expect(checkHeader(header, main, core, behaviorWithout[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[2]);
     await customScroll(wrapwrap, 400, 310);
-    expect(checkHeader(header, main, core, behaviorWithout[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[2]);
     await customScroll(wrapwrap, 310, 290);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 290, 0);
-    expect(checkHeader(header, main, core, behaviorWithout[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[0]);
 });
 
 const behaviorWith = [{
     visibility: true,
-    paddingTop: "",
-    transform: "",
-    classList: "o_header_disappears,o_top_fixed_element",
+    paddingTop: "0px",
+    transform: "none",
+    classList: "o_header_disappears o_top_fixed_element",
 }, {
     visibility: true,
     paddingTop: "50px",
-    transform: "translate(0px, -10px)",
-    classList: "o_header_affixed,o_header_disappears,o_header_is_scrolled,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, -10)",
+    classList: "o_header_affixed o_header_disappears o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: true,
     paddingTop: "50px",
-    transform: "translate(0px, -20px)",
-    classList: "o_header_affixed,o_header_disappears,o_header_is_scrolled,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, -20)",
+    classList: "o_header_affixed o_header_disappears o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: false,
     paddingTop: "50px",
-    transform: "translate(0px, -100%)",
-    classList: "o_header_affixed,o_header_disappears,o_header_is_scrolled",
+    transform: "matrix(1, 0, 0, 1, 0, -50)",
+    classList: "o_header_affixed o_header_disappears o_header_is_scrolled",
 }];
 
 test("[scroll] Template with o_header_hide_on_scroll", async () => {
     const { core, el } = await startInteractions(getTemplateWithHideOnScroll("o_header_disappears"));
     const wrapwrap = el.querySelector("#wrapwrap");
     const header = el.querySelector("header");
-    const main = el.querySelector("main")
+    const main = el.querySelector("main");
     await setupTest(core, wrapwrap);
-    expect(checkHeader(header, main, core, behaviorWith[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[0]);
     await customScroll(wrapwrap, 0, 10);
-    expect(checkHeader(header, main, core, behaviorWith[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[1]);
     await customScroll(wrapwrap, 10, 60);
-    expect(checkHeader(header, main, core, behaviorWith[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[2]);
     await customScroll(wrapwrap, 60, 190);
-    expect(checkHeader(header, main, core, behaviorWith[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[2]);
     await customScroll(wrapwrap, 190, 210);
-    expect(checkHeader(header, main, core, behaviorWith[3])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[3]);
     await customScroll(wrapwrap, 210, 400);
-    expect(checkHeader(header, main, core, behaviorWith[3])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[3]);
     await customScroll(wrapwrap, 400, 310);
-    expect(checkHeader(header, main, core, behaviorWith[3])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[3]);
     await customScroll(wrapwrap, 310, 290);
-    expect(checkHeader(header, main, core, behaviorWith[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[2]);
     await customScroll(wrapwrap, 290, 10);
-    expect(checkHeader(header, main, core, behaviorWith[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[1]);
     await customScroll(wrapwrap, 10, 0);
-    expect(checkHeader(header, main, core, behaviorWith[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[0]);
 });

--- a/addons/website/static/tests/interactions/header/header_fade_out.test.js
+++ b/addons/website/static/tests/interactions/header/header_fade_out.test.js
@@ -24,91 +24,91 @@ test("header_fade_out is started when there is an element header.o_header_fade_o
 
 const behaviorWithout = [{
     visibility: true,
-    paddingTop: "",
-    transform: "",
-    classList: "o_header_fade_out,o_top_fixed_element",
+    paddingTop: "0px",
+    transform: "none",
+    classList: "o_header_fade_out o_top_fixed_element",
 }, {
     visibility: true,
     paddingTop: "50px",
-    transform: "translate(0px, 0px)",
-    classList: "o_header_affixed,o_header_fade_out,o_header_is_scrolled,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
+    classList: "o_header_affixed o_header_fade_out o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: false,
     paddingTop: "50px",
-    transform: "translate(0px, -100%)",
-    classList: "o_header_affixed,o_header_fade_out,o_header_is_scrolled",
+    transform: "matrix(1, 0, 0, 1, 0, -50)",
+    classList: "o_header_affixed o_header_fade_out o_header_is_scrolled",
 }];
 
 test("[scroll] Template without o_header_hide_on_scroll", async () => {
     const { core, el } = await startInteractions(getTemplateWithoutHideOnScroll("o_header_fade_out"));
     const wrapwrap = el.querySelector("#wrapwrap");
     const header = el.querySelector("header");
-    const main = el.querySelector("main")
+    const main = el.querySelector("main");
     await setupTest(core, wrapwrap);
-    expect(checkHeader(header, main, core, behaviorWithout[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[0]);
     await customScroll(wrapwrap, 0, 10);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 10, 60);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 60, 190);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 190, 210);
-    expect(checkHeader(header, main, core, behaviorWithout[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[2]);
     await customScroll(wrapwrap, 210, 400);
-    expect(checkHeader(header, main, core, behaviorWithout[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[2]);
     await customScroll(wrapwrap, 400, 310);
-    expect(checkHeader(header, main, core, behaviorWithout[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[2]);
     await customScroll(wrapwrap, 310, 290);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 290, 0);
-    expect(checkHeader(header, main, core, behaviorWithout[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[0]);
 });
 
 const behaviorWith = [{
     visibility: true,
-    paddingTop: "",
-    transform: "",
-    classList: "o_header_fade_out,o_top_fixed_element",
+    paddingTop: "0px",
+    transform: "none",
+    classList: "o_header_fade_out o_top_fixed_element",
 }, {
     visibility: true,
     paddingTop: "50px",
-    transform: "translate(0px, -10px)",
-    classList: "o_header_affixed,o_header_fade_out,o_header_is_scrolled,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, -10)",
+    classList: "o_header_affixed o_header_fade_out o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: true,
     paddingTop: "50px",
-    transform: "translate(0px, -20px)",
-    classList: "o_header_affixed,o_header_fade_out,o_header_is_scrolled,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, -20)",
+    classList: "o_header_affixed o_header_fade_out o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: false,
     paddingTop: "50px",
-    transform: "translate(0px, -100%)",
-    classList: "o_header_affixed,o_header_fade_out,o_header_is_scrolled",
+    transform: "matrix(1, 0, 0, 1, 0, -50)",
+    classList: "o_header_affixed o_header_fade_out o_header_is_scrolled",
 }];
 
 test("[scroll] Template with o_header_hide_on_scroll", async () => {
     const { core, el } = await startInteractions(getTemplateWithHideOnScroll("o_header_fade_out"));
     const wrapwrap = el.querySelector("#wrapwrap");
     const header = el.querySelector("header");
-    const main = el.querySelector("main")
+    const main = el.querySelector("main");
     await setupTest(core, wrapwrap);
-    expect(checkHeader(header, main, core, behaviorWith[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[0]);
     await customScroll(wrapwrap, 0, 10);
-    expect(checkHeader(header, main, core, behaviorWith[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[1]);
     await customScroll(wrapwrap, 10, 60);
-    expect(checkHeader(header, main, core, behaviorWith[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[2]);
     await customScroll(wrapwrap, 60, 190);
-    expect(checkHeader(header, main, core, behaviorWith[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[2]);
     await customScroll(wrapwrap, 190, 210);
-    expect(checkHeader(header, main, core, behaviorWith[3])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[3]);
     await customScroll(wrapwrap, 210, 400);
-    expect(checkHeader(header, main, core, behaviorWith[3])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[3]);
     await customScroll(wrapwrap, 400, 310);
-    expect(checkHeader(header, main, core, behaviorWith[3])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[3]);
     await customScroll(wrapwrap, 310, 290);
-    expect(checkHeader(header, main, core, behaviorWith[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[2]);
     await customScroll(wrapwrap, 290, 10);
-    expect(checkHeader(header, main, core, behaviorWith[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[1]);
     await customScroll(wrapwrap, 10, 0);
-    expect(checkHeader(header, main, core, behaviorWith[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[0]);
 });

--- a/addons/website/static/tests/interactions/header/header_fixed.test.js
+++ b/addons/website/static/tests/interactions/header/header_fixed.test.js
@@ -24,63 +24,63 @@ test("header_fixed is started when there is an element header.o_header_fixed", a
 
 const behaviorWithout = [{
     visibility: true,
-    paddingTop: "",
-    transform: "",
-    classList: "o_header_fixed,o_top_fixed_element",
+    paddingTop: "0px",
+    transform: "none",
+    classList: "o_header_fixed o_top_fixed_element",
 }, {
     visibility: true,
     paddingTop: "50px",
-    transform: "translate(0px, 0px)",
-    classList: "o_header_affixed,o_header_fixed,o_header_is_scrolled,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
+    classList: "o_header_affixed o_header_fixed o_header_is_scrolled o_top_fixed_element",
 }];
 
 test("[scroll] Template without o_header_hide_on_scroll", async () => {
     const { core, el } = await startInteractions(getTemplateWithoutHideOnScroll("o_header_fixed"));
     const wrapwrap = el.querySelector("#wrapwrap");
     const header = el.querySelector("header");
-    const main = el.querySelector("main")
+    const main = el.querySelector("main");
     await setupTest(core, wrapwrap);
-    expect(checkHeader(header, main, core, behaviorWithout[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[0]);
     await customScroll(wrapwrap, 0, 10);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 10, 400);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 400, 10);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 10, 0);
-    expect(checkHeader(header, main, core, behaviorWithout[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[0]);
 });
 
 const behaviorWith = [{
     visibility: true,
-    paddingTop: "",
-    transform: "",
-    classList: "o_header_fixed,o_top_fixed_element",
+    paddingTop: "0px",
+    transform: "none",
+    classList: "o_header_fixed o_top_fixed_element",
 }, {
     visibility: true,
     paddingTop: "50px",
-    transform: "translate(0px, -10px)",
-    classList: "o_header_affixed,o_header_fixed,o_header_is_scrolled,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, -10)",
+    classList: "o_header_affixed o_header_fixed o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: true,
     paddingTop: "50px",
-    transform: "translate(0px, -20px)",
-    classList: "o_header_affixed,o_header_fixed,o_header_is_scrolled,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, -20)",
+    classList: "o_header_affixed o_header_fixed o_header_is_scrolled o_top_fixed_element",
 }];
 
 test("[scroll] Template with o_header_hide_on_scroll", async () => {
     const { core, el } = await startInteractions(getTemplateWithHideOnScroll("o_header_fixed"));
     const wrapwrap = el.querySelector("#wrapwrap");
     const header = el.querySelector("header");
-    const main = el.querySelector("main")
+    const main = el.querySelector("main");
     await setupTest(core, wrapwrap);
-    expect(checkHeader(header, main, core, behaviorWith[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[0]);
     await customScroll(wrapwrap, 0, 10);
-    expect(checkHeader(header, main, core, behaviorWith[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[1]);
     await customScroll(wrapwrap, 10, 400);
-    expect(checkHeader(header, main, core, behaviorWith[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[2]);
     await customScroll(wrapwrap, 400, 10);
-    expect(checkHeader(header, main, core, behaviorWith[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[1]);
     await customScroll(wrapwrap, 10, 0);
-    expect(checkHeader(header, main, core, behaviorWith[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWith[0]);
 });

--- a/addons/website/static/tests/interactions/header/header_standard.test.js
+++ b/addons/website/static/tests/interactions/header/header_standard.test.js
@@ -24,138 +24,138 @@ test("header_standard is started when there is an element header.o_header_standa
 
 const behaviorWithout = [{
     visibility: true,
-    paddingTop: "",
-    transform: "",
-    classList: "o_header_standard,o_top_fixed_element",
+    paddingTop: "0px",
+    transform: "none",
+    classList: "o_header_standard o_top_fixed_element",
 }, {
     visibility: false,
     paddingTop: "50px",
-    transform: "translate(0px, -100%)",
-    classList: "o_header_affixed,o_header_standard",
+    transform: "matrix(1, 0, 0, 1, 0, -50)",
+    classList: "o_header_affixed o_header_standard",
 }, {
     visibility: true,
     paddingTop: "50px",
-    transform: "translate(0px, 0px)",
-    classList: "o_header_affixed,o_header_is_scrolled,o_header_standard,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
+    classList: "o_header_affixed o_header_is_scrolled o_header_standard o_top_fixed_element",
 }];
 
 test("[scroll] Template without o_header_hide_on_scroll", async () => {
     const { core, el } = await startInteractions(getTemplateWithoutHideOnScroll("o_header_standard"));
     const wrapwrap = el.querySelector("#wrapwrap");
     const header = el.querySelector("header");
-    const main = el.querySelector("main")
+    const main = el.querySelector("main");
     await setupTest(core, wrapwrap);
-    expect(checkHeader(header, main, core, behaviorWithout[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[0]);
     await customScroll(wrapwrap, 0, 40);
-    expect(checkHeader(header, main, core, behaviorWithout[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[0]);
     await customScroll(wrapwrap, 40, 60);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 60, 290);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 290, 310);
-    expect(checkHeader(header, main, core, behaviorWithout[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[2]);
     await customScroll(wrapwrap, 310, 400);
-    expect(checkHeader(header, main, core, behaviorWithout[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[2]);
     await customScroll(wrapwrap, 400, 310);
-    expect(checkHeader(header, main, core, behaviorWithout[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[2]);
     await customScroll(wrapwrap, 310, 290);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 290, 60);
-    expect(checkHeader(header, main, core, behaviorWithout[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[1]);
     await customScroll(wrapwrap, 60, 40);
-    expect(checkHeader(header, main, core, behaviorWithout[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[0]);
     await customScroll(wrapwrap, 40, 0);
-    expect(checkHeader(header, main, core, behaviorWithout[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithout[0]);
 });
 
 const behaviorWithDesktop = [{
     visibility: true,
-    paddingTop: "",
-    transform: "",
-    classList: "o_header_standard,o_top_fixed_element",
+    paddingTop: "0px",
+    transform: "none",
+    classList: "o_header_standard o_top_fixed_element",
 }, {
     visibility: false,
     paddingTop: "50px",
-    transform: "translate(0px, -100%)",
-    classList: "o_header_affixed,o_header_standard",
+    transform: "matrix(1, 0, 0, 1, 0, -30)",
+    classList: "o_header_affixed o_header_standard",
 }, {
     visibility: true,
     paddingTop: "50px",
-    transform: "translate(0px, 0px)",
-    classList: "o_header_affixed,o_header_is_scrolled,o_header_standard,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
+    classList: "o_header_affixed o_header_is_scrolled o_header_standard o_top_fixed_element",
 }];
 
 test.tags("desktop")("[scroll] Template with o_header_hide_on_scroll (desktop)", async () => {
     const { core, el } = await startInteractions(getTemplateWithHideOnScroll("o_header_standard"));
     const wrapwrap = el.querySelector("#wrapwrap");
     const header = el.querySelector("header");
-    const main = el.querySelector("main")
+    const main = el.querySelector("main");
     await setupTest(core, wrapwrap);
-    expect(checkHeader(header, main, core, behaviorWithDesktop[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithDesktop[0]);
     await customScroll(wrapwrap, 0, 40);
-    expect(checkHeader(header, main, core, behaviorWithDesktop[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithDesktop[0]);
     await customScroll(wrapwrap, 40, 60);
-    expect(checkHeader(header, main, core, behaviorWithDesktop[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithDesktop[1]);
     await customScroll(wrapwrap, 60, 290);
-    expect(checkHeader(header, main, core, behaviorWithDesktop[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithDesktop[1]);
     await customScroll(wrapwrap, 290, 310);
-    expect(checkHeader(header, main, core, behaviorWithDesktop[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithDesktop[2]);
     await customScroll(wrapwrap, 310, 400);
-    expect(checkHeader(header, main, core, behaviorWithDesktop[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithDesktop[2]);
     await customScroll(wrapwrap, 400, 310);
-    expect(checkHeader(header, main, core, behaviorWithDesktop[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithDesktop[2]);
     await customScroll(wrapwrap, 310, 290);
-    expect(checkHeader(header, main, core, behaviorWithDesktop[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithDesktop[1]);
     await customScroll(wrapwrap, 290, 60);
-    expect(checkHeader(header, main, core, behaviorWithDesktop[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithDesktop[1]);
     await customScroll(wrapwrap, 60, 40);
-    expect(checkHeader(header, main, core, behaviorWithDesktop[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithDesktop[0]);
     await customScroll(wrapwrap, 40, 0);
-    expect(checkHeader(header, main, core, behaviorWithDesktop[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithDesktop[0]);
 });
 
 const behaviorWithMobile = [{
     visibility: true,
-    paddingTop: "",
-    transform: "",
-    classList: "o_header_standard,o_top_fixed_element",
+    paddingTop: "0px",
+    transform: "none",
+    classList: "o_header_standard o_top_fixed_element",
 }, {
     visibility: false,
     paddingTop: "30px",
-    transform: "translate(0px, -100%)",
-    classList: "o_header_affixed,o_header_standard",
+    transform: "matrix(1, 0, 0, 1, 0, -30)",
+    classList: "o_header_affixed o_header_standard",
 }, {
     visibility: true,
     paddingTop: "30px",
-    transform: "translate(0px, 0px)",
-    classList: "o_header_affixed,o_header_is_scrolled,o_header_standard,o_top_fixed_element",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
+    classList: "o_header_affixed o_header_is_scrolled o_header_standard o_top_fixed_element",
 }];
 
 test.tags("mobile")("[scroll] Template with o_header_hide_on_scroll (mobile)", async () => {
     const { core, el } = await startInteractions(getTemplateWithHideOnScroll("o_header_standard"));
     const wrapwrap = el.querySelector("#wrapwrap");
     const header = el.querySelector("header");
-    const main = el.querySelector("main")
+    const main = el.querySelector("main");
     await setupTest(core, wrapwrap);
-    expect(checkHeader(header, main, core, behaviorWithMobile[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithMobile[0]);
     await customScroll(wrapwrap, 0, 20);
-    expect(checkHeader(header, main, core, behaviorWithMobile[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithMobile[0]);
     await customScroll(wrapwrap, 20, 60);
-    expect(checkHeader(header, main, core, behaviorWithMobile[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithMobile[1]);
     await customScroll(wrapwrap, 60, 290);
-    expect(checkHeader(header, main, core, behaviorWithMobile[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithMobile[1]);
     await customScroll(wrapwrap, 290, 310);
-    expect(checkHeader(header, main, core, behaviorWithMobile[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithMobile[2]);
     await customScroll(wrapwrap, 310, 400);
-    expect(checkHeader(header, main, core, behaviorWithMobile[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithMobile[2]);
     await customScroll(wrapwrap, 400, 310);
-    expect(checkHeader(header, main, core, behaviorWithMobile[2])).toBe(true);
+    checkHeader(header, main, core, behaviorWithMobile[2]);
     await customScroll(wrapwrap, 310, 290);
-    expect(checkHeader(header, main, core, behaviorWithMobile[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithMobile[1]);
     await customScroll(wrapwrap, 290, 60);
-    expect(checkHeader(header, main, core, behaviorWithMobile[1])).toBe(true);
+    checkHeader(header, main, core, behaviorWithMobile[1]);
     await customScroll(wrapwrap, 60, 20);
-    expect(checkHeader(header, main, core, behaviorWithMobile[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithMobile[0]);
     await customScroll(wrapwrap, 20, 0);
-    expect(checkHeader(header, main, core, behaviorWithMobile[0])).toBe(true);
+    checkHeader(header, main, core, behaviorWithMobile[0]);
 });

--- a/addons/website/static/tests/interactions/header/helpers.js
+++ b/addons/website/static/tests/interactions/header/helpers.js
@@ -1,3 +1,4 @@
+import { expect } from "@odoo/hoot";
 import { animationFrame, scroll } from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
 
@@ -32,19 +33,12 @@ export const customScroll = async function (scrollingElement, start, end) {
 }
 
 export const checkHeader = function (header, main, core, expectedStatus) {
-    const visibility = core.interactions[0].interaction.isVisible
-    if (visibility != expectedStatus.visibility
-        || main.style.paddingTop != expectedStatus.paddingTop
-        || header.style.transform != expectedStatus.transform
-    ) {
-        return false;
-    }
-    const headerClasses = header.classList.value.split(" ");
-    headerClasses.sort();
-    if (headerClasses.toString() !== expectedStatus.classList) {
-        return false;
-    }
-    return true;
+    const message = `Interaction visibility should be ${expectedStatus.visibility}`;
+    expect(core.interactions[0].interaction.isVisible).toBe(expectedStatus.visibility, { message });
+    expect(main).toHaveStyle({ paddingTop: expectedStatus.paddingTop });
+    expect(header).toHaveStyle({ transform: expectedStatus.transform });
+    const headerClasses = [...header.classList].sort().join(" ");
+    expect(headerClasses).toEqual(expectedStatus.classList);
 }
 
 export const getTemplateWithoutHideOnScroll = function (class_name) {


### PR DESCRIPTION
`el.style.transform` don't send the same info in Firefox and Chrome, it's better to use the actual computed styles to make the comparison.

Additionnally, `checkHeader` now processes several `expect()` so we have more accurate outputs when launching the tests, rather than just a boolean which is hard to debug when it fails.