### PR TITLE
shadow option: fix svgs buttons

### DIFF
--- a/addons/html_builder/static/img/options/shadow_in.svg
+++ b/addons/html_builder/static/img/options/shadow_in.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="23" height="12" viewBox="0 0 23 12">
+  <g fill="none" fill-rule="evenodd" class="symbols">
+    <g class="3_buttons_shadow" transform="translate(-142 -5)">
+      <g class="shadow_in_s" transform="translate(142 5)">
+        <rect width="23" height="12" class="rectangle"/>
+        <path fill="#D9D9D9" d="M6.5 9.5V3H17l2-3h1v12H3v-1l3.5-1.5z" class="o_graphic"/>
+        <polygon fill="rgba(217, 217, 217, 0.5)" points="3.5 .5 17.5 .5 16.5 2 5.5 2 5.5 9 3.5 10" class="o_subdle"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/addons/html_builder/static/img/options/shadow_out.svg
+++ b/addons/html_builder/static/img/options/shadow_out.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="23" height="12" viewBox="0 0 23 12">
+  <g fill="none" fill-rule="evenodd" class="symbols">
+    <g class="3_buttons_shadow" transform="translate(-185 -5)">
+      <g class="shadow_out_s" transform="translate(185 5)">
+        <rect width="23" height="12" class="rectangle"/>
+        <polygon fill="rgba(217, 217, 217, 0.5)" points="21 3.2 21 12 8.308 12 6 10.9 18.692 10.9 18.692 1" class="o_subdle"/>
+        <rect fill="#D9D9D9" width="15" height="10" x="2" class="o_graphic"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/addons/html_builder/static/src/plugins/shadow_option.xml
+++ b/addons/html_builder/static/src/plugins/shadow_option.xml
@@ -5,8 +5,8 @@
     <BuilderRow label.translate="Shadow">
        <BuilderButtonGroup action="'setShadowMode'">
          <BuilderButton actionParam="'none'" id="'no_shadow'">None</BuilderButton>
-         <BuilderButton actionParam="'outset'" title.translate="Outset" iconImg="'/website/static/src/img/snippets_options/shadow_out.svg'"/>
-         <BuilderButton actionParam="'inset'" title.translate="Inset" iconImg="'/website/static/src/img/snippets_options/shadow_in.svg'"/>
+         <BuilderButton actionParam="'outset'" title.translate="Outset" iconImg="'/html_builder/static/img/options/shadow_out.svg'"/>
+         <BuilderButton actionParam="'inset'" title.translate="Inset" iconImg="'/html_builder/static/img/options/shadow_in.svg'"/>
        </BuilderButtonGroup>
     </BuilderRow>
     <BuilderContext t-if="!this.isActiveItem('no_shadow')">


### PR DESCRIPTION
Before this commit, svg for the shadow option were invisible:
![image](https://github.com/user-attachments/assets/8202091e-dd3b-4764-bd9f-04b32761f6be)

This commits restore the colors of the svg buttons:
![image](https://github.com/user-attachments/assets/a5c7ea8c-3a67-43cc-9255-4f16faa15002)
