### PR TITLE
Map Option

### DIFF
--- a/addons/html_builder/static/src/core/plugins/editor.inside.scss
+++ b/addons/html_builder/static/src/core/plugins/editor.inside.scss
@@ -61,3 +61,7 @@ $-editor-messages-margin-x: 2%;
         width: 100%;
     }
 }
+
+.css_non_editable_mode_hidden {
+    display: block !important;
+}

--- a/addons/html_builder/static/src/plugins/map_option.inside.scss
+++ b/addons/html_builder/static/src/plugins/map_option.inside.scss
@@ -1,0 +1,5 @@
+.s_map {
+    iframe {
+        pointer-events: none;
+    }
+}

--- a/addons/html_builder/static/src/plugins/map_option.xml
+++ b/addons/html_builder/static/src/plugins/map_option.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+<t t-name="html_builder.mapOption">
+    <BuilderRow label.translate="Address" action="'mapUpdateSrc'" preview="false">       
+        <!-- TODO: .o_we_large -->                     
+        <BuilderTextInput  
+            dataAttributeAction="'mapAddress'"
+            placeholder.translate="e.g. Grand Place, Brussels"
+        />    
+    </BuilderRow>
+    <BuilderRow label.translate="Type">
+        <BuilderSelect dataAttributeAction="'mapType'" action="'mapUpdateSrc'" preview="false">
+            <BuilderSelectItem dataAttributeActionValue="'m'" title.translate="Road">Road</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'k'" title.translate="Satellite">Satellite</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+    <BuilderRow label.translate="Zoom">
+        <BuilderSelect dataAttributeAction="'mapZoom'" action="'mapUpdateSrc'" preview="false">
+            <BuilderSelectItem dataAttributeActionValue="'21'">2.5 m</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'20'">5 m</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'19'">10 m</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'18'">20 m</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'17'">50 m</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'16'">100 m</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'15'">200 m</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'14'">400 m</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'13'">1 km</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'12'">2 km</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'11'">4 km</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'10'">8 km</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'9'">15 km</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'8'">30 km</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'7'">50 km</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'6'">100 km</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'5'">200 km</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'4'">400 km</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'3'">1000 km</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'2'">2000 km</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+    <BuilderRow label.translate="Color Filter">
+        <BuilderColorPicker styleAction="'background-color'" applyTo="'.s_map_color_filter'"/>
+    </BuilderRow>
+    <BuilderRow label.translate="Description">
+        <BuilderCheckbox action="'mapDescription'"/>
+    </BuilderRow>
+</t>
+</templates>

--- a/addons/html_builder/static/src/plugins/map_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/map_option_plugin.js
@@ -1,0 +1,59 @@
+import { Plugin } from "@html_editor/plugin";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { generateGMapLink } from "@website/js/utils";
+
+class MapOptionPlugin extends Plugin {
+    static id = "mapOption";
+    resources = {
+        builder_options: [
+            {
+                template: "html_builder.mapOption",
+                selector: ".s_map",
+            },
+        ],
+        builder_actions: this.getActions(),
+    };
+
+    getActions() {
+        return {
+            mapUpdateSrc: {
+                apply: ({ editingElement }) => {
+                    const embedded = editingElement.querySelector(".s_map_embedded");
+
+                    if (editingElement.dataset.mapAddress) {
+                        const url = generateGMapLink(editingElement.dataset);
+                        if (url !== embedded.getAttribute("src")) {
+                            embedded.setAttribute("src", url);
+                        }
+                    } else {
+                        embedded.setAttribute("src", "about:blank");
+                    }
+                    embedded.classList.toggle("d-none", !editingElement.dataset.mapAddress);
+                    editingElement
+                        .querySelector(".missing_option_warning")
+                        .classList.toggle("d-none", !!editingElement.dataset.mapAddress);
+                },
+            },
+            mapDescription: {
+                isApplied: ({ editingElement }) =>
+                    editingElement.querySelector(".description") !== null,
+                apply: ({ editingElement }) => {
+                    editingElement.appendChild(
+                        document.createRange().createContextualFragment(
+                            `<div class="description">
+                                <strong>${_t("Visit us:")}</strong>
+                                ${_t("Our office is open Monday – Friday 8:30 a.m. – 4:00 p.m.")}
+                            </div>`
+                        )
+                    );
+                },
+                clean: ({ editingElement }) => {
+                    editingElement.querySelector(".description").remove();
+                },
+            },
+        };
+    }
+}
+
+registry.category("website-plugins").add(MapOptionPlugin.id, MapOptionPlugin);

--- a/addons/website/static/src/snippets/s_map/000.scss
+++ b/addons/website/static/src/snippets/s_map/000.scss
@@ -45,9 +45,3 @@ $s-map-desc-hover-alpha: 0.55 !default;
         pointer-events: none;
     }
 }
-
-.editor_enable .s_map {
-    iframe {
-        pointer-events: none;
-    }
-}


### PR DESCRIPTION
- Modified html_builder to add the classs "editor_enable" to the body of the document: this is necessary to prevent Google Maps from opening when clicking on the map in edit mode.
- Moved the css snippet regarding "editor_enable" in a the css file "map_option.inside.scss".
- Created the files "map_option.js" and "map_option.xml".