### PR TITLE
CoverProperties (.o_record_cover_container)

### DIFF
--- a/addons/html_builder/static/src/website_blog/blog_cover_properties_option.js
+++ b/addons/html_builder/static/src/website_blog/blog_cover_properties_option.js
@@ -1,0 +1,15 @@
+import { patch } from "@web/core/utils/patch";
+import { useDomState } from "@html_builder/core/utils";
+import { CoverPropertiesOption } from "../website_builder/plugins/options/cover_properties_option";
+
+patch(CoverPropertiesOption, {
+    template: "website_blog.BlogCoverPropertiesOption",
+});
+patch(CoverPropertiesOption.prototype, {
+    setup() {
+        super.setup();
+        this.blogState = useDomState((editingElement) => ({
+            isRegularCover: editingElement.classList.contains("o_wblog_post_page_cover_regular"),
+        }));
+    },
+});

--- a/addons/html_builder/static/src/website_blog/blog_cover_properties_option.xml
+++ b/addons/html_builder/static/src/website_blog/blog_cover_properties_option.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website_blog.BlogCoverPropertiesOption" t-inherit="html_builder.CoverPropertiesOption">
+    <xpath expr="//BuilderSelectItem[@classAction=&quot;'o_full_screen_height'&quot;]/span" position="attributes">
+        <attribute name="t-else"> <!-- Without the space just before this comment, t-else is not applied --></attribute>
+    </xpath>
+    <xpath expr="//BuilderSelectItem[@classAction=&quot;'o_half_screen_height'&quot;]/span" position="attributes">
+        <attribute name="t-else"> <!-- Without the space just before this comment, t-else is not applied --></attribute>
+    </xpath>
+    <xpath expr="//BuilderSelectItem[@classAction=&quot;'cover_auto'&quot;]/span" position="attributes">
+        <attribute name="t-else"> <!-- Without the space just before this comment, t-else is not applied --></attribute>
+    </xpath>
+    <xpath expr="//BuilderSelectItem[@classAction=&quot;'o_full_screen_height'&quot;]/span" position="before">
+        <span t-if="this.blogState.isRegularCover">Large</span>
+    </xpath>
+    <xpath expr="//BuilderSelectItem[@classAction=&quot;'o_half_screen_height'&quot;]/span" position="before">
+        <span t-if="this.blogState.isRegularCover">Medium</span>
+    </xpath>
+    <xpath expr="//BuilderSelectItem[@classAction=&quot;'cover_auto'&quot;]/span" position="before">
+        <span t-if="this.blogState.isRegularCover">Tiny</span>
+    </xpath>
+</t>
+
+</templates>

--- a/addons/html_builder/static/src/website_builder/plugins/options/cover_properties_option.js
+++ b/addons/html_builder/static/src/website_builder/plugins/options/cover_properties_option.js
@@ -1,0 +1,14 @@
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+
+export class CoverPropertiesOption extends BaseOptionComponent {
+    static template = "html_builder.CoverPropertiesOption";
+    static props = {};
+
+    setup() {
+        super.setup();
+        this.state = useDomState((editingElement) => ({
+            useTextAlign: editingElement.dataset.use_text_align === "True",
+            useSize: editingElement.dataset.use_size === "True",
+        }));
+    }
+}

--- a/addons/html_builder/static/src/website_builder/plugins/options/cover_properties_option.xml
+++ b/addons/html_builder/static/src/website_builder/plugins/options/cover_properties_option.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="html_builder.CoverPropertiesOption">
+
+    <BuilderRow label.translate="Background">
+        <!-- todo adapt when colorpicker is implemented: snippet_options_background_color_widget-->
+        <BuilderColorPicker title.translate="Color" styleAction="'background-color'"/>
+        <BuilderButtonGroup>
+            <BuilderButton action="'setCoverBackground'" actionParam="true" preview="false" title.translate="Image" className="'ms-auto fa fa-fw fa-camera'"/>
+            <BuilderButton action="'setCoverBackground'" actionParam="false" title.translate="None" className="'fa fa-fw fa-ban'"/>
+        </BuilderButtonGroup>
+    </BuilderRow>
+
+    <BuilderRow label.translate="Size" t-if="this.state.useSize">
+        <BuilderSelect>
+            <BuilderSelectItem classAction="'o_full_screen_height'"><span>Full Screen</span></BuilderSelectItem>
+            <BuilderSelectItem classAction="'o_half_screen_height'"><span>Half Screen</span></BuilderSelectItem>
+            <BuilderSelectItem classAction="'cover_auto'"><span>Fit text</span></BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+
+    <BuilderRow label.translate="Filter Intensity" applyTo="':scope > .o_record_cover_filter'">
+        <BuilderSelect>
+            <BuilderSelectItem styleAction="'opacity'" styleActionValue="'0'" classAction="''">None</BuilderSelectItem>
+            <BuilderSelectItem styleAction="'opacity'" styleActionValue="'0.2'" classAction="'oe_black'">Low</BuilderSelectItem>
+            <BuilderSelectItem styleAction="'opacity'" styleActionValue="'0.4'" classAction="'oe_black'">Medium</BuilderSelectItem>
+            <BuilderSelectItem styleAction="'opacity'" styleActionValue="'0.6'" classAction="'oe_black'">High</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+
+    <BuilderRow label.translate="Text Alignment" t-if="this.state.useTextAlign">
+        <BuilderSelect>
+            <BuilderSelectItem classAction="''">Left</BuilderSelectItem>
+            <BuilderSelectItem classAction="'text-center'">Centered</BuilderSelectItem>
+            <BuilderSelectItem classAction="'text-end'">Right</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+
+</t>
+
+</templates>

--- a/addons/html_builder/static/src/website_builder/plugins/options/cover_properties_option_plugin.js
+++ b/addons/html_builder/static/src/website_builder/plugins/options/cover_properties_option_plugin.js
@@ -1,0 +1,168 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { CoverPropertiesOption } from "./cover_properties_option";
+import { classAction } from "@html_builder/core/core_builder_action_plugin";
+import { loadImageInfo } from "@html_editor/utils/image_processing";
+import { rpc } from "@web/core/network/rpc";
+
+class CoverPropertiesOptionPlugin extends Plugin {
+    static id = "coverPropertiesOption";
+    static dependencies = ["builderActions", "media", "imagePostProcess"];
+    resources = {
+        builder_options: [
+            {
+                OptionComponent: CoverPropertiesOption,
+                selector: ".o_record_cover_container",
+                editableOnly: false,
+            },
+        ],
+        builder_actions: {
+            setCoverBackground: {
+                load: this.loadBackgroundImage.bind(this),
+                isApplied: ({ editingElement, param: { mainParam: setBackground } }) => {
+                    const bg =
+                        editingElement.querySelector(".o_record_cover_image").style.backgroundImage;
+                    return !setBackground === (!bg || bg === "none");
+                },
+                apply: this.applyBackgroundImage.bind(this),
+            },
+        },
+        before_save_handlers: this.savePendingBackgroundImage.bind(this),
+        clean_for_save_handlers: this.saveToDataset.bind(this),
+    };
+
+    loadBackgroundImage({ param: { mainParam: setBackground } }) {
+        if (!setBackground) {
+            return;
+        }
+        let resultPromise;
+        return this.dependencies.media
+            .openMediaDialog({
+                onlyImages: true,
+                save: (imageEl) => {
+                    resultPromise = (async () => {
+                        Object.assign(imageEl.dataset, await loadImageInfo(imageEl));
+                        let b64ToSave = false;
+                        if (
+                            imageEl.dataset.mimetypeBeforeConversion &&
+                            !["image/gif", "image/svg+xml", "image/webp"].includes(
+                                imageEl.dataset.mimetypeBeforeConversion
+                            )
+                        ) {
+                            // Convert to webp but keep original width.
+                            const updateImgAttributes =
+                                await this.dependencies.imagePostProcess.processImage(imageEl, {
+                                    formatMimetype: "image/webp",
+                                });
+                            updateImgAttributes();
+                            b64ToSave = true;
+                        }
+                        return { imageSrc: imageEl.getAttribute("src"), b64ToSave };
+                    })();
+                },
+            })
+            .then(() => resultPromise || { cancel: true });
+    }
+
+    applyBackgroundImage({ editingElement, loadResult: { imageSrc, b64ToSave, cancel } = {} }) {
+        if (cancel) {
+            return;
+        }
+        (imageSrc ? classAction.apply : classAction.clean)({
+            editingElement,
+            param: { mainParam: "o_record_has_cover" },
+        });
+
+        const bgEl = editingElement.querySelector(".o_record_cover_image");
+
+        (b64ToSave ? classAction.apply : classAction.clean)({
+            editingElement: bgEl,
+            param: { mainParam: "o_b64_cover_image_to_save" },
+        });
+
+        this.dependencies.builderActions.getAction("styleAction").apply({
+            editingElement: bgEl,
+            param: { mainParam: "background-image" },
+            value: imageSrc ? `url('${imageSrc}')` : "",
+        });
+    }
+
+    async savePendingBackgroundImage(editableEl = this.editable) {
+        const coverEl = editableEl.querySelector(".o_record_cover_container");
+        const bgEl = coverEl?.querySelector(".o_record_cover_image");
+        const bgImage = bgEl?.style.backgroundImage;
+        if (bgImage && bgEl.classList.contains("o_b64_cover_image_to_save")) {
+            const resModel = coverEl.dataset.resModel;
+            const resID = Number(coverEl.dataset.resId);
+            if (!resModel || !resID) {
+                throw new Error("There should be a model and id associated to the cover");
+            }
+
+            // Checks if the image is in base64 format for RPC call. Relying
+            // only on the presence of the class "o_b64_cover_image_to_save" is not
+            // robust enough.
+            const groups = bgImage.match(
+                /url\("data:(?<mimetype>.*);base64,(?<imageData>.*)"\)/
+            )?.groups;
+            if (groups?.imageData) {
+                const modelName = await this.services.website.getUserModelName(resModel);
+                const recordNameEl = bgEl
+                    .closest("body")
+                    .querySelector(
+                        `[data-oe-model="${resModel}"][data-oe-id="${resID}"][data-oe-field="name"]`
+                    );
+                const recordName = recordNameEl
+                    ? `'${recordNameEl.textContent.replaceAll("/", "")}'`
+                    : resID;
+                const attachment = await rpc("/web_editor/attachment/add_data", {
+                    name: `${modelName} ${recordName} cover image.${groups.mimetype.split("/")[1]}`,
+                    data: groups.imageData,
+                    is_image: true,
+                    res_model: "ir.ui.view",
+                });
+                bgEl.style.backgroundImage = `url(${attachment.image_src})`;
+            }
+            bgEl.classList.remove("o_b64_cover_image_to_save");
+        }
+    }
+
+    /**
+     * Updates the cover properties dataset used for saving.
+     */
+    saveToDataset({ root }) {
+        if (root.matches(".o_record_cover_container")) {
+            const bg = root.querySelector(".o_record_cover_image")?.style.backgroundImage || "";
+            root.dataset.bgImage = bg;
+
+            // TODO: `o_record_has_cover` should be handled using model field, not
+            // resize_class to avoid all of this.
+            let coverClass = ["o_full_screen_height", "o_half_screen_height", "cover_auto"].find(
+                (e) => root.classList.contains(e)
+            );
+            if (bg && bg !== "none") {
+                coverClass += " o_record_has_cover";
+            }
+            root.dataset.coverClass = coverClass;
+
+            root.dataset.textAlignClass =
+                ["text-center", "text-end"].find((e) => root.classList.contains(e)) || "";
+
+            root.dataset.filterValue =
+                root.querySelector(".o_record_cover_filter")?.style.opacity || 0.0;
+
+            root.dataset.bgColorClass = [...root.classList.values()]
+                .filter((e) => e.startsWith("bg-") || e.startsWith("o_cc"))
+                .join(" ");
+            if (root.style.backgroundImage) {
+                root.dataset.bgColorStyle = `background-color: rgba(0, 0, 0, 0); background-image: ${root.style.backgroundImage};`;
+            } else if (root.style.backgroundColor) {
+                root.dataset.bgColorStyle = `background-color: ${root.style.backgroundColor};`;
+            } else {
+                root.dataset.bgColorStyle = "";
+            }
+        }
+    }
+}
+registry
+    .category("website-plugins")
+    .add(CoverPropertiesOptionPlugin.id, CoverPropertiesOptionPlugin);

--- a/addons/html_builder/static/tests/website_builder/cover_properties_option.test.js
+++ b/addons/html_builder/static/tests/website_builder/cover_properties_option.test.js
@@ -1,0 +1,111 @@
+import { expect, test } from "@odoo/hoot";
+import {
+    defineModels,
+    contains,
+    models,
+    onRpc,
+    patchWithCleanup,
+    dataURItoBlob,
+} from "@web/../tests/web_test_helpers";
+import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
+import { animationFrame, click, waitFor } from "@odoo/hoot-dom";
+import { MockResponse } from "@web/../lib/hoot/mock/network";
+import { Builder } from "@html_builder/builder";
+
+defineWebsiteModels();
+
+class BlogPost extends models.Model {
+    _name = "blog.post";
+}
+defineModels([BlogPost]);
+
+const websiteServiceWithUserModelName = {
+    async getUserModelName() {
+        return "Blog Post";
+    },
+    // Minimal context to avoid crashes.
+    context: { showNewContentModal: false },
+};
+
+test("Add image as cover", async () => {
+    patchWithCleanup(Builder.prototype, {
+        setup() {
+            super.setup();
+            this.env.services.website = websiteServiceWithUserModelName;
+            this.websiteService = websiteServiceWithUserModelName;
+        },
+    });
+
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/png",
+            image_src: "/web/image/hoot.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
+
+    onRpc("/html_editor/get_image_info", () => ({
+        attachment: { id: 1 },
+        original: { id: 1, image_src: "/web/image/hoot.png", mimetype: "image/png" },
+    }));
+
+    onRpc(
+        "/web/image/hoot.png",
+        () => {
+            const mockResponse = new MockResponse({ ok: 200 });
+            const base64Image =
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYIIA" +
+                "A".repeat(1000); // converted image won't be used if original is not larger
+            const blob = dataURItoBlob(base64Image);
+            mockResponse.blob = () => blob;
+            return mockResponse;
+        },
+        { pure: true }
+    );
+
+    const blogPostTitle = "Title of Test Post";
+
+    await setupWebsiteBuilder(`
+        <div class="o_record_cover_container" data-res-model="blog.post" data-res-id="3">
+            <div class="o_record_cover_image"/>
+            <h1 data-oe-model="blog.post" data-oe-id="3" data-oe-field="name">${blogPostTitle}</h1>
+        </div>
+    `);
+
+    await contains(":iframe h1").click();
+    expect("[data-action-id='setCoverBackground'][data-action-param]").toHaveCount(1);
+    await contains("[data-action-id='setCoverBackground'][data-action-param]").click();
+    // We use "click" instead of contains.click because contains wait for the image to be visible.
+    // In this test we don't want to wait ~800ms for the image to be visible but we can still click on it
+    await click("img.o_we_attachment_highlight");
+    await animationFrame();
+    await waitFor(":iframe .o_record_cover_container.o_record_has_cover .o_record_cover_image");
+    expect(":iframe .o_record_cover_image").toHaveStyle({
+        "background-image": /url\("data:image\/webp;base64,(.*)"\)/,
+    });
+    expect(":iframe .o_record_cover_image").toHaveClass("o_b64_cover_image_to_save");
+
+    const expectedName = `Blog Post '${blogPostTitle}' cover image.webp`;
+    const encodedName = encodeURIComponent(expectedName).replace(/'/g, "%27");
+    onRpc("/web_editor/attachment/add_data", async (request) => {
+        expect.step("save attachment");
+        const { name } = (await request.json()).params;
+        expect(name).toBe(expectedName);
+        return { image_src: `/web/image/${encodedName}` };
+    });
+    onRpc("ir.ui.view", "save", ({ args }) => true);
+    onRpc("blog.post", "write", ({ args: [[id], { cover_properties }] }) => {
+        expect.step("save cover");
+        expect(id).toBe(3);
+        const { "background-image": bg, resize_class } = JSON.parse(cover_properties);
+        expect(bg).toBe(`url("/web/image/${encodedName}")`);
+        expect(resize_class.split(" ")).toInclude("o_record_has_cover");
+        return true;
+    });
+
+    await contains(".o-snippets-top-actions button[data-action='save']").click();
+    expect.verifySteps(["save attachment", "save cover"]);
+});

--- a/addons/html_builder/static/tests/website_builder/image_gallery.test.js
+++ b/addons/html_builder/static/tests/website_builder/image_gallery.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import { contains, dataURItoBlob, onRpc } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, dummyBase64Img, setupWebsiteBuilder } from "../website_helpers";
 import { animationFrame, click, queryAll, queryOne, waitFor } from "@odoo/hoot-dom";
 import { MockResponse } from "@web/../lib/hoot/mock/network";
@@ -179,13 +179,3 @@ test("Change gallery restore the container to the cloned equivalent image", asyn
     await contains(".o-snippets-top-actions .fa-repeat").click();
     expectOptionContainerToInclude(queryOne(":iframe .first_img"));
 });
-
-function dataURItoBlob(dataURI) {
-    const binary = atob(dataURI.split(",")[1]);
-    const array = [];
-    const mimeString = dataURI.split(",")[0].split(":")[1].split(";")[0];
-    for (let i = 0; i < binary.length; i++) {
-        array.push(binary.charCodeAt(i));
-    }
-    return new Blob([new Uint8Array(array)], { type: mimeString });
-}

--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -23,7 +23,8 @@ export class ImagePostProcessPlugin extends Plugin {
      *
      * @param {HTMLImageElement} img the image to which modifications are applied
      * @param {Object} newDataset an object containing the modifications to apply
-     * @returns {string} dataURL of the image with the applied modifications
+     * @returns {Function} callback that sets dataURL of the image with the
+     * applied modifications to `img` element
      */
     async processImage(img, newDataset = {}) {
         const processContext = {};

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2,7 +2,7 @@ import { CLIPBOARD_WHITELISTS } from "@html_editor/core/clipboard_plugin";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { manuallyDispatchProgrammaticEvent as dispatch, press, waitFor } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
-import { onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { dataURItoBlob, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { cleanLinkArtifacts, unformat } from "./_helpers/format";
 import { getContent, setSelection } from "./_helpers/selection";
@@ -3817,13 +3817,3 @@ describe("onDrop", () => {
         );
     });
 });
-
-function dataURItoBlob(dataURI) {
-    const binary = atob(dataURI.split(",")[1]);
-    const array = [];
-    const mimeString = dataURI.split(",")[0].split(":")[1].split(";")[0];
-    for (let i = 0; i < binary.length; i++) {
-        array.push(binary.charCodeAt(i));
-    }
-    return new Blob([new Uint8Array(array)], { type: mimeString });
-}

--- a/addons/web/static/tests/web_test_helpers.js
+++ b/addons/web/static/tests/web_test_helpers.js
@@ -168,6 +168,16 @@ export function preloadBundle(bundleName) {
     });
 }
 
+export function dataURItoBlob(dataURI) {
+    const binary = atob(dataURI.split(",")[1]);
+    const array = [];
+    const mimeString = dataURI.split(",")[0].split(":")[1].split(";")[0];
+    for (let i = 0; i < binary.length; i++) {
+        array.push(binary.charCodeAt(i));
+    }
+    return new Blob([new Uint8Array(array)], { type: mimeString });
+}
+
 export const fields = _fields;
 export const models = _models;
 


### PR DESCRIPTION
This option is a bit special, as it is saved with a different orm call

The previous implementation saves the widgets' state to the dataset of the cover's htmlelement on every edit. (in `addons/website/static/src/js/editor/snippets.options.js > options.registry.CoverProperties > _updateSavingDataset`) And on save, the dataset is used to write the model (in `addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js > WysiwygAdapterComponent > _saveCoverProperties`)

The new implementation has the same logic (save to dataset + write in orm on save). But has significant distinctions:
- the state is read just before saving, in a `clean_for_save_handlers`, instead of on every user changes
- the state is read from the dom of the html, instead of the widgets of the option
- the background-image is also passed by the dataset instead of read during save to be more similar to the others
- I relied on the save_plugin to only save once, instead of re-implementing the logic present in `_saveCoverProperties` that avoids several concurrent saves

#### Notes

- I copied the todo about `snippet_options_background_color_widget` from `background_option`. The ability to set the theme is missing. Thus I could not (manually) test if new values for theme are correctly saved, I could only test that the current one is saved