### PR TITLE
[FIX] module status in new content modal

### DIFF
--- a/addons/website_blog/static/src/js/systray_items/new_content.js
+++ b/addons/website_blog/static/src/js/systray_items/new_content.js
@@ -1,4 +1,5 @@
-import { NewContentModal, MODULE_STATUS } from '@website/systray_items/new_content';
+import { NewContentModal } from '@html_builder/website_preview/new_content_modal';
+import { MODULE_STATUS } from "@html_builder/website_preview/new_content_element";
 import { patch } from "@web/core/utils/patch";
 
 patch(NewContentModal.prototype, {

--- a/addons/website_event/static/src/js/systray_items/new_content.js
+++ b/addons/website_event/static/src/js/systray_items/new_content.js
@@ -1,4 +1,5 @@
-import { NewContentModal, MODULE_STATUS } from '@website/systray_items/new_content';
+import { NewContentModal } from '@html_builder/website_preview/new_content_modal';
+import { MODULE_STATUS } from "@html_builder/website_preview/new_content_element";
 import { patch } from "@web/core/utils/patch";
 
 patch(NewContentModal.prototype, {

--- a/addons/website_forum/static/src/js/systray_items/new_content.js
+++ b/addons/website_forum/static/src/js/systray_items/new_content.js
@@ -1,4 +1,5 @@
-import { NewContentModal, MODULE_STATUS } from '@website/systray_items/new_content';
+import { NewContentModal } from '@html_builder/website_preview/new_content_modal';
+import { MODULE_STATUS } from "@html_builder/website_preview/new_content_element";
 import { patch } from "@web/core/utils/patch";
 
 patch(NewContentModal.prototype, {

--- a/addons/website_hr_recruitment/static/src/js/systray_items/new_content.js
+++ b/addons/website_hr_recruitment/static/src/js/systray_items/new_content.js
@@ -1,4 +1,5 @@
-import { NewContentModal, MODULE_STATUS } from '@website/systray_items/new_content';
+import { NewContentModal } from '@html_builder/website_preview/new_content_modal';
+import { MODULE_STATUS } from "@html_builder/website_preview/new_content_element";
 import { rpc } from "@web/core/network/rpc";
 import { patch } from "@web/core/utils/patch";
 

--- a/addons/website_livechat/static/src/js/systray_items/new_content.js
+++ b/addons/website_livechat/static/src/js/systray_items/new_content.js
@@ -1,4 +1,5 @@
-import { NewContentModal, MODULE_STATUS } from "@website/systray_items/new_content";
+import { NewContentModal } from '@html_builder/website_preview/new_content_modal';
+import { MODULE_STATUS } from "@html_builder/website_preview/new_content_element";
 import { patch } from "@web/core/utils/patch";
 
 patch(NewContentModal.prototype, {

--- a/addons/website_sale/static/src/js/systray_items/new_content.js
+++ b/addons/website_sale/static/src/js/systray_items/new_content.js
@@ -1,5 +1,6 @@
 import { patch } from "@web/core/utils/patch";
-import { MODULE_STATUS, NewContentModal } from '@website/systray_items/new_content';
+import { NewContentModal } from '@html_builder/website_preview/new_content_modal';
+import { MODULE_STATUS } from "@html_builder/website_preview/new_content_element";
 
 patch(NewContentModal.prototype, {
     setup() {

--- a/addons/website_slides/static/src/js/systray_items/new_content.js
+++ b/addons/website_slides/static/src/js/systray_items/new_content.js
@@ -1,4 +1,5 @@
-import { NewContentModal, MODULE_STATUS } from '@website/systray_items/new_content';
+import { NewContentModal } from '@html_builder/website_preview/new_content_modal';
+import { MODULE_STATUS } from "@html_builder/website_preview/new_content_element";
 import { patch } from "@web/core/utils/patch";
 
 patch(NewContentModal.prototype, {


### PR DESCRIPTION
Module status wasn't patched correctly because of importing the old content modal, and therefore modules weren't available even after installing them.