### PR TITLE
Set contenteditable=false on .o_not_editable elements

### DIFF
--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -68,10 +68,13 @@ export class SetupEditorPlugin extends Plugin {
         );
     }
 
-    setContenteditable() {
+    setContenteditable(root = this.editable) {
         // TODO: Should be imp, we need to check _getReadOnlyAreas etc
         const editableEls = this.getEditableElements(".o_editable");
         editableEls.forEach((el) => el.setAttribute("contenteditable", !el.matches(":empty")));
+
+        const uneditableEls = root.querySelectorAll(".o_not_editable");
+        uneditableEls.forEach((el) => el.setAttribute("contenteditable", false));
     }
 
     /**


### PR DESCRIPTION
Such mechanism was present in the old editor (web_editor), but not yet on the new one (html_editor).
As it is considered a website/mass_mailing-only mechanism, it is now done by one of the plugins introduced by html_builder.

This is important for some snippets that are not meant to be editable via the editor.