### PR TITLE
image plugin: make image preview on dblclick deactivable

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -62,7 +62,10 @@ export class Builder extends Component {
 
         const editorBus = new EventBus();
 
-        const mainPlugins = removePlugins([...MAIN_PLUGINS], ["PowerButtonsPlugin"]);
+        const mainPlugins = removePlugins(
+            [...MAIN_PLUGINS],
+            ["PowerButtonsPlugin", "DoubleClickImagePreviewPlugin"]
+        );
         const Plugins = [...mainPlugins, ...CORE_PLUGINS, ...(this.props.Plugins || [])];
         // TODO: maybe do a different config for the translate mode and the
         // "regular" mode.

--- a/addons/html_editor/static/src/main/media/dblclick_image_preview_plugin.js
+++ b/addons/html_editor/static/src/main/media/dblclick_image_preview_plugin.js
@@ -1,0 +1,14 @@
+import { Plugin } from "@html_editor/plugin";
+
+export class DoubleClickImagePreviewPlugin extends Plugin {
+    static id = "dblclickImagePreview";
+    static dependencies = ["image"];
+
+    setup() {
+        this.addDomListener(this.editable, "dblclick", (e) => {
+            if (e.target.tagName === "IMG") {
+                this.dependencies.image.previewImage();
+            }
+        });
+    }
+}

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -36,6 +36,7 @@ const IMAGE_SIZE = [
 export class ImagePlugin extends Plugin {
     static id = "image";
     static dependencies = ["history", "link", "powerbox", "dom", "selection"];
+    static shared = ["previewImage"];
     resources = {
         user_commands: [
             {
@@ -190,11 +191,6 @@ export class ImagePlugin extends Plugin {
 
     setup() {
         this.imageSize = reactive({ displayName: "Default" });
-        this.addDomListener(this.editable, "dblclick", (e) => {
-            if (e.target.tagName === "IMG") {
-                this.previewImage();
-            }
-        });
         this.addDomListener(this.editable, "pointerup", (e) => {
             if (e.target.tagName === "IMG") {
                 const [anchorNode, anchorOffset, focusNode, focusOffset] = boundariesOut(e.target);

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -65,6 +65,7 @@ import { VideoPlugin } from "@html_editor/others/embedded_components/plugins/vid
 import { QWebPlugin } from "./others/qweb_plugin";
 import { EditorVersionPlugin } from "./core/editor_version_plugin";
 import { ImagePostProcessPlugin } from "./main/media/image_post_process_plugin";
+import { DoubleClickImagePreviewPlugin } from "./main/media/dblclick_image_preview_plugin";
 
 /**
  * @typedef { Object } SharedMethods
@@ -151,6 +152,7 @@ export const MAIN_PLUGINS = [
     ImagePlugin,
     ImagePostProcessPlugin,
     ImageCropPlugin,
+    DoubleClickImagePreviewPlugin,
     LinkPlugin,
     LinkPastePlugin,
     FeffPlugin,


### PR DESCRIPTION
Before:
In an image gallery, double-clicking an image would open the media dialog (expected) and preview the image (unexpected)

Now:
Double-clicking an image only opens the media dialog—the preview no longer appears.