### PR TITLE
[FIX] portal: does not create menu without sidebar

### DIFF
--- a/addons/portal/static/src/interactions/sidebar.js
+++ b/addons/portal/static/src/interactions/sidebar.js
@@ -71,6 +71,9 @@ export class Sidebar extends Interaction {
         let lastLI = false;
         let lastUL = null;
         const bsSidenavEl = this.el.querySelector(".bs-sidenav");
+        if (!bsSidenavEl) {
+            return;
+        }
 
         const quoteEls = document.querySelectorAll("#quote_content [id^=quote_header_], #quote_content [id^=quote_]");
         for (const quoteEl of quoteEls) {


### PR DESCRIPTION
Before this commit, the sidebar interactions generated a menu by adding the links within a .bs-sidenav element. There was an error that occur when trying to generate a menu when the .bs-sidenav is not in the DOM.

This commit stop the generation of the menu if no .bs-sidenav is found.