### PR TITLE
Ensure container selection updates when remove button is used

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -16,6 +16,7 @@ export class BuilderOptionsPlugin extends Plugin {
         "overlayButtons",
     ];
     static shared = [
+        "computeContainers",
         "getContainers",
         "updateContainers",
         "deactivateContainers",

--- a/addons/html_builder/static/src/core/remove_plugin.js
+++ b/addons/html_builder/static/src/core/remove_plugin.js
@@ -44,7 +44,7 @@ export class RemovePlugin extends Plugin {
             getButtons: this.getActiveOverlayButtons.bind(this),
         }),
     };
-    static shared = ["removeElement"];
+    static shared = ["removeElement", "removeElementAndUpdateContainers"];
 
     setup() {
         this.overlayTarget = null;
@@ -64,13 +64,13 @@ export class RemovePlugin extends Plugin {
             title: _t("Remove"),
             disabledReason,
             handler: () => {
-                this.removeElement(this.overlayTarget);
+                this.removeElementAndUpdateContainers(this.overlayTarget);
             },
         });
         return buttons;
     }
 
-    isEmptyAndRemovable(el, optionsTargetEls) {
+    isEmptyAndRemovable(el) {
         const childrenEls = [...el.children];
         // Consider a <figure> element as empty if it only contains a
         // <figcaption> element (e.g. when its image has just been
@@ -88,6 +88,10 @@ export class RemovePlugin extends Plugin {
                     el.matches(layoutElementsSelector)
                 ));
 
+        const optionsTargetEls = this.dependencies["builder-options"]
+            .computeContainers(el)
+            .map((e) => e.element);
+
         return (
             isEmpty &&
             !el.classList.contains("oe_structure") &&
@@ -99,10 +103,16 @@ export class RemovePlugin extends Plugin {
         );
     }
 
+    removeElementAndUpdateContainers(el) {
+        const elementToSelect = this.removeElement(el);
+        this.dependencies.history.addStep();
+        this.dependencies["builder-options"].updateContainers(elementToSelect);
+    }
+
     removeElement(el) {
-        this.updateContainers(el);
-        this.removeCurrentTarget(el);
+        const elementToSelect = this.removeCurrentTarget(el);
         this.dispatchTo("after_remove_handlers", el);
+        return elementToSelect;
     }
 
     removeCurrentTarget(toRemoveEl) {
@@ -145,9 +155,10 @@ export class RemovePlugin extends Plugin {
             }
         }
 
+        let nextElementToSelect;
         if (previousSiblingEl || nextSiblingEl) {
             // Activate the previous or next visible siblings if any.
-            this.updateContainers(previousSiblingEl || nextSiblingEl);
+            nextElementToSelect = previousSiblingEl || nextSiblingEl;
         } else {
             // Remove potential ancestors (like when removing the last column of
             // a snippet).
@@ -161,10 +172,11 @@ export class RemovePlugin extends Plugin {
                 }
                 parentEl = nextParentEl;
             }
-            this.updateContainers(parentEl);
+            nextElementToSelect = parentEl;
+
             optionsTargetEls = this.getOptionsContainersElements();
             if (this.isEmptyAndRemovable(parentEl, optionsTargetEls)) {
-                this.removeCurrentTarget(parentEl);
+                nextElementToSelect = this.removeCurrentTarget(parentEl);
             }
         }
 
@@ -174,6 +186,7 @@ export class RemovePlugin extends Plugin {
             .forEach((el) => (el.style.display = "none"));
         this.editable.querySelectorAll(".o_table_handler").forEach((el) => el.remove());
 
+        return nextElementToSelect;
         // TODO:
         // - trigger snippet_removed
         //   - display message in the editor if no snippets,
@@ -184,9 +197,5 @@ export class RemovePlugin extends Plugin {
 
     getOptionsContainersElements() {
         return this.dependencies["builder-options"].getContainers().map((option) => option.element);
-    }
-
-    updateContainers(el) {
-        this.dependencies["builder-options"].updateContainers(el);
     }
 }

--- a/addons/html_builder/static/src/sidebar/option_container.js
+++ b/addons/html_builder/static/src/sidebar/option_container.js
@@ -115,7 +115,9 @@ export class OptionsContainer extends BaseOptionComponent {
     // Actions of the buttons in the title bar.
     removeElement() {
         this.callOperation(() => {
-            this.env.editor.shared.remove.removeElement(this.props.editingElement);
+            this.env.editor.shared.remove.removeElementAndUpdateContainers(
+                this.props.editingElement
+            );
         });
     }
 

--- a/addons/html_builder/static/src/website_builder/plugins/options/card_image_option_plugin.js
+++ b/addons/html_builder/static/src/website_builder/plugins/options/card_image_option_plugin.js
@@ -23,7 +23,7 @@ const imageRelatedStyles = [
 
 class CardImageOptionPlugin extends Plugin {
     static id = "cardImageOption";
-    static dependencies = ["remove"];
+    static dependencies = ["remove", "history", "builder-options"];
     resources = {
         builder_actions: {
             setCoverImagePosition: {
@@ -40,9 +40,11 @@ class CardImageOptionPlugin extends Plugin {
             removeCoverImage: {
                 apply: ({ editingElement }) => {
                     const imageWrapper = editingElement.querySelector(".o_card_img_wrapper");
-                    this.dependencies.remove.removeElement(imageWrapper);
+                    const elementToSelect = this.dependencies.remove.removeElement(imageWrapper);
                     editingElement.classList.remove(...imageRelatedClasses);
                     imageRelatedStyles.forEach((prop) => editingElement.style.removeProperty(prop));
+                    this.dependencies.history.addStep();
+                    this.dependencies["builder-options"].updateContainers(elementToSelect);
                 },
             },
             addCoverImage: {

--- a/addons/html_builder/static/src/website_builder/plugins/options/navtabs_header_buttons_plugin.js
+++ b/addons/html_builder/static/src/website_builder/plugins/options/navtabs_header_buttons_plugin.js
@@ -63,7 +63,7 @@ class NavTabsOptionPlugin extends Plugin {
 
         this.showTab(nextActiveLinkEl, nextActivePaneEl);
         this.dependencies.remove.removeElement(activeLinkEl.parentElement);
-        this.dependencies.remove.removeElement(activePaneEl);
+        this.dependencies.remove.removeElementAndUpdateContainers(activePaneEl);
     }
 
     onNormalize(root) {

--- a/addons/html_builder/static/src/website_mass_mailing/mailing_list_subscribe_option_plugin.js
+++ b/addons/html_builder/static/src/website_mass_mailing/mailing_list_subscribe_option_plugin.js
@@ -78,7 +78,7 @@ class MailingListSubscribeOptionPlugin extends Plugin {
                         "/odoo/action-mass_mailing.action_view_mass_mailing_lists";
                 },
                 cancel: () => {
-                    this.dependencies.remove.removeElement(elementToAdd);
+                    this.dependencies.remove.removeElementAndUpdateContainers(elementToAdd);
                 },
             });
         }

--- a/addons/html_builder/static/tests/builder_option.test.js
+++ b/addons/html_builder/static/tests/builder_option.test.js
@@ -90,3 +90,34 @@ test("Container fallback to a valid ancestor if target dissapear", async () => {
     expectOptionContainerToInclude(editor, queryOne(":iframe .test-ancestor"));
     expect("[data-action-id='ancestorAction']").toHaveCount(1);
 });
+
+test("Remove element, undo should restore the selection to the removed element", async () => {
+    addActionOption({
+        customAction: {
+            apply: ({ editingElement }) => {
+                editingElement.remove();
+            },
+        },
+    });
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'">Test</BuilderButton>`,
+        title: "child",
+    });
+    const { getEditor } = await setupWebsiteBuilder(`
+        <div class="test-ancestor">
+            Hey I'm an ancestor
+            <div class="test-options-target target1">
+                Homepage
+            </div>
+        </div>
+
+    `);
+    const editor = getEditor();
+
+    await contains(":iframe .target1").click();
+    expectOptionContainerToInclude(editor, queryOne(":iframe .target1"));
+    await contains("[data-container-title='child'] button.fa-trash").click();
+    await contains(".o-snippets-top-actions .fa-undo").click();
+    expectOptionContainerToInclude(editor, queryOne(":iframe .target1"));
+});


### PR DESCRIPTION
### Before this commit:
- Select an element
- Remove it with the `fa-trash` button in the option container
- Undo the changes
- The element is restored but not the builder selection

