### PR TITLE
Do not record dynamic snippet render in the history at window resize

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
@@ -2,7 +2,7 @@ import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 
 import { rpc } from "@web/core/network/rpc";
-import { listenSizeChange, utils as uiUtils } from "@web/core/ui/ui_service";
+import { utils as uiUtils } from "@web/core/ui/ui_service";
 import { uniqueId } from "@web/core/utils/functions";
 import { renderToFragment } from "@web/core/utils/render";
 import { verifyHttpsUrl } from "@website/utils/misc";
@@ -18,6 +18,7 @@ export class DynamicSnippet extends Interaction {
         "[data-url]": {
             "t-on-click": this.callToAction,
         },
+        _window: { "t-on-resize": this.throttled(this.render) },
         _root: {
             "t-att-class": () => ({
                 "o_dynamic_snippet_empty": !this.isVisible,
@@ -46,7 +47,6 @@ export class DynamicSnippet extends Interaction {
     }
 
     start() {
-        this.registerCleanup(listenSizeChange(this.render.bind(this)));
         this.render();
     }
 


### PR DESCRIPTION
The problem of doing the resize in `listenSizeChange` is that DOM modification are recorded on the history plugin