### PR TITLE
Handle unobserved and system classes

### DIFF
--- a/addons/html_builder/static/tests/custom_tab/container_buttons.test.js
+++ b/addons/html_builder/static/tests/custom_tab/container_buttons.test.js
@@ -332,7 +332,7 @@ test("applying option container button should wait for actions in progress", asy
 
     undo(editor);
     expect(editable).toHaveInnerHTML(
-        `<div class="test-options-target customAction o-paragraph">plop</div>`
+        `<div class="test-options-target o-paragraph customAction">plop</div>`
     );
 
     undo(editor);

--- a/addons/html_builder/static/tests/options/top_menu_visibility_option.test.js
+++ b/addons/html_builder/static/tests/options/top_menu_visibility_option.test.js
@@ -83,7 +83,7 @@ test("undo hidden and come back to regular", async () => {
         openEditor: true,
         beforeWrapwrapContent: `<input type="hidden" class="o_page_option_data" autocomplete="off" data-oe-model="ir.ui.view" data-oe-id="543" data-oe-field="arch" data-oe-xpath="/data/xpath[13]/t[1]/t[1]/input[1]" name="header_visible" value="True">`,
         headerContent: `
-            <header id="top" data-anchor="true" data-name="Header" class="">   
+            <header id="top" data-anchor="true" data-name="Header">   
                     Menu Content
             </header>`,
     });

--- a/addons/html_builder/static/tests/overlay_buttons.test.js
+++ b/addons/html_builder/static/tests/overlay_buttons.test.js
@@ -292,7 +292,7 @@ test("Applying an overlay button action should wait for the actions in progress"
 
     undo(editor);
     expect(editable).toHaveInnerHTML(
-        `<div class="test-options-target customAction o-paragraph">plop</div>`
+        `<div class="test-options-target o-paragraph customAction">plop</div>`
     );
 
     undo(editor);

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -4,6 +4,7 @@ import { childNodes, descendants, getCommonAncestor } from "../utils/dom_travers
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { withSequence } from "@html_editor/utils/resource";
 import { Deferred } from "@web/core/utils/concurrency";
+import { toggleClass } from "@html_editor/utils/dom";
 
 /**
  * @typedef { import("./selection_plugin").EditorSelection } EditorSelection
@@ -47,6 +48,13 @@ import { Deferred } from "@web/core/utils/concurrency";
  * // todo change oldValue to attributeOldValue
  * @property { string } oldValue
  *
+ * @typedef { Object } HistoryMutationClassList
+ * @property { "classList" } type
+ * @property { string } id
+ * @property { string } className
+ * @property { boolean } value
+ * @property { boolean } oldValue
+ *
  * @typedef { Object } HistoryMutationAdd
  * @property { "add" } type
  * // todo change id to nodeId
@@ -73,7 +81,23 @@ import { Deferred } from "@web/core/utils/concurrency";
  * // todo change previousId to previousNodeId
  * @property { string } previousId
  *
- * @typedef { HistoryMutationCharacterData | HistoryMutationAttributes | HistoryMutationAdd | HistoryMutationRemove } HistoryMutation
+ * @typedef { HistoryMutationCharacterData | HistoryMutationAttributes | HistoryMutationClassList | HistoryMutationAdd | HistoryMutationRemove } HistoryMutation
+ *
+ * @typedef {Object} MutationRecordClassList
+ * @property { "classList" } type
+ * @property { Node } target
+ * @property { string } className
+ * @property { boolean } oldValue
+ * @property { boolean } newValue
+ *
+ * @typedef {Object} MutationRecordAttributes
+ * @property { "attributes" } type
+ * @property { Node } target
+ * @property { string } attributeName
+ * @property { string } oldValue
+ * @property { string } newValue
+ *
+ * @typedef { MutationRecord | MutationRecordClassList | MutationRecordAttributes } HistoryMutationRecord
  *
  * @typedef { Object } PreviewableOperation
  * @property { Function } apply
@@ -337,16 +361,25 @@ export class HistoryPlugin extends Plugin {
     }
 
     /**
-     * @param { MutationRecord[] } records
-     * @returns { MutationRecord[] } processed records
+     * @param { MutationRecord[] } mutationRecords
+     * @returns { HistoryMutationRecord[] }
      */
-    processNewRecords(records) {
-        records = this.filterMutationRecords(records);
-        if (!records.length) {
-            return [];
-        }
+    processNewRecords(mutationRecords) {
+        mutationRecords = this.filterMutationRecords(mutationRecords);
+        /** @type {HistoryMutationRecord[]} */
+        const records = mutationRecords
+            .flatMap((record) => this.transformRecord(record))
+            .filter((record) => !this.isSystemClassOrAttributeRecord(record))
+            .filter((record) => !this.isNoOpRecord(record));
         this.stageRecords(records);
         return records;
+    }
+
+    /**
+     * @param {HistoryMutationRecord} param0
+     */
+    isNoOpRecord({ type, oldValue, newValue }) {
+        return type === "attributes" && oldValue === newValue;
     }
 
     dispatchContentUpdated() {
@@ -404,75 +437,136 @@ export class HistoryPlugin extends Plugin {
     }
     /**
      * @param { MutationRecord[] } records
+     * @returns { MutationRecord[] }
      */
     filterMutationRecords(records) {
         this.dispatchTo("before_filter_mutation_record_handlers", records);
         for (const callback of this.getResource("savable_mutation_record_predicates")) {
             records = records.filter(callback);
         }
+        records = this.filterAttributeMutationRecords(records);
+        // @todo: this removes mutation records that change the node reference.
+        // Fix this!
+        records = records.filter((record) => !this.isSameTextContentMutation(record));
+        records = this.filterOutIntermediateStateMutationRecords(records);
+        return records;
+    }
 
-        // Save the first attribute in a cache to compare only the first
-        // attribute record of node to its latest state.
-        const attributeCache = new Map();
+    /**
+     * @param { MutationRecord[] } records
+     */
+    filterAttributeMutationRecords(records) {
+        return records.filter((record) => {
+            if (record.type !== "attributes") {
+                return true;
+            }
+            // Skip the attributes change on the dom.
+            if (record.target === this.editable) {
+                return false;
+            }
+            if (record.attributeName === "contenteditable") {
+                return false;
+            }
+            return true;
+        });
+    }
+
+    /**
+     * @todo: handle characterData mutations
+     *
+     * @param { MutationRecord[] } records
+     */
+    filterOutIntermediateStateMutationRecords(records) {
+        /** @type {Map<Node, Set<string>>} */
+        const nodeToAttributes = new Map();
         const filteredRecords = [];
-
         for (const record of records) {
-            if (record.type === "attributes") {
-                // Skip the attributes change on the dom.
-                if (record.target === this.editable) {
-                    continue;
-                }
-                if (record.attributeName === "contenteditable") {
-                    continue;
-                }
-                if (this.mutationFilteredAttributes.has(record.attributeName)) {
-                    continue;
-                }
-                // @todo @phoenix test attributeCache
-                attributeCache.set(record.target, attributeCache.get(record.target) || {});
-                // @todo @phoenix add test for mutationFilteredClasses.
-                if (record.attributeName === "class") {
-                    const classBefore = (record.oldValue && record.oldValue.split(" ")) || [];
-                    const classAfter =
-                        (record.target.className &&
-                            record.target.className.split &&
-                            record.target.className.split(" ")) ||
-                        [];
-                    const excludedClasses = [];
-                    for (const klass of classBefore) {
-                        if (!classAfter.includes(klass)) {
-                            excludedClasses.push(klass);
-                        }
-                    }
-                    for (const klass of classAfter) {
-                        if (!classBefore.includes(klass)) {
-                            excludedClasses.push(klass);
-                        }
-                    }
-                    if (
-                        excludedClasses.length &&
-                        excludedClasses.every((c) => this.mutationFilteredClasses.has(c))
-                    ) {
-                        continue;
-                    }
-                }
-                if (
-                    typeof attributeCache.get(record.target)[record.attributeName] === "undefined"
-                ) {
-                    const oldValue = record.oldValue === undefined ? null : record.oldValue;
-                    attributeCache.get(record.target)[record.attributeName] =
-                        oldValue !== record.target.getAttribute(record.attributeName);
-                }
-                if (!attributeCache.get(record.target)[record.attributeName]) {
-                    continue;
-                }
-            } else if (record.type === "childList" && this.isSameTextContentMutation(record)) {
+            if (record.type !== "attributes") {
+                filteredRecords.push(record);
                 continue;
             }
-            filteredRecords.push(record);
+            // Add entry for current target if not already present.
+            if (!nodeToAttributes.has(record.target)) {
+                nodeToAttributes.set(record.target, new Set());
+            }
+            const visitedAttributes = nodeToAttributes.get(record.target);
+            // Keep only the first mutation record for each attribute.
+            if (!visitedAttributes.has(record.attributeName)) {
+                filteredRecords.push(record);
+                visitedAttributes.add(record.attributeName);
+            }
         }
-        // @todo @phoenix allow an option to filter mutation records.
         return filteredRecords;
+    }
+
+    /**
+     * Class attribute records are expanded into multiple classList records.
+     * Attribute records have their oldValue normalized and newValue added to it.
+     * @todo: expand childList mutations to add/remove records.
+     *
+     * @param { MutationRecord } record
+     * @returns { HistoryMutationRecord | HistoryMutationRecord[] }
+     */
+    transformRecord(record) {
+        if (record.type === "attributes") {
+            if (record.attributeName === "class") {
+                return this.splitClassMutationRecord(record);
+            }
+            const oldValue = record.oldValue === undefined ? null : record.oldValue;
+            const newValue = record.target.getAttribute(record.attributeName);
+            const { type, target, attributeName } = record;
+            return { type, target, attributeName, oldValue, newValue };
+        }
+        return record;
+    }
+
+    /**
+     * Breaks down a class attribute mutation into individual class
+     * addition/removal records for more precise history tracking.
+     *
+     * @param { MutationRecord } record of type "attributes" with attributeName === "class"
+     * @returns { MutationRecordClassList[]}
+     */
+    splitClassMutationRecord(record) {
+        // oldValue can be nullish, or have extra spaces
+        const oldValue = record.oldValue?.split(" ").filter(Boolean);
+        const classesBefore = new Set(oldValue);
+        const classesAfter = new Set(record.target.classList);
+        // @todo: use Set.prototype.difference when it becomes widely available
+        const setDifference = (setA, setB) => {
+            const diff = new Set(setA);
+            setB.forEach((item) => diff.delete(item));
+            return diff;
+        };
+        const addedClasses = setDifference(classesAfter, classesBefore);
+        const removedClasses = setDifference(classesBefore, classesAfter);
+
+        /** @type {(className: string, operation: string) => MutationRecordClassList } */
+        const createClassRecord = (className, isAdded) => ({
+            type: "classList",
+            target: record.target,
+            className,
+            newValue: isAdded,
+            oldValue: !isAdded,
+        });
+        // Generate records for each class change
+        return [
+            ...[...addedClasses].map((cls) => createClassRecord(cls, true)),
+            ...[...removedClasses].map((cls) => createClassRecord(cls, false)),
+        ];
+    }
+
+    /**
+     * @param { HistoryMutationRecord } record
+     */
+    isSystemClassOrAttributeRecord(record) {
+        if (record.type === "attributes") {
+            return this.mutationFilteredAttributes.has(record.attributeName);
+        }
+        if (record.type === "classList") {
+            return this.mutationFilteredClasses.has(record.className);
+        }
+        return false;
     }
 
     /**
@@ -517,7 +611,7 @@ export class HistoryPlugin extends Plugin {
         this.currentStep.selection = this.serializeSelection(selection);
     }
     /**
-     * @param { MutationRecord[] } records
+     * @param { HistoryMutationRecord[] } records
      */
     stageRecords(records) {
         this.setIdOnRecords(records);
@@ -551,19 +645,29 @@ export class HistoryPlugin extends Plugin {
                     });
                     break;
                 }
+                case "classList": {
+                    this.currentStep.mutations.push({
+                        type: "classList",
+                        id: this.nodeToIdMap.get(record.target),
+                        className: record.className,
+                        oldValue: record.oldValue,
+                        value: record.newValue,
+                    });
+                    break;
+                }
                 case "attributes": {
                     this.currentStep.mutations.push({
                         type: "attributes",
                         id: this.nodeToIdMap.get(record.target),
                         attributeName: record.attributeName,
-                        value: record.target.getAttribute(record.attributeName),
                         oldValue: record.oldValue,
+                        value: record.newValue,
                     });
                     this.dispatchTo("attribute_change_handlers", {
                         target: record.target,
                         attributeName: record.attributeName,
                         oldValue: record.oldValue,
-                        value: record.target.getAttribute(record.attributeName),
+                        value: record.newValue,
                     });
                     break;
                 }
@@ -922,10 +1026,17 @@ export class HistoryPlugin extends Plugin {
                     }
                     break;
                 }
+                case "classList": {
+                    const node = this.idToNodeMap.get(mutation.id);
+                    if (node) {
+                        toggleClass(node, mutation.className, mutation.value);
+                    }
+                    break;
+                }
                 case "attributes": {
                     const node = this.idToNodeMap.get(mutation.id);
                     if (node) {
-                        let value = this.getAttributeValue(mutation.attributeName, mutation.value);
+                        let value = mutation.value;
                         for (const cb of this.getResource("attribute_change_processors")) {
                             value = cb(
                                 {
@@ -991,13 +1102,17 @@ export class HistoryPlugin extends Plugin {
                     }
                     break;
                 }
+                case "classList": {
+                    const node = this.idToNodeMap.get(mutation.id);
+                    if (node) {
+                        toggleClass(node, mutation.className, mutation.oldValue);
+                    }
+                    break;
+                }
                 case "attributes": {
                     const node = this.idToNodeMap.get(mutation.id);
                     if (node) {
-                        let value = this.getAttributeValue(
-                            mutation.attributeName,
-                            mutation.oldValue
-                        );
+                        let value = mutation.oldValue;
                         for (const cb of this.getResource("attribute_change_processors")) {
                             value = cb(
                                 {
@@ -1234,19 +1349,6 @@ export class HistoryPlugin extends Plugin {
         );
     }
 
-    /**
-     * @param { string } attributeName
-     * @param { string } value
-     */
-    getAttributeValue(attributeName, value) {
-        if (typeof value === "string" && attributeName === "class") {
-            value = value
-                .split(" ")
-                .filter((c) => !this.mutationFilteredClasses.has(c))
-                .join(" ");
-        }
-        return value;
-    }
     /**
      * @param { Node } node
      * @param { string } attributeName

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -218,10 +218,18 @@ export function cleanTrailingBR(el, predicates = []) {
     }
 }
 
-export function toggleClass(node, className) {
-    node.classList.toggle(className);
-    if (!node.className) {
-        node.removeAttribute("class");
+/**
+ * Wrapper for classList.toggle that removes the class attribute if the
+ * element has no class name after the toggle.
+ *
+ * @param {Element} element
+ * @param {string} className
+ * @param {boolean} [force]
+ */
+export function toggleClass(element, className, force) {
+    element.classList.toggle(className, force);
+    if (!element.className) {
+        element.removeAttribute("class");
     }
 }
 

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -251,11 +251,12 @@ describe("step", () => {
     });
 });
 
-describe("prevent system classes to be set from history", () => {
+describe("system classes and attributes", () => {
     class TestSystemClassesPlugin extends Plugin {
         static id = "testRenderClasses";
         resources = {
             system_classes: ["x"],
+            system_attributes: ["data-x"],
         };
     }
     const Plugins = [...MAIN_PLUGINS, TestSystemClassesPlugin];
@@ -273,22 +274,52 @@ describe("prevent system classes to be set from history", () => {
         });
     });
 
-    test("should prevent system classes to be added when adding 2 classes", async () => {
+    test("system classes are ignored by history (neither added or removed)", async () => {
+        const { editor, el } = await setupEditor(`<p>a[]</p>`, { config: { Plugins: Plugins } });
+        const p = editor.editable.querySelector("p");
+        p.className = "x y";
+        addStep(editor);
+        undo(editor);
+        expect(getContent(el)).toBe(`<p class="x">a[]</p>`);
+        redo(editor);
+        expect(getContent(el)).toBe(`<p class="x y">a[]</p>`);
+    });
+
+    test("system class with char mutation", async () => {
         await testEditor({
             contentBefore: `<p>a[]</p>`,
             stepFunction: async (editor) => {
                 const p = editor.editable.querySelector("p");
-                p.className = "x y";
+                p.className = "x";
+                p.textContent = "b";
+                editor.shared.selection.setCursorEnd(p);
                 addStep(editor);
                 undo(editor);
                 redo(editor);
             },
-            contentAfter: `<p class="y">a[]</p>`,
+            contentAfter: `<p class="x">b[]</p>`,
             config: { Plugins: Plugins },
         });
     });
 
-    test("should prevent system classes to be added in historyApply", async () => {
+    test("system attributes mutations are ignored by history", async () => {
+        const { editor, el } = await setupEditor(`<p>a[]</p>`, { config: { Plugins: Plugins } });
+        const p = editor.editable.querySelector("p");
+        p.setAttribute("data-x", "1");
+        p.setAttribute("data-y", "1");
+        addStep(editor);
+        undo(editor);
+        expect(getContent(el)).toBe(`<p data-x="1">a[]</p>`);
+        redo(editor);
+        expect(getContent(el)).toBe(`<p data-x="1" data-y="1">a[]</p>`);
+    });
+
+    // @todo: probably remove this test?
+    // We no longer store records of type "attributes" with attributeName: "class",
+    // as "classList" records are stored instead. And classList records with
+    // system classes are not stored, so such record would never be received to
+    // be applied.
+    test.skip("should prevent system classes to be added in historyApply", async () => {
         const { el, plugins } = await setupEditor(`<p>a</p>`, { config: { Plugins } });
         /** @type import("../src/core/history_plugin").HistoryPlugin") */
         const historyPlugin = plugins.get("history");
@@ -694,5 +725,28 @@ describe("custom mutation", () => {
 
         restoreSavePoint();
         expect.verifySteps(["custom apply", "custom revert", "custom apply", "custom revert"]);
+    });
+});
+
+describe("unobserved mutations", () => {
+    const withAddStep = (editor, callback) => {
+        callback();
+        editor.shared.history.addStep();
+    };
+
+    describe("classes", () => {
+        test("unobserved class mutations should not be affected by undo/redo", async () => {
+            const { editor } = await setupEditor(`<p>test</p>`);
+            /** @type {HTMLElement} */
+            const p = editor.editable.querySelector("p");
+            withAddStep(editor, () => p.classList.add("a"));
+            editor.shared.history.ignoreDOMMutations(() => p.classList.add("b"));
+            withAddStep(editor, () => p.classList.add("c"));
+            editor.shared.history.undo();
+            expect(p.className).toBe("a b");
+            editor.shared.history.ignoreDOMMutations(() => p.classList.remove("b"));
+            editor.shared.history.redo();
+            expect(p.className).toBe("a c");
+        });
     });
 });


### PR DESCRIPTION
- split classList mutations into individual records (one per class)

- handle system classes mutations (completely ignore them)
