### PR TITLE
fix number inputs

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -69,7 +69,13 @@ export class BuilderNumberInput extends Component {
     }
 
     parseDisplayValue(displayValue) {
+        // Replace commas by dots and only accept 0-9, dot, - sign and space.
+        displayValue = displayValue.replace(/,/g, ".").replace(/[^0-9.-\s]/g, "");
+
         return this.convertSpaceSplitValues(displayValue, (value) => {
+            if (value === "") {
+                return value;
+            }
             const unit = this.props.unit;
             const saveUnit = this.props.saveUnit;
             if (unit && saveUnit) {

--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -51,7 +51,7 @@ export class BuilderNumberInput extends Component {
         if (!values) {
             return "";
         }
-        return values.split(/\s+/g).map(convertSingleValueFn).join(" ");
+        return values.trim().split(/\s+/g).map(convertSingleValueFn).join(" ");
     }
 
     formatRawValue(rawValue) {

--- a/addons/html_builder/static/src/plugins/border_configurator_option.js
+++ b/addons/html_builder/static/src/plugins/border_configurator_option.js
@@ -35,6 +35,7 @@ export class BorderConfigurator extends Component {
                 mainParam: this.getStyleActionParam("width"),
             },
         });
-        return parseInt(styleActionValue.match(/\d+/g)[0]) > 0;
+        const values = (styleActionValue || "0").match(/\d+/g);
+        return values.some((value) => parseInt(value) > 0);
     }
 }

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
@@ -482,3 +482,55 @@ test("trailing space in BuilderNumberInput is ignored", async () => {
     expect.verifySteps(["customAction 3 4 5", "customAction 3 4 5"]); // input, change
     expect(".options-container input").toHaveValue("3 4 5");
 });
+test("after input, displayed value is cleaned to match only numbers", async () => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderNumberInput dataAttributeAction="'number'"/>`,
+    });
+    await setupWebsiteBuilder(`
+        <div class="test-options-target" data-number="10">Test</div>
+    `);
+    await contains(":iframe .test-options-target").click();
+    await contains(".options-container input").edit(" a&$*+>");
+    expect(".options-container input").toHaveValue("");
+    expect(":iframe .test-options-target").not.toHaveAttribute("data-number");
+});
+test("after copy / pasting, displayed value is cleaned to match only numbers", async () => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderNumberInput dataAttributeAction="'number'"/>`,
+    });
+    await setupWebsiteBuilder(`
+        <div class="test-options-target" data-number="10">Test</div>
+    `);
+    await contains(":iframe .test-options-target").click();
+    await contains(".options-container input").edit(" a&$*-3+>", { instantly: true });
+    expect(".options-container input").toHaveValue("-3");
+    expect(":iframe .test-options-target").toHaveAttribute("data-number", "-3");
+});
+test("accept decimal numbers", async () => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderNumberInput dataAttributeAction="'number'"/>`,
+    });
+    await setupWebsiteBuilder(`
+        <div class="test-options-target" data-number="10">Test</div>
+    `);
+    await contains(":iframe .test-options-target").click();
+    await contains(".options-container input").edit("3.3");
+    expect(".options-container input").toHaveValue("3.3");
+    expect(":iframe .test-options-target").toHaveAttribute("data-number", "3.3");
+});
+test("BuilderNumberInput transforms , into .", async () => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderNumberInput dataAttributeAction="'number'"/>`,
+    });
+    await setupWebsiteBuilder(`
+        <div class="test-options-target" data-number="10">Test</div>
+    `);
+    await contains(":iframe .test-options-target").click();
+    await contains(".options-container input").edit("3,3");
+    expect(".options-container input").toHaveValue("3.3");
+    expect(":iframe .test-options-target").toHaveAttribute("data-number", "3.3");
+});

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
@@ -461,3 +461,24 @@ test("down on empty BuilderNumberInput gives -1", async () => {
     expect("[data-action-id='customAction'] input").toHaveValue("-1");
     expect(":iframe .test-options-target").toHaveAttribute("data-number", "-1");
 });
+test("trailing space in BuilderNumberInput is ignored", async () => {
+    addActionOption({
+        customAction: {
+            getValue: ({ editingElement }) => editingElement.innerHTML,
+            apply: ({ value }) => {
+                expect.step(`customAction ${value}`);
+            },
+        },
+    });
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderNumberInput action="'customAction'"/>`,
+    });
+    await setupWebsiteBuilder(`
+        <div class="test-options-target">10</div>
+    `);
+    await contains(":iframe .test-options-target").click();
+    await contains(".options-container input").fill("3 4 5 ", { instantly: true });
+    expect.verifySteps(["customAction 3 4 5", "customAction 3 4 5"]); // input, change
+    expect(".options-container input").toHaveValue("3 4 5");
+});

--- a/addons/html_builder/static/tests/options/border_configurator_option.test.js
+++ b/addons/html_builder/static/tests/options/border_configurator_option.test.js
@@ -1,0 +1,58 @@
+import { expect, test } from "@odoo/hoot";
+import { addOption, defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
+import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
+import { xml } from "@odoo/owl";
+
+defineWebsiteModels();
+
+test("empty border input is treated as 0", async () => {
+    patchWithCleanup(BorderConfigurator.prototype, {
+        hasBorder(editingElement) {
+            const styleActionValue = this.env.editor.shared.builderActions
+                .getAction("styleAction")
+                .getValue({
+                    editingElement,
+                    param: {
+                        mainParam: this.getStyleActionParam("width"),
+                    },
+                });
+            expect(styleActionValue).toBe("0px");
+            const hasBorder = super.hasBorder(editingElement);
+            expect.step("hasBorder");
+            expect(hasBorder).toBe(false);
+            return hasBorder;
+        },
+    });
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BorderConfigurator label="'Border'"/>`,
+    });
+    await setupWebsiteBuilder(`<section class="test-options-target">Bordered block</section>`);
+    await contains(":iframe section").click();
+    expect.verifySteps(["hasBorder"]);
+    await contains(".options-container [data-label=Border] input").edit(" "); // .clear() doesn't trigger a rerender.
+    expect.verifySteps(["hasBorder"]);
+});
+test("hasBorder is true when multiple-value border starts by 0", async () => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BorderConfigurator label="'Border'"/>`,
+    });
+    await setupWebsiteBuilder(`<section class="test-options-target">Bordered block</section>`, {
+        loadIframeBundles: true,
+    });
+    await contains(":iframe section").click();
+    expect(".options-container [data-label=Border] input").toHaveValue("0");
+    expect(".options-container [data-label=Border] .o_we_color_preview").not.toBeVisible();
+    await contains(".options-container [data-label=Border] input").edit("0 3 4 4", {
+        confirm: "enter",
+    });
+    expect(".options-container [data-label=Border] .o_we_color_preview").toBeVisible();
+    expect(":iframe section").toHaveStyle({
+        "border-top-width": "0px",
+        "border-right-width": "3px",
+        "border-bottom-width": "4px",
+        "border-left-width": "4px",
+    });
+});


### PR DESCRIPTION
- If you write "0 3 " in a number input, the last space creates an empty string which causes an error.
- If there is no border, `hasBorder` returns an empty string which triggers an error on `.match()`.