### PR TITLE
[FIX] html_editor: close overlay+ link popover with iframe

### DIFF
--- a/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
+++ b/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
@@ -145,6 +145,7 @@ export class OverlayButtonsPlugin extends Plugin {
             this.refreshButtons();
             this.overlay.open({
                 target: optionWithOverlayButtons.element,
+                closeOnPointerdown: false,
                 props: {
                     state: this.state,
                 },

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -238,6 +238,27 @@ export class SelectionPlugin extends Plugin {
                 this.onKeyDownArrows(ev);
             }
         });
+
+        this.focusEditableDocument = true;
+        if (this.document !== document) {
+            const focusEditable = () => {
+                this.focusEditableDocument = true;
+            };
+            const unFocusEditable = (ev) => {
+                if (this.focusEditableDocument) {
+                    const preventClosing = ev.target?.closest?.("[data-prevent-closing-overlay]");
+                    if (preventClosing?.dataset?.preventClosingOverlay === "true") {
+                        return;
+                    }
+                    this.focusEditableDocument = false;
+                    this.dispatchTo("selection_leave_handlers");
+                }
+            };
+            this.addDomListener(this.document, "focus", focusEditable, { capture: true });
+            this.addDomListener(document, "focus", unFocusEditable, { capture: true });
+            this.addDomListener(this.document, "pointerdown", focusEditable, { capture: true });
+            this.addDomListener(document, "pointerdown", unFocusEditable, { capture: true });
+        }
     }
 
     selectAll() {
@@ -442,6 +463,8 @@ export class SelectionPlugin extends Plugin {
             documentSelection: documentSelection,
             editableSelection: editableSelection,
             documentSelectionIsInEditable: documentSelectionIsInEditable,
+            currentSelectionIsInEditable:
+                documentSelectionIsInEditable && this.focusEditableDocument,
         };
 
         Object.defineProperty(selectionData, "deepEditableSelection", {

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -27,7 +27,7 @@ export class HintPlugin extends Plugin {
                     text: this.config.placeholder,
                     target: (selectionData, editable) => {
                         if (
-                            selectionData.documentSelectionIsInEditable ||
+                            selectionData.currentSelectionIsInEditable ||
                             childNodes(editable).length !== 1
                         ) {
                             return;

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -6,7 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 import { LinkPopover } from "./link_popover";
 import { DIRECTIONS, leftPos, nodeSize, rightPos } from "@html_editor/utils/position";
 import { EMAIL_REGEX, URL_REGEX, cleanZWChars, deduceURLfromText } from "./utils";
-import { isVisible, isZwnbsp } from "@html_editor/utils/dom_info";
+import { isElement, isVisible, isZwnbsp } from "@html_editor/utils/dom_info";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { rpc } from "@web/core/network/rpc";
 import { memoize } from "@web/core/utils/functions";
@@ -469,6 +469,7 @@ export class LinkPlugin extends Plugin {
 
         const restoreSavePoint = this.dependencies.history.makeSavePoint();
         const props = {
+            document: this.document,
             linkElement,
             isImage: isImage,
             onApply: (...args) => {
@@ -613,9 +614,9 @@ export class LinkPlugin extends Plugin {
                 }
             }
         }
-        if (!selectionData.documentSelectionIsInEditable) {
-            const popoverEl = document.querySelector(".o-we-linkpopover");
-            if (popoverEl?.contains(selectionData.documentSelection?.anchorNode)) {
+        if (!selectionData.currentSelectionIsInEditable) {
+            const anchorNode = document.getSelection()?.anchorNode;
+            if (anchorNode && isElement(anchorNode) && anchorNode.closest(".o-we-linkpopover")) {
                 return;
             }
             this.linkInDocument = null;

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -7,6 +7,7 @@ import { cleanZWChars, deduceURLfromText } from "./utils";
 export class LinkPopover extends Component {
     static template = "html_editor.linkPopover";
     static props = {
+        document: { validate: (p) => p.nodeType === Node.DOCUMENT_NODE },
         linkElement: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
         onApply: Function,
         onChange: Function,
@@ -63,7 +64,8 @@ export class LinkPopover extends Component {
                 this.props.type ||
                 this.props.linkElement.className
                     .match(/btn(-[a-z0-9_-]*)(primary|secondary)/)
-                    ?.pop() || "",
+                    ?.pop() ||
+                "",
             isImage: this.props.isImage,
         });
 
@@ -82,7 +84,7 @@ export class LinkPopover extends Component {
                 this.loadAsyncLinkPreview();
             }
         });
-        useExternalListener(document, "pointerdown", (ev) => {
+        const onPointerDown = (ev) => {
             if (
                 this.editingWrapper?.el &&
                 !this.state.isImage &&
@@ -90,7 +92,12 @@ export class LinkPopover extends Component {
             ) {
                 this.onClickApply();
             }
-        });
+        };
+        useExternalListener(this.props.document, "pointerdown", onPointerDown);
+        if (this.props.document !== document) {
+            // Listen to pointerdown outside the iframe
+            useExternalListener(document, "pointerdown", onPointerDown);
+        }
     }
 
     onChange() {

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -107,9 +107,9 @@ export class PowerButtonsPlugin extends Plugin {
 
     updatePowerButtons() {
         this.powerButtonsContainer.classList.add("d-none");
-        const { editableSelection, documentSelectionIsInEditable } =
+        const { editableSelection, currentSelectionIsInEditable } =
             this.dependencies.selection.getSelectionData();
-        if (!documentSelectionIsInEditable) {
+        if (!currentSelectionIsInEditable) {
             return;
         }
         const block = closestBlock(editableSelection.anchorNode);

--- a/addons/html_editor/static/src/main/toolbar/toolbar.xml
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.xml
@@ -2,7 +2,7 @@
     <t t-name="html_editor.Toolbar">
         <div class="o-we-toolbar d-flex align-items-center m-0" t-att-class="props.class"
             style="overflow-x: auto; overflow-y:hidden" t-on-pointerdown.prevent=""
-            t-att-data-namespace="state.namespace">
+            t-att-data-namespace="state.namespace" data-prevent-closing-overlay="true">
             <t t-foreach="this.getFilteredButtonGroups()" t-as="buttonGroup" t-key="buttonGroup.id">
                 <span class="o-we-toolbar-vertical-separator"></span>
                 <div class="btn-group" t-att-name="buttonGroup.id">

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -134,6 +134,7 @@ export class ToolbarPlugin extends Plugin {
     static shared = ["getToolbarInfo"];
     resources = {
         selectionchange_handlers: this.handleSelectionChange.bind(this),
+        selection_leave_handlers: () => this.overlay.close(),
         step_added_handlers: () => this.updateToolbar(),
         user_commands: {
             id: "expandToolbar",
@@ -328,15 +329,14 @@ export class ToolbarPlugin extends Plugin {
                 this.isToolbarExpanded = false;
             }
             this.overlay.open({ props });
-        } else if (this.overlay.isOpen && !this.shouldPreventClosing(selectionData)) {
-            // Close toolbar
+        } else if (this.overlay.isOpen && !this.shouldPreventClosing()) {
             this.overlay.close();
         }
     }
 
     shouldBeVisible(selectionData) {
         const inEditable =
-            selectionData.documentSelectionIsInEditable &&
+            selectionData.currentSelectionIsInEditable &&
             !selectionData.documentSelectionIsProtected &&
             !selectionData.documentSelectionIsProtecting;
         if (!inEditable) {
@@ -358,10 +358,11 @@ export class ToolbarPlugin extends Plugin {
         return this.getFilterTraverseNodes().length;
     }
 
-    shouldPreventClosing(selectionData) {
-        const preventClosing = selectionData.documentSelection?.anchorNode?.closest?.(
-            "[data-prevent-closing-overlay]"
-        );
+    shouldPreventClosing() {
+        // Should check in the document with overlays.
+        const preventClosing = document
+            .getSelection()
+            ?.anchorNode?.closest?.("[data-prevent-closing-overlay]");
         return preventClosing?.dataset?.preventClosingOverlay === "true";
     }
 

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -195,6 +195,45 @@ test("Can change an emoji banner", async () => {
     expect("i.o_editor_banner_icon").toHaveText("😀");
 });
 
+test("toolbar should be closed when you open the emojipicker", async () => {
+    const { editor, el } = await setupEditor(`<p class="test">Test</p><p>a[]</p>`);
+    await insertText(editor, "/bannerinfo");
+    await press("enter");
+
+    // Move the selection to open the toolbar
+    const textNode = el.querySelector(".test").childNodes[0];
+    setSelection({ anchorNode: textNode, anchorOffset: 0, focusNode: textNode, focusOffset: 2 });
+    await waitFor(".o-we-toolbar");
+
+    await loader.loadEmoji();
+    await click("i.o_editor_banner_icon");
+    await waitFor(".o-EmojiPicker");
+    await animationFrame();
+    expect(".o-EmojiPicker").toHaveCount(1);
+    expect(".o-we-toolbar").toHaveCount(0);
+});
+
+test.tags("desktop", "iframe");
+test("toolbar should be closed when you open the emojipicker (iframe)", async () => {
+    const { editor, el } = await setupEditor(`<p class="test">Test</p><p>a[]</p>`, {
+        props: { iframe: true },
+    });
+    await insertText(editor, "/bannerinfo");
+    await press("enter");
+
+    // Move the selection to open the toolbar
+    const textNode = el.querySelector(".test").childNodes[0];
+    setSelection({ anchorNode: textNode, anchorOffset: 0, focusNode: textNode, focusOffset: 2 });
+    await waitFor(".o-we-toolbar");
+
+    await loader.loadEmoji();
+    await click(":iframe i.o_editor_banner_icon");
+    await waitFor(".o-EmojiPicker");
+    await animationFrame();
+    expect(".o-EmojiPicker").toHaveCount(1);
+    expect(".o-we-toolbar").toHaveCount(0);
+});
+
 test("add banner inside empty list", async () => {
     const { el, editor } = await setupEditor("<ul><li>[]<br></li></ul>");
     await insertText(editor, "/bannerinfo");

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -840,6 +840,15 @@ test("toolbar should close on open link popover", async () => {
     expect(".o-we-toolbar").toHaveCount(0);
 });
 
+test.tags("desktop", "iframe");
+test("toolbar should close on open link popover (iframe)", async () => {
+    await setupEditor("<p>[a]</p>", { props: { iframe: true } });
+    expect(".o-we-toolbar").toHaveCount(1);
+    await click(".o-we-toolbar .fa-link");
+    await waitForNone(".o-we-toolbar");
+    expect(".o-we-toolbar").toHaveCount(0);
+});
+
 test.tags("desktop");
 test("toolbar should close on edit link from preview", async () => {
     await setupEditor(`<p><a href="#">[a]</a></p>`);
@@ -921,6 +930,16 @@ test("toolbar shouldn't be visible if can_display_toolbar === false", async () =
     expect(".o-we-toolbar").toHaveCount(1);
     setContent(el, "<p>test[<img>]</p>");
     await animationFrame();
+    expect(".o-we-toolbar").toHaveCount(0);
+});
+
+test.tags("desktop", "iframe");
+test("toolbar should close when clicked outside the iframe", async () => {
+    await setupEditor("<p>[a]</p>", { props: { iframe: true } });
+    expect(".o-we-toolbar").toHaveCount(1);
+    // click outside the iframe
+    await click(".o-main-components-container");
+    await waitForNone(".o-we-toolbar");
     expect(".o-we-toolbar").toHaveCount(0);
 });
 


### PR DESCRIPTION
Before this commit, in website builder:
- overlay does not close when clicked outside the iframe (Toolbar, link popover)
- When you add a link with the link popover, it closes when you add the first char of the url.