### PR TITLE
!fixup [REF] website: rewrite public widgets as interactions

### DIFF
--- a/addons/website/static/src/interactions/header/base_header.js
+++ b/addons/website/static/src/interactions/header/base_header.js
@@ -24,9 +24,6 @@ export class BaseHeader extends Interaction {
                 "o_header_is_scrolled": this.isScrolled,
                 "o_header_no_transition": !this.transitionActive,
             }),
-            "t-att-style": () => ({
-                "transition": this.isHiding ? "none" : "",
-            })
         },
         ".offcanvas": {
             "t-on-show.bs.offcanvas": this.disableScroll,
@@ -195,10 +192,15 @@ export class BaseHeader extends Interaction {
     //--------------------------------------------------------------
 
     getHeaderHeight() {
-        if (this.hideEl && !this.isHideElTop && !this.isSmall()) {
-            // Ensure the header height stays the same on desktop
-            return this.hiddenQuantity + this.el.getBoundingClientRect().height;
+        if (this.isSmall()) {
+            // Ensure we don't consider the hiddenOnScroll element on mobile
+            return this.el.getBoundingClientRect().height;
         }
+        if (this.hideEl?.classList.contains("hidden")) {
+            // Ensure the header height stays the same on desktop
+            return this.hideElHeight + this.el.getBoundingClientRect().height;
+        }
+        this.hideElHeight = this.hideEl?.getBoundingClientRect().height || this.hideElHeight;
         return this.el.getBoundingClientRect().height;
     }
 

--- a/addons/website/static/src/interactions/header/base_header_special.js
+++ b/addons/website/static/src/interactions/header/base_header_special.js
@@ -26,23 +26,8 @@ export class BaseHeaderSpecial extends BaseHeader {
         this.scrollOffset = 200;
         this.scrollingDownward = true;
 
+        this.searchbarEl = this.hideEl?.querySelector(":not(.modal-content) > .o_searchbar_form");
         this.dropdownClickedEl = null;
-
-        if (this.hideEl) {
-            this.searchbarEl = this.hideEl.querySelector(":not(.modal-content) > .o_searchbar_form");
-            this.isHideElTop = this.hideEl.matches(":first-child");
-            if (!this.isHideElTop) {
-                // If the hideEl is not the top element, we need to set the 
-                // z-index in order to hide it behind the top element (showEl).
-                // The z-index property is not active with position: static, 
-                // which is the default value.
-                const showEl = this.hideEl.previousElementSibling;
-                showEl.style.position = "relative";
-                showEl.style.setProperty("z-index", 1);
-                this.hideEl.style.position = "relative";
-                this.hideEl.style.setProperty("z-index", 0);
-            }
-        }
     }
 
     onDropdownShow(ev) {
@@ -88,20 +73,38 @@ export class BaseHeaderSpecial extends BaseHeader {
             this.toggleCSSAffixed(false);
         }
 
-        if (this.hideEl && this.isVisible) {
-            // We check if we are hiding the scrollingElement to deactivate the 
-            // transition and avoid the translate animation. Otherwise, we need 
-            // to reactivate it for transformShow / transformHide.
-            this.isHiding = scroll < this.hideEl.getBoundingClientRect().height;
-            this.hiddenQuantity = Math.min(scroll, this.hideEl.getBoundingClientRect().height);
-            if (this.isHideElTop) {
-                // If the hideEl is at the top, we move the whole header element.
-                this.forcedScroll = this.hiddenQuantity;
-                this.transformShow();
+        if (this.hideEl) {
+            let elHeight = 0;
+            if (this.cssAffixed && this.searchbarEl?.matches(".show")) {
+                // Close the dropdown of the search bar if it's open when
+                // scrolling. Otherwise, the calculated height of the
+                // 'hideEl' element will be incorrect because it will
+                // include the dropdown height.
+                this.searchbarEl.querySelector("input").blur();
+                elHeight = this.hideEl.offsetHeight;
             } else {
-                // If the hideEl is at the bottom, we only move the hideEl and
-                // it will be hidden behind the other part of the header.
-                this.hideEl.style.marginTop = `-${this.hiddenQuantity}px`;
+                elHeight = this.hideEl.scrollHeight;
+            }
+            const scrollDelta = window.matchMedia(`(prefers-reduced-motion: reduce)`).matches ?
+                scroll : Math.floor(scroll / 4);
+            elHeight = Math.max(0, elHeight - scrollDelta);
+            this.hideEl.classList.toggle("hidden", elHeight === 0);
+            if (elHeight === 0) {
+                this.hideEl.removeAttribute("style");
+            } else {
+                // When the page hasn't been scrolled yet, we don't set overflow
+                // to hidden. Without this, the dropdowns would be invisible.
+                // (e.g., "user menu" dropdown).
+                this.hideEl.style.overflow = this.cssAffixed ? "hidden" : "";
+                this.hideEl.style.height = this.cssAffixed ? `${elHeight}px` : "";
+                let elPadding = parseInt(getComputedStyle(this.hideEl).paddingBlock);
+                if (elHeight < elPadding * 2) {
+                    const heightDifference = elPadding * 2 - elHeight;
+                    elPadding = Math.max(0, elPadding - Math.floor(heightDifference / 2));
+                    this.hideEl.style.setProperty("padding-block", `${elPadding}px`, "important");
+                } else {
+                    this.hideEl.style.paddingBlock = "";
+                }
                 this.adaptToHeaderChange();
             }
         }

--- a/addons/website/static/tests/interactions/header/header_disappears.test.js
+++ b/addons/website/static/tests/interactions/header/header_disappears.test.js
@@ -71,18 +71,18 @@ const behaviorWith = [{
     classList: "o_header_disappears o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "50px",
-    transform: "matrix(1, 0, 0, 1, 0, -10)",
+    paddingTop: "38.9915px",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_disappears o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "50px",
-    transform: "matrix(1, 0, 0, 1, 0, -20)",
+    paddingTop: "38.9915px",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_disappears o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: false,
-    paddingTop: "50px",
-    transform: "matrix(1, 0, 0, 1, 0, -50)",
+    paddingTop: "38.9915px",
+    transform: "matrix(1, 0, 0, 1, 0, -30)",
     classList: "o_header_affixed o_header_disappears o_header_is_scrolled",
 }];
 

--- a/addons/website/static/tests/interactions/header/header_fade_out.test.js
+++ b/addons/website/static/tests/interactions/header/header_fade_out.test.js
@@ -71,18 +71,18 @@ const behaviorWith = [{
     classList: "o_header_fade_out o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "50px",
-    transform: "matrix(1, 0, 0, 1, 0, -10)",
+    paddingTop: "38.9915px",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_fade_out o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "50px",
-    transform: "matrix(1, 0, 0, 1, 0, -20)",
+    paddingTop: "38.9915px",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_fade_out o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: false,
-    paddingTop: "50px",
-    transform: "matrix(1, 0, 0, 1, 0, -50)",
+    paddingTop: "38.9915px",
+    transform: "matrix(1, 0, 0, 1, 0, -30)",
     classList: "o_header_affixed o_header_fade_out o_header_is_scrolled",
 }];
 

--- a/addons/website/static/tests/interactions/header/header_fixed.test.js
+++ b/addons/website/static/tests/interactions/header/header_fixed.test.js
@@ -58,13 +58,13 @@ const behaviorWith = [{
     classList: "o_header_fixed o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "50px",
-    transform: "matrix(1, 0, 0, 1, 0, -10)",
+    paddingTop: "38.9915px",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_fixed o_header_is_scrolled o_top_fixed_element",
 }, {
     visibility: true,
-    paddingTop: "50px",
-    transform: "matrix(1, 0, 0, 1, 0, -20)",
+    paddingTop: "38.9915px",
+    transform: "matrix(1, 0, 0, 1, 0, 0)",
     classList: "o_header_affixed o_header_fixed o_header_is_scrolled o_top_fixed_element",
 }];
 


### PR DESCRIPTION
Revert previous header behavior modification & adapt the test accordingly.
The header now behave the same way as it was in master (18.0)