### PR TITLE
[FIX] use lastWebsiteId to have websiteSystrayItem consistently

### DIFF
--- a/addons/html_builder/static/src/website_preview/website_builder_action.js
+++ b/addons/html_builder/static/src/website_preview/website_builder_action.js
@@ -94,6 +94,8 @@ export class WebsiteBuilder extends Component {
             }
         });
         onMounted(() => {
+            this.addSystrayItems();
+            this.websiteService.useMysterious = true;
             const { enable_editor, edit_translations } = this.props.action.context.params || {};
             const edition = !!(enable_editor || edit_translations);
             if (edition) {
@@ -102,7 +104,6 @@ export class WebsiteBuilder extends Component {
         });
         this.publicRootReady = new Deferred();
         this.setIframeLoaded();
-        this.addSystrayItems();
         onWillDestroy(() => {
             registry.category("systray").remove("website.WebsiteSystrayItem");
             this.websiteService.useMysterious = false;

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -30,6 +30,7 @@ export const websiteService = {
     start(env, { orm, action, hotkey }) {
         let websites = [];
         let currentWebsiteId;
+        let currentWebsiteIdList = [];
         let currentMetadata = {};
         let fullscreen;
         let pageDocument;
@@ -80,13 +81,34 @@ export const websiteService = {
             Component: WebsiteLoader,
             props: { bus },
         });
+
+        function addWebsiteId(id) {
+            if (!currentWebsiteIdList.length) {
+                currentWebsiteId = id;
+            }
+            currentWebsiteIdList.push(id);
+        }
+
+        function removeWebsiteId() {
+            currentWebsiteIdList.shift();
+            if (currentWebsiteIdList.length) {
+                currentWebsiteId = currentWebsiteIdList[0];
+            } else {
+                currentWebsiteId = null;
+            }
+        }
+
         return {
             set currentWebsiteId(id) {
+                if (id === null) {
+                    removeWebsiteId();
+                    return;
+                }
                 if (id && id !== lastWebsiteId) {
                     invalidateSnippetCache = true;
                     lastWebsiteId = id;
                 }
-                currentWebsiteId = id;
+                addWebsiteId(id);
                 websiteSystrayRegistry.trigger('EDIT-WEBSITE');
             },
             /**


### PR DESCRIPTION
To replicate the situation when there's a conflict, install link tracker, go to website -> "site" dropdown -> link tracker -> click on navigation back button -> websiteSystrayItem is absent. This happens because of the race condition between component lifecycles - onWillStart is called before onWillDestroy when going back in history, which ends up in the currentWebsiteId being null and useMysterious being false.