### PR TITLE
[FIX] html_builder: fix cookie bar incorrectly marked as outdated

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_option.xml
@@ -20,6 +20,7 @@
                     preview="false"
                     id="'toggle_bg_shape_id'"
                     iconImg="'/html_builder/static/img/options/bg_shape.svg'"
+                    title="'Shape'"
                 />
             </t>
         </t>

--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -291,6 +291,9 @@ export class SnippetModel extends Reactive {
      * @returns {Object}
      */
     getOriginalSnippet(snippetKey) {
+        if (!snippetKey) {
+            return;
+        }
         return [...this.snippetStructures, ...this.snippetInnerContents].find(
             (snippet) => snippet.name === snippetKey
         );


### PR DESCRIPTION
Before this PR, the cookie bar was incorrectly detected as outdated. This happened because the version check relied on the snippet name, but the cookie bar is a template, not a snippet. As a result, the snippet key was undefined, causing `getOriginalSnippet` to return an arbitrary snippet. This led to the cookie bar being falsely marked as outdated.

Along with that, tooltip was missing on one fo the options, i fixed that as well in commit[3f9504e66b3e8a0bf3103a204b1fc91a8897c76d]