### PR TITLE
add post_undo and post_redo handlers to DisableSnippetsPlugin

### DIFF
--- a/addons/html_builder/static/src/core/disable_snippets_plugin.js
+++ b/addons/html_builder/static/src/core/disable_snippets_plugin.js
@@ -8,6 +8,8 @@ export class DisableSnippetsPlugin extends Plugin {
     resources = {
         after_remove_handlers: this.disableUndroppableSnippets.bind(this),
         on_mobile_preview_clicked: this.disableUndroppableSnippets.bind(this),
+        post_undo_handlers: this.disableUndroppableSnippets.bind(this),
+        post_redo_handlers: this.disableUndroppableSnippets.bind(this),
     };
 
     setup() {


### PR DESCRIPTION
We have an issue when we undo or redo in drop areas that can't have certain snippets (for example you can't add a pop-up to another pop-up, but can add some other snippets). 
For example, when we undo adding a pop-up snippet, we can't drop that same snippet again because the disableUndroppableSnippets function isn't being called again for the new drop area. 