### PR TITLE
image_gallery_option: add spacing between images & fix builder_range style

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_range.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.xml
@@ -6,6 +6,7 @@
         <div class="d-flex flex-row flex-nowrap align-items-center" t-att-data-action-id="props.action" style="width: 60px">
             <input
             type="range"
+            class="p-0 border-0"
             t-att-min="props.min"
             t-att-max="props.max"
             t-att-step="props.step"

--- a/addons/html_builder/static/src/plugins/image_gallery_option.xml
+++ b/addons/html_builder/static/src/plugins/image_gallery_option.xml
@@ -7,12 +7,19 @@
         <BuilderButton type="'danger'" className="'flex-grow-1'" preview="false" title.translate="Remove all images" action="'removeAllImages'"> Remove all </BuilderButton>
     </BuilderRow>
     <BuilderRow label.translate="Mode">
+        <!-- TODO: No mode when implementing layout slideshow -->
         <BuilderSelect>
             <BuilderSelectItem action="'setImageGalleryLayout'" actionParam="'grid'">Grid</BuilderSelectItem>
             <BuilderSelectItem action="'setImageGalleryLayout'" actionParam="'masonry'">Masonry</BuilderSelectItem>
             <BuilderSelectItem action="'setImageGalleryLayout'" actionParam="'nomode'">Float</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
+    <!-- TODO: No image spacing when implementing layout slideshow -->
+    <BuilderRow
+        label.translate="Images Spacing">
+        <BuilderRange action="'setClassRange'" actionParam="['o_spc-none','o_spc-small','o_spc-medium','o_spc-big']" max="3"/>
+    </BuilderRow>
+
 </t>
 
 </templates>


### PR DESCRIPTION
[image_gallery_option: add spacing between images](https://github.com/odoo-dev/odoo/commit/be31d747fb59aa0507e8aeb28719392b2a44d7fa)

[builder_range: Fix style](https://github.com/odoo-dev/odoo/commit/4b0e551f42a805ea79c2e903a2b634f11915dff5) 

Before this commit, the start and end of the input range were not reachable due to its styling.
![image](https://github.com/user-attachments/assets/661fa00b-3974-4627-9463-d9d4a204421c)

Now, this issue is resolved, improving usability.
![image](https://github.com/user-attachments/assets/79510745-4d0f-4bcc-9538-d8d42da52b69)

