### PR TITLE
[FIX] Firefox dirty mutations with ZWS

### DIFF
--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -93,7 +93,9 @@ export class MediaPlugin extends Plugin {
                 "contenteditable",
                 el.hasAttribute("contenteditable") ? el.getAttribute("contenteditable") : "false"
             );
-            if (isIconElement(el)) {
+            // Do not update the text if it's already OK to avoid recording a
+            // mutation on Firefox. (Chrome filters them out.)
+            if (isIconElement(el) && el.textContent !== "\u200B") {
                 el.textContent = "\u200B";
             }
         }


### PR DESCRIPTION
Firefox records a mutation when the textContent of an element is assigned to the same value as before, but Chrome doesn't. This leads to the builder marking many elements as dirty as soon as a single modification is done.
This commit is a quick fix for the observed errors. A deeper fix should come with task-4629669.