### PR TITLE
[IMP] html_builder: apply bg-color on connection shape

### DIFF
--- a/addons/html_builder/static/src/core/clone_plugin.js
+++ b/addons/html_builder/static/src/core/clone_plugin.js
@@ -13,7 +13,7 @@ export function isClonable(el) {
 
 export class ClonePlugin extends Plugin {
     static id = "clone";
-    static dependencies = ["history", "builder-options"];
+    static dependencies = ["history", "builder-options", "backgroundShapeOption"];
     static shared = ["cloneElement"];
 
     resources = {
@@ -28,9 +28,11 @@ export class ClonePlugin extends Plugin {
             // }
         ],
         on_cloned_handlers: [
-            // ({ cloneEl: cloneEl, originalEl: el }) => {
-            //     called after an element was cloned and inserted in the DOM
-            // }
+            ({ cloneEl: cloneEl, originalEl: el }) => {
+                // called after an element was cloned and inserted in the DOM
+                this.dependencies.backgroundShapeOption.handleBgColorChanged(cloneEl);
+                this.dependencies.backgroundShapeOption.handleBgColorChanged(el);
+            },
         ],
     };
 

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -6,7 +6,7 @@ import { closest, touching } from "@web/core/utils/ui";
 
 export class DropZonePlugin extends Plugin {
     static id = "dropzone";
-    static dependencies = ["history", "setup_editor_plugin"];
+    static dependencies = ["history", "setup_editor_plugin", "backgroundShapeOption"];
     static shared = [
         "displayDropZone",
         "dragElement",
@@ -307,6 +307,7 @@ export class DropZonePlugin extends Plugin {
             this.services.ui.block();
             await Promise.all(proms);
             this.services.ui.unblock();
+            this.dependencies.backgroundShapeOption.handleBgColorChanged(elementToAdd);
             scrollToWindow(elementToAdd, { behavior: "smooth", offset: 50 });
             this.dependencies.history.addStep();
         };

--- a/addons/html_builder/static/src/core/move_plugin.js
+++ b/addons/html_builder/static/src/core/move_plugin.js
@@ -73,6 +73,7 @@ export class MovePlugin extends Plugin {
         on_cloned_handlers: this.onCloned.bind(this),
         on_remove_handlers: this.onRemove.bind(this),
     };
+    static dependencies = ["backgroundShapeOption"];
 
     setup() {
         this.overlayTarget = null;
@@ -188,6 +189,7 @@ export class MovePlugin extends Plugin {
     onMoveClick(direction) {
         // TODO nav-item ? (=> specific plugin)
         // const isNavItem = this.overlayTarget.classList.contains("nav-item");
+        this.dependencies.backgroundShapeOption.handleSnippetMoved(this.overlayTarget);
         let hasMobileOrder = !!this.overlayTarget.style.order;
         const siblingEls = this.overlayTarget.parentNode.children;
 
@@ -217,7 +219,7 @@ export class MovePlugin extends Plugin {
                 this.overlayTarget
             );
         }
-
+        this.dependencies.backgroundShapeOption.handleBgColorChanged(this.overlayTarget);
         // TODO scroll (data-no-scroll)
         // TODO update invisible dom
     }

--- a/addons/html_builder/static/src/core/remove_plugin.js
+++ b/addons/html_builder/static/src/core/remove_plugin.js
@@ -35,7 +35,7 @@ const layoutElementsSelector = [".o_we_shape", ".o_we_bg_filter"].join(",");
 
 export class RemovePlugin extends Plugin {
     static id = "remove";
-    static dependencies = ["history", "builder-options"];
+    static dependencies = ["history", "builder-options", "backgroundShapeOption"];
     resources = {
         get_overlay_buttons: withSequence(4, {
             getButtons: this.getActiveOverlayButtons.bind(this),
@@ -96,6 +96,7 @@ export class RemovePlugin extends Plugin {
 
     removeElement(el) {
         this.updateContainers(el);
+        this.dependencies.backgroundShapeOption.handleSnippetMoved(el);
         this.removeCurrentTarget(el);
         this.dispatchTo("after_remove_handlers", el);
     }

--- a/addons/html_builder/static/src/plugins/background_option/background_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_option.xml
@@ -47,7 +47,7 @@
 
 <!-- TODO: handle bg_color_opt-->
 <t t-name="html_builder.BackgroundColorWidgetOption">
-    <BuilderColorPicker title.translate="Color" styleAction="'background-color'"/>
+    <BuilderColorPicker title.translate="Color" styleAction="'background-color'" action="'dispatchChange'"/>
 </t>
 
 </templates>

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option.js
@@ -19,6 +19,7 @@ export class BackgroundShapeOption extends BaseOptionComponent {
                 isAnimated: shapeInfo?.animated,
             };
         });
+        // this.backgroundShapePlugin.handleBgColorChanged(this.env.getEditingElements()[0]);
     }
     showBackgroundShapes() {
         this.backgroundShapePlugin.showBackgroundShapes(this.env.getEditingElements());

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option.xml
@@ -14,8 +14,8 @@
     </BuilderRow>
 
     <BuilderRow label.translate="Flip" level="2" t-if="isActiveItem('toggle_bg_shape_id')">
-        <BuilderButton icon="'oi-arrows-h'" preview="false" action="'flipShape'" actionParam="'x'"/>
-        <BuilderButton icon="'oi-arrows-v'" preview="false" action="'flipShape'" actionParam="'y'"/>
+        <BuilderButton icon="'oi-arrows-h'" action="'flipShape'" actionParam="'x'"/>
+        <BuilderButton icon="'oi-arrows-v'" action="'flipShape'" actionParam="'y'"/>
     </BuilderRow>
 
     <BuilderRow label.translate="Colors" level="2">
@@ -23,7 +23,7 @@
             <BuilderColorPicker action="'backgroundShapeColor'" actionParam="colorName"/>
         </t>
         <!-- TODO handle all the attributes -->
-        <BuilderColorPicker styleAction="'background-color'" applyTo="':scope > .o_we_shape'"/>
+        <!-- <BuilderColorPicker styleAction="'background-color'" applyTo="':scope > .o_we_shape'"/> -->
     </BuilderRow>
     <BuilderRow label.translate="Speed" level="2" t-if="state.isAnimated">
         <BuilderRange

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.js
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.js
@@ -11,6 +11,7 @@ export class ShapeSelector extends BaseOptionComponent {
         buttonWrapperClassName: { type: String, optional: true },
         imgThroughDiv: { type: Boolean, optional: true },
         getShapeUrl: { type: Function, optional: true },
+        shapeData: Object,
     };
 
     setup() {
@@ -18,7 +19,29 @@ export class ShapeSelector extends BaseOptionComponent {
         this.rootRef = useRef("root");
     }
     getShapeUrl(shapePath) {
-        return this.props.getShapeUrl ? this.props.getShapeUrl(shapePath) : getShapeURL(shapePath);
+        if (this.props.getShapeUrl) {
+            const baseUrl = this.props.getShapeUrl(shapePath);
+            if (baseUrl) {
+                const { colors, flip: flipProxy } = this.props.shapeData;
+                const flip = Array.from(flipProxy);
+                const urlMatch = baseUrl.match(/url\(["']?(.*?)["']?\)/);
+                const url = new URL(urlMatch[1], window.location.origin);
+
+                if (!Object.keys(colors).length == 0) {
+                    Object.entries(colors).forEach(([key, value]) => {
+                        url.searchParams.set(key, value);
+                    });
+                    if (flip.includes("y")) {
+                        url.searchParams.set("flip", "y");
+                    }
+                }
+                return `url("${url.toString()}")`;
+            } else {
+                return getShapeURL(shapePath);
+            }
+        } else {
+            return getShapeURL(shapePath);
+        }
     }
     scrollToShapes(id) {
         this.rootRef.el


### PR DESCRIPTION
Test PR to try to migrate an old task on the original website builder. 

The purpose of this commit is to apply a bg-color on 'connection' shape based on the next snippet bg-color to have a smooth transition. When the connection is flipped the bg-color will be determined by the previous snippet instead of the next.
The shape bg-color is recomputed when it's related snippet bg-color changes.