### PR TITLE
fix BuilderColorPicker custom colors + chart option

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -38,7 +38,7 @@ export function useColorPickerBuilderComponent() {
         const { actionId, actionParam } = actionWithGetValue;
         const actionValue = getAction(actionId).getValue({ editingElement, param: actionParam });
         return {
-            selectedColor: actionValue,
+            selectedColor: actionValue || "#FFFFFF00",
         };
     }
     function getColor(colorValue) {

--- a/addons/html_builder/static/src/plugins/chart_option.js
+++ b/addons/html_builder/static/src/plugins/chart_option.js
@@ -53,10 +53,6 @@ export class ChartOption extends Component {
         return data;
     }
 
-    getColor(color) {
-        return this.props.getColor(color, this.env.getEditingElement());
-    }
-
     isPieChart(editingElement) {
         const isPieChart = this.props.isPieChart(editingElement);
         if (this.state && this.domState.isPieChart !== isPieChart) {
@@ -78,13 +74,16 @@ export class ChartOption extends Component {
         const colorSet = new Set();
         for (const dataset of data.datasets) {
             if (this.isPieChart(editingElement)) {
-                dataset.backgroundColor.forEach((color) => colorSet.add(this.getColor(color)));
-                dataset.borderColor.forEach((color) => colorSet.add(this.getColor(color)));
+                dataset.backgroundColor.forEach((color) =>
+                    colorSet.add(this.props.getColor(color))
+                );
+                dataset.borderColor.forEach((color) => colorSet.add(this.props.getColor(color)));
             } else {
-                colorSet.add(this.getColor(dataset.backgroundColor));
-                colorSet.add(this.getColor(dataset.borderColor));
+                colorSet.add(this.props.getColor(dataset.backgroundColor));
+                colorSet.add(this.props.getColor(dataset.borderColor));
             }
         }
+        colorSet.delete(""); // No color, remove to avoid bugs.
         return colorSet;
     }
     /**

--- a/addons/html_builder/static/src/plugins/chart_option.xml
+++ b/addons/html_builder/static/src/plugins/chart_option.xml
@@ -34,7 +34,7 @@
     <table class="o_builder_matrix ms-3"
             t-on-mouseover="onTableMouseover"
             t-on-mouseout="onTableMouseoutOrFocusout"
-            t-on-focusin="onTableFocusin.bind(this)"
+            t-on-focusin="onTableFocusin"
             t-on-focusout="onTableMouseoutOrFocusout">
         <thead>
             <tr>
@@ -44,7 +44,7 @@
                         <BuilderTextInput
                             action="'updateDatasetLabel'"
                             actionParam="dataset.key"
-                            style="domState.isPieChart ? '' : ('border: 2px solid ' + getColor(dataset.backgroundColor) || getColor(dataset.borderColor))"/>
+                            style="domState.isPieChart ? '' : ('border: 2px solid ' + props.getColor(dataset.backgroundColor) || props.getColor(dataset.borderColor))"/>
                     </th>
                 </t>
 
@@ -65,8 +65,8 @@
                 </th>
 
                 <t t-foreach="domState.data.datasets" t-as="dataset" t-key="dataset.key">
-                    <t t-set="backgroundColor" t-value="getColor(dataset.backgroundColor[label_index])"/>
-                    <t t-set="borderColor" t-value="getColor(dataset.borderColor[label_index])"/>
+                    <t t-set="backgroundColor" t-value="props.getColor(dataset.backgroundColor[label_index])"/>
+                    <t t-set="borderColor" t-value="props.getColor(dataset.borderColor[label_index])"/>
                     <td>
                         <BuilderNumberInput
                             action="'updateDatasetValue'"
@@ -115,7 +115,7 @@
                 t-key="window.String(state.currentCell.datasetIndex) + window.String(state.currentCell.dataIndex)"
                 label="state.currentCell.backgroundLabel">
         <BuilderColorPicker
-            getUsedCustomColors="getColorPalette.bind(this)"
+            getUsedCustomColors.bind="getColorPalette"
             action="'colorChange'"
             actionParam="{
                 type: 'backgroundColor',
@@ -128,7 +128,7 @@
                 t-key="window.String(state.currentCell.datasetIndex) + window.String(state.currentCell.dataIndex)"
                 label="state.currentCell.borderLabel">
         <BuilderColorPicker
-            getUsedCustomColors="getColorPalette.bind(this)"
+            getUsedCustomColors.bind="getColorPalette"
             action="'colorChange'"
             actionParam="{
                 type: 'borderColor',

--- a/addons/html_builder/static/src/plugins/chart_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/chart_option_plugin.js
@@ -15,7 +15,7 @@ class ChartOptionPlugin extends Plugin {
                 selector: CHART_SELECTOR,
                 props: {
                     isPieChart: this.isPieChart,
-                    getColor: (color, editingElement) => this.getColor(color, editingElement),
+                    getColor: (color) => this.getColor(color),
                 },
             },
         ],
@@ -237,12 +237,9 @@ class ChartOptionPlugin extends Plugin {
                     const data = this.getData(editingElement);
                     if (this.isPieChart(editingElement)) {
                         // TODO: shouldn't getColor be done directly in BuilderColorPicker?
-                        return this.getColor(
-                            data.datasets[datasetIndex]?.[type][dataIndex],
-                            editingElement
-                        );
+                        return this.getColor(data.datasets[datasetIndex]?.[type][dataIndex]);
                     } else {
-                        return this.getColor(data.datasets[datasetIndex]?.[type], editingElement);
+                        return this.getColor(data.datasets[datasetIndex]?.[type]);
                     }
                 },
                 apply: ({ editingElement, value, param: { type, datasetIndex, dataIndex } }) => {
@@ -280,7 +277,7 @@ class ChartOptionPlugin extends Plugin {
         return Math.ceil(Math.max(...dataValues) / 5) * 5;
     }
 
-    getColor(color, editingElement) {
+    getColor(color) {
         if (!color) {
             return "";
         }
@@ -288,9 +285,7 @@ class ChartOptionPlugin extends Plugin {
             ? color
             : getCSSVariableValue(
                   color,
-                  this.document.defaultView.getComputedStyle(
-                      editingElement.ownerDocument.documentElement
-                  )
+                  this.document.defaultView.getComputedStyle(this.document.documentElement)
               );
     }
 

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
@@ -131,3 +131,33 @@ test("should revert preview on escape", async () => {
     await press("escape");
     expect(":iframe .test-options-target").toHaveStyle({ "background-color": "rgba(0, 0, 0, 0)" });
 });
+
+test("should apply transparent color if no color is defined", async () => {
+    addActionOption({
+        customAction: {
+            getValue: ({ editingElement }) => {
+                expect.step("getValue");
+                return editingElement.dataset.color;
+            },
+            apply: ({ editingElement, value }) => {
+                editingElement.dataset.color = value;
+            },
+        },
+    });
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker action="'customAction'"/>`,
+    });
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+    await contains(":iframe .test-options-target").click();
+    expect(".options-container").toBeDisplayed();
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    await contains(".o-overlay-item button:contains('Custom')").click();
+    expect.verifySteps(["getValue"]);
+    expect(".o-overlay-item .o_hex_input").toHaveValue("#FFFFFF");
+    expect(":iframe .test-options-target").not.toHaveAttribute("data-color");
+    await contains(".o-overlay-item .o_color_pick_area").click({ top: "50%", left: "50%" });
+    expect(".o-overlay-item .o_hex_input").not.toHaveValue("#FFFFFF");
+    expect(":iframe .test-options-target").toHaveAttribute("data-color");
+    expect.verifySteps(["getValue"]);
+});


### PR DESCRIPTION
The ColorPicker needs a default value (set to transparent #FFFFFF00) when no color is set.