### PR TITLE
[FIX] web_editor: use proper Javascript events

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -7894,9 +7894,9 @@ registry.ImageTools = ImageHandlerOption.extend({
             // the "setImgShapeHoverEffect" option, where we trigger it when
             // preview mode is "true".
             if (previewMode === hasSetImgShapeHoverEffectMethod) {
-                this.$target[0].dispatchEvent(new Event("mouseover"));
+                this.$target[0].dispatchEvent(new Event("mouseenter"));
                 this.hoverTimeoutId = setTimeout(() => {
-                    this.$target[0].dispatchEvent(new Event("mouseout"));
+                    this.$target[0].dispatchEvent(new Event("mouseleave"));
                 }, 700);
             } else if (previewMode === "reset") {
                 clearTimeout(this.hoverTimeoutId);


### PR DESCRIPTION
Since version 18.0 [1], previews for hover effects on images are dispatched with the `mouseover` and `mouseout` events. This was needed because publicWidgets' events used jQuery, which remaps jQuery's `mouseenter` to JS' `mouseover`, and `mouseleave` to `mouseout` for event delegation reasons.
In short, the `ImageShapeHoverEffet` publicWidget received a `mouseenter` jQuery event and dispatched a JS `mouseover` event to trigger the `_onMouseEnter` method. This means that from the outside, you had to dispatch `new Event("mouseover")` to trigger the method. Idem for `mouseleave` -> `mouseout`.

Since we are replacing publicWidgets with Interactions, we now use vanilla JS events and do not need that intermediate remapping anymore. Meaning that when dispatching the event manually, we want to use the actual `mouseenter`/`mouseleave`.

[1]: https://github.com/odoo/odoo/commit/d1a3da8b3833f05a8be9ebd2bda9340dd7442350