### PR TITLE
[FIX] html_builder: missing tooltip for Background>shape option

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_option.xml
@@ -20,6 +20,7 @@
                     preview="false"
                     id="'toggle_bg_shape_id'"
                     iconImg="'/html_builder/static/img/options/bg_shape.svg'"
+                    title="'Shape'"
                 />
             </t>
         </t>


### PR DESCRIPTION
This PR adds a missing tooltip for background shape option.