### PR TITLE
[FIX] html_builder: resolve race condition in WebsiteBuilder edit flow

### DIFF
--- a/addons/html_builder/static/src/website_preview/website_builder_action.js
+++ b/addons/html_builder/static/src/website_preview/website_builder_action.js
@@ -119,6 +119,7 @@ export class WebsiteBuilder extends Component {
 
     async onEditPage() {
         document.querySelector(".o_main_navbar").setAttribute("style", "margin-top: -100%;");
+        await this.iframeLoaded;
         await this.loadAssetsEditBundle();
 
         setTimeout(() => {
@@ -143,6 +144,7 @@ export class WebsiteBuilder extends Component {
     onIframeLoad(ev) {
         history.pushState(null, "", ev.target.contentWindow.location.pathname);
         this.websiteService.pageDocument = this.websiteContent.el.contentDocument;
+        this.websiteContent.el.setAttribute("is-ready", "true");
         if (this.translation) {
             deleteQueryParam("edit_translations", this.websiteService.contentWindow, true);
         }


### PR DESCRIPTION
This PR addresses a race condition in the `onEditPage` method of the `WebsiteBuilder` component. The issue occurred when asynchronous operations (like iframe loading and asset bundle loading) were not completed before proceeding with the editing flow, leading to unpredictable behavior.

Changes:
- Added `await this.iframeLoaded` in `onEditPage` to ensure the iframe is fully loaded before loading assets or enabling editing.
- Set the `is-ready` attribute on the iframe element in `onIframeLoad` to mark it as ready once the iframe content is loaded.

These changes ensure that all dependencies are properly initialized before enabling the editing mode, resolving the race condition.