### PR TITLE
[FIX] html_builder: avoid crash when currentWebsite is not defined

### DIFF
--- a/addons/html_builder/static/src/website_preview/website_switcher_systray_item.xml
+++ b/addons/html_builder/static/src/website_preview/website_switcher_systray_item.xml
@@ -5,7 +5,7 @@
         <Dropdown menuClass="{'mw-100': false}">
             <button data-hotkey="w" class="mx-1 border-0">
                 <div class="d-none d-md-flex align-items-md-center">
-                    <span t-esc="websiteService.currentWebsite.name" class="me-2 text-truncate" style="max-width: 200px"/>
+                    <span t-esc="websiteService.currentWebsite?.name" class="me-2 text-truncate" style="max-width: 200px"/>
                     <i class="fa fa-caret-down"/>
                 </div>
                 <div class="d-md-none">

--- a/addons/html_builder/static/src/website_preview/website_systray_item.js
+++ b/addons/html_builder/static/src/website_preview/website_systray_item.js
@@ -50,8 +50,9 @@ export class WebsiteSystrayItem extends Component {
 
     get canEdit() {
         return (
-            this.website.currentWebsite.metadata.editable ||
-            this.website.currentWebsite.metadata.translatable
+            this.website.currentWebsite &&
+            (this.website.currentWebsite.metadata.editable ||
+                this.website.currentWebsite.metadata.translatable)
         );
     }
 


### PR DESCRIPTION
Steps to reproduce:
- Be connected as an admin, on the website homepage
- Click on "Website" in the admin navbar => crash.