### PR TITLE
Fix BR in div with canvas

### DIFF
--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -326,7 +326,9 @@ export function isMediaElement(node) {
     return (
         isIconElement(node) ||
         (node.classList &&
-            (node.classList.contains("o_image") || node.classList.contains("media_iframe_video")))
+            (node.classList.contains("o_image") ||
+                node.classList.contains("media_iframe_video"))) ||
+        node.nodeName === "CANVAS"
     );
 }
 

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -305,4 +305,11 @@ describe("fillEmpty", () => {
         fillEmpty(div);
         expect(el.innerHTML).toBe('<div data-oe-protected="true" contenteditable="false"></div>');
     });
+    test("should not fill a block containing a canvas", async () => {
+        const { el } = await setupEditor("<div><canvas></canvas></div>");
+        expect(el.innerHTML).toBe('<div class="o-paragraph"><canvas></canvas></div>');
+        const div = el.firstChild;
+        fillEmpty(div);
+        expect(el.innerHTML).toBe('<div class="o-paragraph"><canvas></canvas></div>');
+    });
 });

--- a/addons/html_editor/static/tests/utils/dom_info.test.js
+++ b/addons/html_editor/static/tests/utils/dom_info.test.js
@@ -439,4 +439,9 @@ describe("isShrunkBlock", () => {
         const result = isShrunkBlock(hr);
         expect(result).toBe(false);
     });
+    test("should not consider a block containing a canvas as a shrunk block", () => {
+        const [canvas] = insertTestHtml("<canvas></canvas>");
+        const result = isShrunkBlock(canvas);
+        expect(result).toBe(false);
+    });
 });


### PR DESCRIPTION
In html_builder, adding a Countdown snippet triggers the usual normalization, which fills shrunk blocks with BRs.
This snippet contains DIVs having a CANVAS element as the single child, and such DIVs are mistakingly considered as shrunk blocks and thus have a BR appended to them.

Having a BR element in the referred DIVs allows the user to place the cursor there, which is undesired for the Countdown snippet.