### PR TITLE
[REF] pos: real time syncing adaptation for preparation display

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -226,6 +226,13 @@ class PosConfig(models.Model):
         self.ensure_one()
         return self.trusted_config_ids
 
+    def notify_data_chnage(self, queue, login_number):
+        if not self:
+            # No config is available to notify in certain scenarios (e.g., pre-display)
+            return
+        for config in self._configs_that_share_data() + self:
+            config._notify('DATA_CHANGED', {'queue': queue, 'login_number': login_number, 'config_id': self.id})
+
     def flush(self, queue, login_number):
 
         def get_record(model, id):
@@ -261,8 +268,8 @@ class PosConfig(models.Model):
                         record.unlink()
                 case _:
                     pass
-        for config in self._configs_that_share_data() + self:
-            config._notify('DATA_CHANGED', {'queue': queue, 'login_number': login_number, 'config_id': self.id})
+
+        self.notify_data_chnage(queue, login_number)
         return id_updates
 
     @api.depends('payment_method_ids')

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -583,10 +583,8 @@ class PosSession(models.Model):
         self.ensure_one()
         # Even if this is called in `post_closing_cash_details`, we need to call this here too for case
         # where cash_control = False
-        open_order_ids = self.get_session_orders().filtered(lambda o: o.state == 'draft' and len(o.lines) > 0).ids
         check_closing_session = self._cannot_close_session(bank_payment_method_diffs)
         if check_closing_session:
-            check_closing_session['open_order_ids'] = open_order_ids
             return check_closing_session
 
         validate_result = self.action_pos_session_closing_control(bank_payment_method_diffs=bank_payment_method_diffs)
@@ -596,7 +594,6 @@ class PosSession(models.Model):
         if isinstance(validate_result, dict):
             # imbalance accounting entry
             return {
-                'open_order_ids': open_order_ids,
                 'successful': False,
                 'message': validate_result.get('name'),
                 'redirect': True
@@ -630,8 +627,6 @@ class PosSession(models.Model):
         self.ensure_one()
         check_closing_session = self._cannot_close_session()
         if check_closing_session:
-            open_order_ids = self.get_session_orders().filtered(lambda o: o.state == 'draft').ids
-            check_closing_session['open_order_ids'] = open_order_ids
             return check_closing_session
 
         if not self.cash_journal_id:

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -305,7 +305,7 @@ export class ClosePosPopup extends Component {
             cancel: async () => {
                 if (!response.redirect) {
                     const ordersDraft = this.pos.models["pos.order"].filter((o) => !o.finalized);
-                    await this.pos.deleteOrders(ordersDraft, response.open_order_ids);
+                    await this.pos.deleteOrders(ordersDraft);
                     this.closeSession();
                 }
             },

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -270,7 +270,7 @@ export class PosOrder extends Base {
         return this.lines.length;
     }
     recomputeOrderData() {
-        this.amount_paid = this.getTotalPaid() - this.getChange();
+        this.amount_paid = this.getTotalPaid();
         this.amount_tax = this.getTotalTax();
         this.amount_total = this.getTotalWithTax();
         this.amount_return = this.getChange();

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -253,7 +253,8 @@ export class PosData extends Reactive {
                     return;
                 }
                 const vals = models[modelName].getBy("uuid", ids[0]).raw;
-                this.indexedDB.create(modelName, [vals]);
+                // Skip IndexedDB calls if it hasn't been initialized (e.g., in prepDisplay, kiosk)
+                this.indexedDB?.create(modelName, [vals]);
                 this.queue.push(["CREATE", modelName, omit(vals, "id")]);
                 this.debouncedFlush();
             });
@@ -261,7 +262,7 @@ export class PosData extends Reactive {
                 if (!this.shouldSync || !vals) {
                     return;
                 }
-                this.indexedDB.update(modelName, id, prepareVals(vals));
+                this.indexedDB?.update(modelName, id, prepareVals(vals));
                 this.queue.push(["UPDATE", modelName, id, prepareVals(vals)]);
                 this.debouncedFlush();
             });
@@ -269,7 +270,7 @@ export class PosData extends Reactive {
                 if (!this.shouldSync) {
                     return;
                 }
-                this.indexedDB.delete(modelName, [id]);
+                this.indexedDB?.delete(modelName, [id]);
                 this.queue.push(["DELETE", modelName, id]);
                 this.debouncedFlush();
             });

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
@@ -32,7 +32,7 @@ patch(ActionpadWidget.prototype, {
         return hasChange;
     },
     async submitOrder() {
-        await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
+        await this.pos.sendOrderInPreparation(this.currentOrder);
         this.pos.showDefault();
     },
     hasQuantity(order) {

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.js
@@ -48,8 +48,7 @@ patch(ProductScreen.prototype, {
         return this.pos.categoryCount.slice(0, 3);
     },
     async submitOrder() {
-        await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
-        this.pos.addPendingOrder([this.currentOrder.id]);
+        await this.pos.sendOrderInPreparation(this.currentOrder);
         const page = this.pos.defaultPage;
         this.pos.navigate(page.page, page.params);
     },

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -116,13 +116,13 @@ patch(PosStore.prototype, {
         currentOrder.setCustomerCount(guestCount);
         return true;
     },
-    async sendOrderInPreparationUpdateLastChange(order, cancelled = false) {
+    async sendOrderInPreparation(order, opts = {}) {
         const currentPreset = order.preset_id;
         if (
             this.config.use_presets &&
             currentPreset?.use_guest &&
             !order.uiState.guestSetted &&
-            !cancelled
+            !opts.cancelled
         ) {
             const response = await this.setCustomerCount(order);
             if (!response) {
@@ -131,7 +131,7 @@ patch(PosStore.prototype, {
             order.uiState.guestSetted = true;
         }
 
-        if (!cancelled) {
+        if (!opts.cancelled) {
             order.cleanCourses();
             const firstCourse = order.getFirstCourse();
             if (firstCourse && !firstCourse.fired) {
@@ -140,7 +140,7 @@ patch(PosStore.prototype, {
             }
         }
 
-        return await super.sendOrderInPreparationUpdateLastChange(order, cancelled);
+        return await super.sendOrderInPreparation(order, opts);
     },
     handlePreparationHistory(srcPrep, destPrep, srcLine, destLine, qty) {
         const srcKey = srcLine.preparationKey;

--- a/addons/pos_self_order_adyen/controllers/main.py
+++ b/addons/pos_self_order_adyen/controllers/main.py
@@ -43,7 +43,6 @@ class PosSelfAdyenController(PosAdyenController):
                 'pos_order_id': order.id
             })
             order.action_pos_order_paid()
-            order._send_order()
 
         if order.config_id.self_ordering_mode == 'kiosk':
             order.config_id._notify('PAYMENT_STATUS', {


### PR DESCRIPTION
Fix errors in `flush` method:
- Skip `IndexedDB` calls if it hasn't been initialized (e.g., in prepDisplay, kiosk)
- Prevent removal of unsynced operations from the queue
- Fix notify error in prepDisplay due to missing config

Other Fixes:
- Fix combo line sequence: create parent line before child lines
- Fix incorrect `amount_paid` value when no payment is made.
---
Improve order preparation change handling:

- Ensure `last_order_preparation_change` is stored as a stringified JSON object in the `pos.order` field
- Use `sendOrderInPreparation` instead of `sendOrderInPreparationUpdateLastChange`

---
Remove unused methods and variable
- `_send_order`
- `sendOrderInPreparationUpdateLastChange`
- `open_order_ids`


Task: 4766738

Related: odoo-dev/enterprise#1087
