### PR TITLE
[FIX] web: remove assets errors when changing page

### DIFF
--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -55,6 +55,10 @@ const onLoadAndError = (el, onLoad, onError) => {
 
     el.addEventListener("load", onLoadListener);
     el.addEventListener("error", onErrorListener);
+
+    window.addEventListener("pagehide", () => {
+        removeListeners();
+    });
 };
 
 /** @type {typeof assets["getBundle"]} */


### PR DESCRIPTION
Loading assets are attached with a load and an error listener. They are sometimes triggered when leaving a page before the assets have been properly loaded, which triggers the error and displays a traceback to unknowing users instants before they are directed to the new requested page.

This commit removes the listeners on pagehide.