### PR TITLE
[IMP] image gallery option

### DIFF
--- a/addons/html_builder/static/src/builder/options/image_gallery_option.js
+++ b/addons/html_builder/static/src/builder/options/image_gallery_option.js
@@ -1,0 +1,165 @@
+import { registry } from "@web/core/registry";
+import { Plugin } from "@html_editor/plugin";
+
+class ImageGalleryOption extends Plugin {
+    static id = "ImageGalleryOption";
+    static dependencies = ["media", "dom", "history"];
+    resources = {
+        builder_options: [
+            {
+                template: "html_builder.ImageGalleryOption",
+                selector: ".s_image_gallery",
+            },
+        ],
+        builder_actions: this.getActions(),
+    };
+
+    getActions() {
+        return {
+            addImage: {
+                load: async () =>
+                    new Promise((resolve) => {
+                        this.dependencies.media.openMediaDialog({
+                            onlyImages: true,
+                            multiImages: true,
+                            save: (images) => {
+                                resolve(images);
+                            },
+                        });
+                    }),
+                apply: ({ editingElement, loadResult: images }) => {
+                    addImages(images, editingElement);
+                    this.dependencies.history.addStep();
+                },
+            },
+            removeAllImages: {
+                // TODO: implement the remove images
+                apply: () => console.log("Remove all"),
+            },
+        };
+    }
+}
+
+/**
+ * Add the images selected in the media dialog in the gallery
+ */
+function addImages(images, imageGalleryElement) {
+    const container = getContainer(imageGalleryElement);
+    if (!container) {
+        return;
+    }
+    container.append(...images);
+
+    const lastImage = getImages(imageGalleryElement).at(-1);
+    let lastIndex = lastImage ? getIndex(lastImage) : -1;
+    for (const image of images) {
+        image.classList.add(
+            "d-block",
+            "mh-100",
+            "mw-100",
+            "mx-auto",
+            "rounded",
+            "object-fit-cover"
+        );
+        image.dataset.index = ++lastIndex;
+        // TODO: Change mimetype
+    }
+    relayout(imageGalleryElement);
+}
+
+/**
+ * Redraw the current layout
+ * @param {Element} imageGalleryElement
+ */
+function relayout(imageGalleryElement) {
+    // TODO DAFL: implement other layout
+    if (getMode(imageGalleryElement) === "masonry") {
+        masonry(imageGalleryElement);
+    }
+}
+
+function masonry(imageGalleryElement) {
+    const imagesHolder = getImageHolder(imageGalleryElement);
+    const columnsNumber = getColumns(imageGalleryElement);
+    const colClass = "col-lg-" + 12 / columnsNumber;
+    const columns = [];
+
+    const row = document.createElement("div");
+    row.classList.add("row", "s_nb_column_fixed");
+    getContainer(imageGalleryElement).replaceChildren(row);
+
+    for (let i = 0; i < columnsNumber; i++) {
+        const column = document.createElement("div");
+        column.classList.add("o_masonry_col", "o_snippet_not_selectable", colClass);
+        row.append(column);
+        columns.push(column);
+    }
+
+    // Dispatch images in columns by always putting the next one in the smallest height column
+    for (const imageEl of imagesHolder) {
+        let min = Infinity;
+        let smallestColEl;
+        for (const colEl of columns) {
+            const imagesInCol = colEl.querySelectorAll("img");
+            const lastImageRect =
+                imagesInCol.length && imagesInCol[imagesInCol.length - 1].getBoundingClientRect();
+            const height = lastImageRect ? Math.round(lastImageRect.top + lastImageRect.height) : 0;
+            if (height < min) {
+                min = height;
+                smallestColEl = colEl;
+            }
+        }
+        // Only on Chrome: appended images are sometimes invisible
+        // and not correctly loaded from cache, we use a clone of the
+        // image to force the loading.
+        const newImg = imageEl.cloneNode(true);
+        smallestColEl.append(newImg);
+    }
+}
+
+/**
+ * Get the image target's layout mode (slideshow, masonry, grid or nomode).
+ *
+ * @returns {String('slideshow'|'masonry'|'grid'|'nomode')}
+ */
+function getMode(imageGalleryElement) {
+    if (imageGalleryElement.classList.contains("o_masonry")) {
+        return "masonry";
+    }
+    if (imageGalleryElement.classList.contains("o_grid")) {
+        return "grid";
+    }
+    if (imageGalleryElement.classList.contains("o_nomode")) {
+        return "nomode";
+    }
+    return "slideshow";
+}
+
+function getImages(currentContainer) {
+    const imgs = currentContainer.querySelectorAll("img");
+    return [...imgs].sort((imgA, imgB) => getIndex(imgA) - getIndex(imgB));
+}
+
+function getIndex(img) {
+    return parseInt(img.dataset.index) || 0;
+}
+
+function getImageHolder(currentContainer) {
+    const images = getImages(currentContainer);
+    return [...images].map((image) => image.closest("a") || image);
+}
+
+/**
+ * Relayout the imageGalleryElement with the "masonry" layout.
+ * @param {Element} imageGalleryElement
+ */
+
+function getColumns(imageGalleryElement) {
+    return parseInt(imageGalleryElement.dataset.columns) || 3;
+}
+
+function getContainer(imageGalleryElement) {
+    return imageGalleryElement.querySelector(".container, .container-fluid, .o_container_small");
+}
+
+registry.category("website-plugins").add(ImageGalleryOption.id, ImageGalleryOption);

--- a/addons/html_builder/static/src/builder/options/image_gallery_option.xml
+++ b/addons/html_builder/static/src/builder/options/image_gallery_option.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="html_builder.ImageGalleryOption">
+    <WeRow label.translate="Images">
+        <WeButton preview="false" title.translate="Add Image"  action="'addImage'"> Add </WeButton>
+        <WeButton preview="false" title.translate="Remove all images" action="'removeAllImages'"> Remove all </WeButton>
+    </WeRow>
+</t>
+
+</templates>

--- a/addons/html_builder/static/tests/options/image_gallery.test.js
+++ b/addons/html_builder/static/tests/options/image_gallery.test.js
@@ -1,0 +1,57 @@
+import { expect, test } from "@odoo/hoot";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import { defineWebsiteModels, setupWebsiteBuilder } from "../helpers";
+import { animationFrame, click, queryAll, waitFor } from "@odoo/hoot-dom";
+
+defineWebsiteModels();
+
+const base64Img =
+    "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
+
+test("Add image in gallery", async () => {
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", (test) => {
+        return [
+            {
+                id: 1,
+                name: "logo",
+                mimetype: "image/png",
+                image_src: "/web/static/img/logo2.png",
+                access_token: false,
+                public: true,
+            },
+        ];
+    });
+    await setupWebsiteBuilder(
+        `
+        <section class="s_image_gallery o_masonry" data-columns="2">
+            <div class="container">
+                <div class="o_masonry_col col-lg-6">
+                    <img class="first_img img img-fluid d-block rounded" data-index="1" src='${base64Img}'>
+                    <img class="a_nice_img img img-fluid d-block rounded" data-index="2" src='${base64Img}'>
+                    <img class="a_nice_img img img-fluid d-block rounded" data-index="3" src='${base64Img}'>
+                    <img class="a_nice_img img img-fluid d-block rounded" data-index="4" src='${base64Img}'>
+                </div>
+                <div class="o_masonry_col col-lg-6">
+                    <img class="a_nice_img img img-fluid d-block rounded" data-index="5"  src='${base64Img}'>
+                </div>
+            </div>
+        </section>
+        `,
+        { loadIframeBundles: true }
+    );
+    await contains(":iframe .first_img").click();
+    expect("[data-action-id='addImage']").toHaveCount(1);
+    await click("[data-action-id='addImage']");
+    await animationFrame();
+    await click("img.o_we_attachment_highlight");
+    await animationFrame();
+    await click(".modal-footer button");
+    await waitFor(":iframe img[data-index='6']");
+
+    const columns = queryAll(":iframe .o_masonry_col");
+    const columnImgs = columns.map((column) =>
+        [...column.children].map((img) => img.dataset.index)
+    );
+
+    expect(columnImgs).toEqual([["1", "3", "4", "5", "6"], ["2"]]);
+});


### PR DESCRIPTION

[[IMP] mysterious_egg: Add image in s_image_gallery](https://github.com/odoo-dev/odoo/pull/3949/commits/35752b575b4bca966fa93330b9da6fb0a54f945d)
This commit allows to add an image in the s_image_gallery option.
Currently only the masonry layout is supported. 

[[IMP] html_editor: accepts multiples images](https://github.com/odoo-dev/odoo/pull/3949/commits/f82da257b9715b0d44e84d6659b1c17c88284ad1)
Before this commit it was not possible to select multiple images in the media dialog.
This commit make it possible to selects multiple images in the media dialog.

This commit also improve the API of `openMediaDialog` shared method. This shared returned
a promise that is resolved when the dialog is closed but without indicating which media was chosen.
Now it returns a promise that is resolved with the selected image value, letting the caller
know and process the inserted images.
