### PR TITLE
Stop interactions on exit

### DIFF
--- a/addons/html_builder/static/src/website_builder/plugins/edit_interaction_plugin.js
+++ b/addons/html_builder/static/src/website_builder/plugins/edit_interaction_plugin.js
@@ -21,6 +21,10 @@ export class EditInteractionPlugin extends Plugin {
         window.parent.document.dispatchEvent(new CustomEvent("edit_interaction_plugin_loaded"));
     }
 
+    destroy() {
+        this.stopInteractions(this.editable);
+    }
+
     updateEditInteraction({ detail: { websiteEditService } }) {
         this.websiteEditService = websiteEditService;
     }
@@ -30,6 +34,13 @@ export class EditInteractionPlugin extends Plugin {
             throw new Error("website edit service not loaded");
         }
         this.websiteEditService.update(element, true);
+    }
+
+    stopInteractions(element) {
+        if (!this.websiteEditService) {
+            throw new Error("website edit service not loaded");
+        }
+        this.websiteEditService.stop(element);
     }
 }
 


### PR DESCRIPTION
Interactions weren't stopped when exiting the builder. Done in before_save_handlers because in clean_for_save, elements are clones, so they're not recognized as the `interaction.el` and the interactions are not stopped.