### PR TITLE
[IMP] web: allow reading properties with `web_read`

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -242,6 +242,30 @@ class Base(models.AbstractModel):
                                 'model': co_record._name
                             }
 
+            elif field.type == "properties":
+                if not field_spec or 'fields' not in field_spec:
+                    continue
+
+                for values in values_list:
+                    old_values = values[field_name]
+                    next_values = []
+                    for property_name, spec in field_spec['fields'].items():
+                        property_ = next((p for p in old_values if p.get('name') == property_name), None)
+                        if not property_:
+                            continue
+
+                        if property_.get('type') == 'many2one' and property_.get('comodel'):
+                            record = self.env[property_['comodel']].with_context(field_spec.get('context')).browse(property_['value'][0])
+                            property_['value'] = record.web_read(spec['fields']) if 'fields' in spec else property_['value']
+
+                        if property_.get('type') == 'many2many' and property_.get('comodel'):
+                            records = self.env[property_['comodel']].with_context(field_spec.get('context')).browse([r[0] for r in property_['value']])
+                            property_['value'] = records.web_read(spec['fields']) if 'fields' in spec else property_['value']
+
+                        next_values.append(property_)
+
+                    values[field_name] = next_values
+
         return values_list
 
     def web_resequence(self, specification: dict[str, dict], field_name: str = 'sequence', offset: int = 0) -> list[dict]:

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -186,6 +186,72 @@ class PropertiesCase(TestPropertiesMixin):
             # missing 'type'
             self.message_1.attributes = [{'name': 'name', 'definition_changed': True}]
 
+    def test_properties_web_read(self):
+        """Test the web_read method when reading properties field."""
+        self.message_1.write({
+            'attributes': [{
+                'name': 'discussion_color_code',
+                'string': 'Test color code',
+                'type': 'char',
+                'default': 'blue',
+                'value': 'purple',
+                'definition_changed': True,
+            }, {
+                'name': 'selection',
+                'string': 'Selection',
+                'type': 'selection',
+                'selection': [['a', 'A'], ['b', 'B']],
+                'value': 'b',
+                'definition_changed': True,
+            }, {
+                'name': 'moderator_partner_id',
+                'string': 'Partner',
+                'type': 'many2one',
+                'comodel': 'test_new_api.partner',
+                'value': [self.partner.id, 'Bob'],
+                'definition_changed': True,
+            }, {
+                'name': 'moderator_partner_ids',
+                'string': 'Partners',
+                'type': 'many2many',
+                'comodel': 'test_new_api.partner',
+                'value': [[self.partner.id, 'Bob'], [self.partner_2.id, "Alice"]],
+                'definition_changed': True,
+            }],
+        })
+
+        result = self.message_1.web_read({
+            'attributes': {
+                'fields': {
+                    'moderator_partner_id': {'fields': {'name': {}}},
+                    'moderator_partner_ids': {'fields': {'name': {}}},
+                    'selection': {},
+                },
+            },
+        })
+        self.assertEqual(result[0]['attributes'], [{
+            'name': 'moderator_partner_id',
+            'string': 'Partner',
+            'type': 'many2one',
+            'comodel': 'test_new_api.partner',
+            'value': [{'id': self.partner.id, 'name': 'Test Partner Properties'}],
+        }, {
+            'name': 'moderator_partner_ids',
+            'string': 'Partners',
+            'type': 'many2many',
+            'comodel': 'test_new_api.partner',
+            'value': [
+                {'id': self.partner.id, 'name': 'Test Partner Properties'},
+                {'id': self.partner_2.id, 'name': 'Test Partner Properties 2'},
+            ],
+        }, {
+            'name': 'selection',
+            'string': 'Selection',
+            'type': 'selection',
+            'selection': [['a', 'A'], ['b', 'B']],
+            'value': 'b',
+        }])
+
     def test_properties_field_parameters_raised(self):
         # check that the keys not valid for the given type are raised
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Purpose
=======
For the AI module, when reading in batch, we use the `web_read` api.

For that purpose, we need to be able to use that method with the properties.

Task-4526274