### PR TITLE
many2one ([data-oe-many2one-model]:not([data-oe-readonly]))

### DIFF
--- a/addons/html_builder/static/src/website_blog/author_avatar_many2one_plugin.js
+++ b/addons/html_builder/static/src/website_blog/author_avatar_many2one_plugin.js
@@ -1,0 +1,32 @@
+import { patch } from "@web/core/utils/patch";
+import { Many2OneOptionPlugin } from "../website_builder/plugins/options/many2one_option_plugin";
+
+patch(Many2OneOptionPlugin, {
+    dependencies: [...Many2OneOptionPlugin.dependencies, "history"],
+});
+
+patch(Many2OneOptionPlugin.prototype, {
+    getActions() {
+        const actions = super.getActions();
+        const newApply = (args) => {
+            actions.many2OneAction.apply(args);
+            const { editingElement, value } = args;
+            const { id } = JSON.parse(value);
+            const { oeId, oeField } = editingElement.dataset;
+
+            if (oeField === "author_id") {
+                for (const node of this.editable.querySelectorAll(
+                    `[data-oe-model="blog.post"][data-oe-id="${oeId}"][data-oe-field="author_avatar"]`
+                )) {
+                    node.querySelector("img").src = `/web/image/res.partner/${id}/avatar_1024`;
+                    // We do not want to save it to the server
+                    // TODO: a more general approach for editing records that are used at different parts of the page
+                    this.dependencies.history.ignoreDOMMutations(() => {
+                        node.classList.remove("o_dirty");
+                    });
+                }
+            }
+        };
+        return { ...actions, many2OneAction: { ...actions.many2OneAction, apply: newApply } };
+    },
+});

--- a/addons/html_builder/static/src/website_builder/plugins/options/many2one_option.js
+++ b/addons/html_builder/static/src/website_builder/plugins/options/many2one_option.js
@@ -1,0 +1,21 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+import { onWillStart } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+export class Many2OneOption extends BaseOptionComponent {
+    static template = "website_builder.Many2OneOption";
+    static props = [];
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        onWillStart(async () => {
+            const el = this.env.getEditingElement();
+            this.model = el.dataset.oeMany2oneModel;
+            [{ name: this.label }] = await this.orm.searchRead(
+                "ir.model",
+                [["model", "=", this.model]],
+                ["name"]
+            );
+        });
+    }
+}

--- a/addons/html_builder/static/src/website_builder/plugins/options/many2one_option.xml
+++ b/addons/html_builder/static/src/website_builder/plugins/options/many2one_option.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website_builder.Many2OneOption">
+    <BuilderRow label="label">
+        <BuilderMany2One action="'many2OneAction'" model="model" fields="['name']" allowUnselect="false"/>
+    </BuilderRow>
+</t>
+
+</templates>

--- a/addons/html_builder/static/src/website_builder/plugins/options/many2one_option_plugin.js
+++ b/addons/html_builder/static/src/website_builder/plugins/options/many2one_option_plugin.js
@@ -1,0 +1,77 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { Many2OneOption } from "./many2one_option";
+
+export class Many2OneOptionPlugin extends Plugin {
+    static id = "many2OneOption";
+    resources = {
+        builder_options: [
+            {
+                OptionComponent: Many2OneOption,
+                selector: "[data-oe-many2one-model]:not([data-oe-readonly])",
+                editableOnly: false,
+            },
+        ],
+        builder_actions: this.getActions(),
+    };
+    getActions() {
+        return {
+            many2OneAction: {
+                load: async ({ editingElement, value }) => {
+                    const { id } = JSON.parse(value);
+                    const { oeModel, oeId, oeField } = editingElement.dataset;
+                    const allContactOptions = new Set(
+                        this.editable
+                            .querySelectorAll(
+                                `[data-oe-model="${oeModel}"][data-oe-id="${oeId}"][data-oe-field="${oeField}"][data-oe-type="contact"]`
+                            )
+                            .values()
+                            .map((el) => el.dataset.oeContactOptions)
+                    );
+                    return Object.fromEntries(
+                        await Promise.all(
+                            allContactOptions
+                                .values()
+                                .map(async (contactOptions) => [
+                                    contactOptions,
+                                    await this.services.orm.call(
+                                        "ir.qweb.field.contact",
+                                        "get_record_to_html",
+                                        [[id]],
+                                        { options: JSON.parse(contactOptions) }
+                                    ),
+                                ])
+                        )
+                    );
+                },
+                apply: ({ editingElement, value, loadResult }) => {
+                    const { id, name } = JSON.parse(value);
+                    const { oeModel, oeId, oeField, oeContactOptions } = editingElement.dataset;
+
+                    for (const el of [
+                        ...this.editable.querySelectorAll(
+                            `[data-oe-model="${oeModel}"][data-oe-id="${oeId}"][data-oe-field="${oeField}"]:not([data-oe-contact-options='${oeContactOptions}'])`
+                        ),
+                        editingElement,
+                    ]) {
+                        el.dataset.oeMany2oneId = id;
+                        if (el.dataset.oeType === "contact") {
+                            el.replaceChildren(
+                                ...new DOMParser().parseFromString(
+                                    loadResult[el.dataset.oeContactOptions],
+                                    "text/html"
+                                ).body.childNodes
+                            );
+                        } else {
+                            el.textContent = name;
+                        }
+                    }
+                },
+                getValue: ({ editingElement }) =>
+                    JSON.stringify({ id: parseInt(editingElement.dataset.oeMany2oneId) }),
+            },
+        };
+    }
+}
+
+registry.category("website-plugins").add(Many2OneOptionPlugin.id, Many2OneOptionPlugin);

--- a/addons/html_builder/static/tests/website_builder/many2one_option.test.js
+++ b/addons/html_builder/static/tests/website_builder/many2one_option.test.js
@@ -1,0 +1,41 @@
+import { expect, test } from "@odoo/hoot";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
+
+defineWebsiteModels();
+
+test("Change contact oe-many2one-id of a blog author changes other instance of same contact and avatar", async () => {
+    onRpc(
+        "ir.qweb.field.contact",
+        "get_record_to_html",
+        ({ args: [[id]], kwargs }) => `<span>The ${kwargs.options.option} of ${id}</span>`
+    );
+
+    await setupWebsiteBuilder(`
+        <div>
+            <div data-oe-model="blog.post" data-oe-id="3" data-oe-field="author_avatar">
+                <img src="/web/image/res.partner/3/avatar_1024">
+            </div>
+            <span class="span-1" data-oe-model="blog.post" data-oe-id="3" data-oe-field="author_id" data-oe-type="contact" data-oe-many2one-id="3" data-oe-many2one-model="res.partner" data-oe-contact-options='{"option": "Name"}'>
+                <span>The Name of 3</span>
+            </span>
+            <span class="span-2" data-oe-model="blog.post" data-oe-id="3" data-oe-field="author_id" data-oe-type="contact" data-oe-many2one-id="3" data-oe-many2one-model="res.partner" data-oe-contact-options='{"option": "Address"}'>
+                <span>The Address of 3</span>
+            </span>
+            <span class="span-3" data-oe-model="blog.post" data-oe-id="6" data-oe-field="author_id" data-oe-type="contact" data-oe-many2one-id="3" data-oe-many2one-model="res.partner" data-oe-contact-options='{"option": "Address"}'>
+                <span>The Address of 3</span>
+            </span>
+            <span class="span-4" data-oe-model="blog.post" data-oe-id="3" data-oe-field="author_id" data-oe-type="other" data-oe-many2one-id="3" data-oe-many2one-model="res.partner">Other</span>
+        <div>
+    `);
+
+    await contains(":iframe .span-1").click();
+    expect("button.btn.dropdown").toHaveCount(1);
+    await contains("button.btn.dropdown").click();
+    await contains("span.o-dropdown-item.dropdown-item").click();
+    expect(":iframe span.span-1 > span").toHaveText("The Name of 1");
+    expect(":iframe span.span-2 > span").toHaveText("The Address of 1");
+    expect(":iframe span.span-3 > span").toHaveText("The Address of 3"); // author of other post is not changed
+    expect(":iframe span.span-4").toHaveText("Hermit");
+    expect(":iframe div > img").toHaveAttribute("src", "/web/image/res.partner/1/avatar_1024");
+});


### PR DESCRIPTION
This also fixes a regression introduced in aa9c71f689939c934039d4a0296637d59a51ebf9
that missed to update `_selectRecord` in `addons/website_blog/static/src/js/options.js`