### PR TITLE
fix ColorPicker

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -95,15 +95,21 @@ export class BuilderColorPicker extends Component {
         const { state, onApply, onPreview, onPreviewRevert } = useColorPickerBuilderComponent();
         this.colorButton = useRef("colorButton");
         this.state = state;
-        useColorPicker("colorButton", {
-            state,
-            applyColor: onApply,
-            applyColorPreview: onPreview,
-            applyColorResetPreview: onPreviewRevert,
-            getUsedCustomColors: this.props.getUsedCustomColors,
-            colorPrefix: "color-prefix-",
-            noTransparency: this.props.noTransparency,
-        });
+        useColorPicker(
+            "colorButton",
+            {
+                state,
+                applyColor: onApply,
+                applyColorPreview: onPreview,
+                applyColorResetPreview: onPreviewRevert,
+                getUsedCustomColors: this.props.getUsedCustomColors,
+                colorPrefix: "color-prefix-",
+                noTransparency: this.props.noTransparency,
+            },
+            {
+                onClose: onPreviewRevert,
+            }
+        );
     }
 
     getSelectedColorStyle() {

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.xml
@@ -3,7 +3,7 @@
 
 <t t-name="html_builder.BuilderColorPicker">
     <BuilderComponent>
-        <div t-att-title="props.title" class="o_we_color_preview" t-ref="colorButton" t-att-style="this.getSelectedColorStyle()" />
+        <button t-att-title="props.title" class="o_we_color_preview" t-ref="colorButton" t-att-style="this.getSelectedColorStyle()" />
     </BuilderComponent>
 </t>
 

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click } from "@odoo/hoot-dom";
+import { click, hover, press } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
@@ -105,5 +105,29 @@ test("apply custom action", async () => {
     await contains(":iframe .test-options-target").click();
     await contains(".we-bg-options-container .o_we_color_preview").click();
     await contains(".o-overlay-item [data-color='#FF0000']").click();
-    expect.verifySteps(["load", "apply rgb(255, 0, 0)", "load", "apply rgb(255, 0, 0)"]);
+    // 3 times for hover (preview), focus (preview), click
+    expect.verifySteps([
+        "load",
+        "apply rgb(255, 0, 0)",
+        "load",
+        "apply rgb(255, 0, 0)",
+        "load",
+        "apply rgb(255, 0, 0)",
+    ]);
+});
+
+test("should revert preview on escape", async () => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker styleAction="'background-color'"/>`,
+    });
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+    await contains(":iframe .test-options-target").click();
+    expect(":iframe .test-options-target").toHaveStyle({ "background-color": "rgba(0, 0, 0, 0)" });
+    expect(".options-container").toBeDisplayed();
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    await hover(".o-overlay-item [data-color='#FF0000']");
+    expect(":iframe .test-options-target").toHaveStyle({ "background-color": "rgb(255, 0, 0)" });
+    await press("escape");
+    expect(":iframe .test-options-target").toHaveStyle({ "background-color": "rgba(0, 0, 0, 0)" });
 });

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -21,13 +21,17 @@
                     title="Reset"
                     t-on-click="onColorApply"
                     t-on-mouseover="onColorHover"
-                    t-on-mouseout="onColorHoverOut"/>
+                    t-on-mouseout="onColorHoverOut"
+                    t-on-focusin="onColorHover"
+                    t-on-focusout="onColorHoverOut"/>
         </div>
         <t t-if="state.activeTab==='solid'">
             <div class="p-1"
                 t-on-click="onColorApply"
                 t-on-mouseover="onColorHover"
-                t-on-mouseout="onColorHoverOut">
+                t-on-mouseout="onColorHoverOut"
+                t-on-focusin="onColorHover"
+                t-on-focusout="onColorHoverOut">
                 <div class="o_colorpicker_section">
                     <button data-color="o-color-1" t-attf-style="background-color: var(--o-color-1)" class="btn o_color_button"/>
                     <button data-color="o-color-3" t-attf-style="background-color: var(--o-color-3)" class="btn o_color_button"/>
@@ -47,13 +51,13 @@
         </t>
         <t t-if="state.activeTab==='custom'">
             <div class="p-1">
-                <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut">
+                <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorHover" t-on-focusout="onColorHoverOut">
                     <t t-foreach="this.usedCustomColors" t-as="color" t-key="color_index">
                         <button t-if="color !== this.state.currentCustomColor.toLowerCase()" class="o_color_button btn" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                     </t>
                     <button class="o_color_button btn selected" t-att-data-color="this.state.currentCustomColor" t-attf-style="background-color: {{this.state.currentCustomColor}}"/>
                 </div>
-                <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut">
+                <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorHover" t-on-focusout="onColorHoverOut">
                     <button data-color="black" class="btn o_color_button bg-black"></button>
                     <button data-color="900" class="o_color_button btn" style="background-color: var(--900)"></button>
                     <button data-color="800" class="o_color_button btn" style="background-color: var(--800)"></button>
@@ -71,7 +75,7 @@
             </div>
         </t>
         <t t-if="state.activeTab==='gradient'">
-            <div class="o_colorpicker_sections p-2" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut">
+            <div class="o_colorpicker_sections p-2" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorHover" t-on-focusout="onColorHoverOut">
                 <t t-foreach="this.DEFAULT_GRADIENT_COLORS" t-as="gradient" t-key="gradient">
                     <button class="w-50 m-0 o_color_button btn" t-attf-style="background-image: #{gradient};" t-att-data-color="gradient"/>
                 </t>


### PR DESCRIPTION
- revert preview when closing the ColorPicker
- use a button for the BuilderColorPicker to be able to focus it
- apply preview when tabbing around the colors