### PR TITLE
[FIX] html_builder: restore carousel controls after edit

### DIFF
--- a/addons/html_builder/static/src/interactions/carousel.edit.js
+++ b/addons/html_builder/static/src/interactions/carousel.edit.js
@@ -76,6 +76,8 @@ export class CarouselEdit extends Interaction {
             indicatorEls.forEach((indicatorEl, i) =>
                 indicatorEl.setAttribute("data-bs-slide-to", i)
             );
+            this.el.querySelector(".carousel-control-prev")?.setAttribute("data-bs-slide", "prev");
+            this.el.querySelector(".carousel-control-next")?.setAttribute("data-bs-slide", "next");
         }
     }
 }


### PR DESCRIPTION
This commit fixes the following problem:
place a carousel element, click on an arrow, save => the arrow elements don't work anymore outside edit mode.