### PR TITLE
[IMP] html_builder, *: fix default recipient email based on company email

### DIFF
--- a/addons/html_builder/static/src/website_builder/plugins/form/form_option_plugin.js
+++ b/addons/html_builder/static/src/website_builder/plugins/form/form_option_plugin.js
@@ -31,6 +31,7 @@ import {
     replaceFieldElement,
     setActiveProperties,
     setVisibilityDependency,
+    getParsedDataFor,
 } from "./utils";
 import { SyncCache } from "@html_builder/utils/sync_cache";
 import { _t } from "@web/core/l10n/translation";
@@ -215,6 +216,13 @@ export class FormOptionPlugin extends Plugin {
                         // 3. The default value (`defaultEmailToValue`)
                         if (value && value !== this.defaultEmailToValue) {
                             return value;
+                        }
+                        // Get the email_to value from the data-for attribute if it exists.
+                        // We use it if there is no value on the email_to input.
+                        const formId = el.id;
+                        const dataForValues = getParsedDataFor(formId, el.ownerDocument);
+                        if (dataForValues) {
+                            this.dataForEmailTo = dataForValues["email_to"];
                         }
                         return this.dataForEmailTo || this.defaultEmailToValue;
                     }

--- a/addons/html_builder/static/src/website_builder/plugins/form/form_option_plugin.js
+++ b/addons/html_builder/static/src/website_builder/plugins/form/form_option_plugin.js
@@ -221,10 +221,7 @@ export class FormOptionPlugin extends Plugin {
                         // We use it if there is no value on the email_to input.
                         const formId = el.id;
                         const dataForValues = getParsedDataFor(formId, el.ownerDocument);
-                        if (dataForValues) {
-                            this.dataForEmailTo = dataForValues["email_to"];
-                        }
-                        return this.dataForEmailTo || this.defaultEmailToValue;
+                        return dataForValues["email_to"] || this.defaultEmailToValue
                     }
                     if (value) {
                         return value;

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -36,7 +36,6 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
             'test@test.test',
             'The email was edited, the form should have been sent to the configured email')
 
-    @unittest.skip
     def test_website_form_contact_us_edition_no_email(self):
         self.env.company.email = 'website_form_contactus_edition_no_email@mail.com'
         self.start_tour('/odoo', 'website_form_contactus_edition_no_email', login="admin")


### PR DESCRIPTION
*: website
Before this PR, the default recipient email address in the website form options did not update based on the company's email. Instead, it always displayed a placeholder or default email.

This PR resolves the issue by allowing the website form to dynamically use the company email as the default `email_to`. If the company email is not available, it will gracefully fall back to the default address.

Additionally, this PR also enables the Tours used to test this functionality.