### PR TITLE
Fix toolbar dropdowns close on click

### DIFF
--- a/addons/html_editor/static/src/main/align/align_selector.xml
+++ b/addons/html_editor/static/src/main/align/align_selector.xml
@@ -7,14 +7,16 @@
                 </span>
             </button>
             <t t-set-slot="content">
-                <t t-foreach="items" t-as="item" t-key="item_index">
-                    <button
-                        t-attf-class="btn btn-light fa fa-align-{{item.mode}}"
-                        t-att-class="{ active: item.mode === state.displayName }"
-                        t-on-click="() => this.onSelected(item)"
-                        t-on-pointerdown.prevent="() => {}"
-                    />
-                </t>
+                <div data-prevent-closing-overlay="true">
+                    <t t-foreach="items" t-as="item" t-key="item_index">
+                        <button
+                            t-attf-class="btn btn-light fa fa-align-{{item.mode}}"
+                            t-att-class="{ active: item.mode === state.displayName }"
+                            t-on-click="() => this.onSelected(item)"
+                            t-on-pointerdown.prevent="() => {}"
+                        />
+                    </t>
+                </div>
             </t>
         </Dropdown>
     </t>

--- a/addons/html_editor/static/src/main/chatgpt/language_selector.xml
+++ b/addons/html_editor/static/src/main/chatgpt/language_selector.xml
@@ -10,11 +10,13 @@
                 <t t-set="onClick" t-value="() => {}"/>
             </t>
             <t t-set-slot="content">
-                <t t-foreach="state.languages" t-as="language" t-key="language[0]">
-                    <DropdownItem class="'user-select-none'" onSelected="() => this.onSelected(language[1])">
-                        <div class="lang" t-esc="language[1]"/>
-                    </DropdownItem>
-                </t>
+                <div data-prevent-closing-overlay="true">
+                    <t t-foreach="state.languages" t-as="language" t-key="language[0]">
+                        <DropdownItem class="'user-select-none'" onSelected="() => this.onSelected(language[1])">
+                            <div class="lang" t-esc="language[1]"/>
+                        </DropdownItem>
+                    </t>
+                </div>
             </t>
         </Dropdown>
     </t>

--- a/addons/html_editor/static/src/main/font/font_family_selector.xml
+++ b/addons/html_editor/static/src/main/font/font_family_selector.xml
@@ -5,11 +5,15 @@
                 <span class="px-1" t-esc="props.currentFontFamily.displayName"/>
             </button>
             <t t-set-slot="content">
-                <t t-foreach="props.fontFamilyItems" t-as="item" t-key="item_index">
-                    <DropdownItem onSelected="() => props.onSelected(item)" t-on-pointerdown.prevent="() => {}">
-                        <t t-esc="item.name"/>
-                    </DropdownItem>
-                </t>
+                <div data-prevent-closing-overlay="true">
+                    <t t-foreach="props.fontFamilyItems" t-as="item" t-key="item_index">
+                        <DropdownItem
+                            attrs="{ name: item.nameShort }"
+                            onSelected="() => props.onSelected(item)" t-on-pointerdown.prevent="() => {}">
+                            <t t-esc="item.name"/>
+                        </DropdownItem>
+                    </t>
+                </div>
             </t>
         </Dropdown>
     </t>

--- a/addons/html_editor/static/src/main/font/font_selector.xml
+++ b/addons/html_editor/static/src/main/font/font_selector.xml
@@ -5,11 +5,15 @@
                 <span class="px-1" t-esc="state.displayName"/>
             </button>
             <t t-set-slot="content">
-                <t t-foreach="items" t-as="item" t-key="item_index">
-                    <DropdownItem onSelected="() => this.onSelected(item)" t-on-pointerdown.prevent="() => {}">
-                        <t t-esc="item.name"/>
-                    </DropdownItem>
-                </t>
+                <div data-prevent-closing-overlay="true">
+                    <t t-foreach="items" t-as="item" t-key="item_index">
+                        <DropdownItem
+                            attrs="{ name: item.tagName }"
+                            onSelected="() => this.onSelected(item)" t-on-pointerdown.prevent="() => {}">
+                            <t t-esc="item.name"/>
+                        </DropdownItem>
+                    </t>
+                </div>
             </t>
         </Dropdown>
     </t>

--- a/addons/html_editor/static/src/main/font/font_size_selector.js
+++ b/addons/html_editor/static/src/main/font/font_size_selector.js
@@ -116,7 +116,7 @@ export class FontSizeSelector extends Component {
         if (["Enter", "Tab"].includes(ev.key) && this.dropdown.isOpen) {
             this.dropdown.close();
         } else if (["ArrowUp", "ArrowDown"].includes(ev.key)) {
-            const fontSizeSelectorMenu = document.querySelector(".o_font_size_selector_menu");
+            const fontSizeSelectorMenu = document.querySelector(".o_font_size_selector_menu div");
             if (!fontSizeSelectorMenu) {
                 return;
             }

--- a/addons/html_editor/static/src/main/font/font_size_selector.xml
+++ b/addons/html_editor/static/src/main/font/font_size_selector.xml
@@ -5,11 +5,13 @@
                 <iframe t-ref="iframeContent" style="width: 4ch; height:100%;"/>
             </button>
             <t t-set-slot="content">
-                <t t-foreach="items" t-as="item" t-key="item_index">
-                    <DropdownItem onSelected="() => this.onSelected(item)" t-on-pointerdown.prevent="() => {}">
-                        <t t-esc="item.name"/>
-                    </DropdownItem>
-                </t>
+                <div data-prevent-closing-overlay="true">
+                    <t t-foreach="items" t-as="item" t-key="item_index">
+                        <DropdownItem onSelected="() => this.onSelected(item)" t-on-pointerdown.prevent="() => {}">
+                            <t t-esc="item.name"/>
+                        </DropdownItem>
+                    </t>
+                </div>
             </t>
         </Dropdown>
     </t>

--- a/addons/html_editor/static/src/main/list/list_selector.xml
+++ b/addons/html_editor/static/src/main/list/list_selector.xml
@@ -3,16 +3,18 @@
         <Dropdown menuClass="'o-we-toolbar-dropdown'">
             <button class="btn btn-light fa fa-list-ul" t-att-title="props.title" name="list_selector"/>
             <t t-set-slot="content" t-key="props.key.value">
-            <t t-set="activeMode" t-value="getActiveMode()"/>
-                <t t-foreach="props.getButtons()" t-as="button" t-key="button_index">
-                    <button
-                        t-att-title="button.description"
-                        t-att-name="button.id"
-                        t-attf-class="btn btn-light fa {{button.icon}}"
-                        t-att-class="{ active: activeMode === button.mode }"
-                        t-on-click="button.run"
-                    />
-                </t>
+                <div data-prevent-closing-overlay="true">
+                    <t t-set="activeMode" t-value="getActiveMode()"/>
+                    <t t-foreach="props.getButtons()" t-as="button" t-key="button_index">
+                        <button
+                            t-att-title="button.description"
+                            t-att-name="button.id"
+                            t-attf-class="btn btn-light fa {{button.icon}}"
+                            t-att-class="{ active: activeMode === button.mode }"
+                            t-on-click="button.run"
+                        />
+                    </t>
+                </div>
             </t>
         </Dropdown>
     </t>

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -453,7 +453,7 @@ test("toolbar works: ArrowUp/Down moves focus to font size dropdown", async () =
     expect(".o_font_size_selector_menu").toHaveCount(1);
     expect(getActiveElement()).toBe(inputEl);
 
-    const fontSizeSelectorMenu = queryOne(".o_font_size_selector_menu");
+    const fontSizeSelectorMenu = queryOne(".o_font_size_selector_menu div");
     await press("ArrowDown");
     await animationFrame();
     expect(".o_font_size_selector_menu").toHaveCount(1);


### PR DESCRIPTION
    Affected dropdown menus: list, text-align, font-family, font-style,
    font-size, translate.

    On mousedown on one of the dropdown items for the referred menus, the
    focus event on the main document would trigger the toolbar (and the
    dropdown menu) to close (see unFocusEditable @ SelectionPlugin's setup).

    Other than the undesidered effect of closing the toolbar, the mouseup
    and click events would not be triggered on the dropdown item, making it
    impossible to perform its action.