### PR TITLE
[FIX] html_builder, website: use <svg> element for builder svg images

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_select.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.xml
@@ -6,7 +6,7 @@
         <!-- Render the SelectItem(s) into an invisible node to ensure the label of the
         button is being set. -->
         <div t-ref="root" class="w-100" style="overflow: hidden;">
-            <div t-att-class="'d-none ' + props.className" t-ref="content"><WithIgnoreItem><t t-slot="default" /></WithIgnoreItem></div>
+            <div inert="" class="h-0 w-0 overflow-hidden" t-att-class="props.className" t-ref="content"><WithIgnoreItem><t t-slot="default" /></WithIgnoreItem></div>
             <Dropdown state="this.dropdown">
                 <button class="btn btn-primary text-start o-dropdown-caret" t-ref="button" t-att-id="props.id"
                     style="width: 100%; overflow: hidden; text-overflow: ellipsis;">

--- a/addons/html_builder/static/src/core/img.js
+++ b/addons/html_builder/static/src/core/img.js
@@ -1,4 +1,25 @@
-import { Component, onWillStart, xml } from "@odoo/owl";
+import { Component, onWillStart, onWillUpdateProps, useEffect, useRef, xml } from "@odoo/owl";
+import { Cache } from "@web/core/utils/cache";
+
+const svgCache = new Cache(async (src) => {
+    let text;
+    try {
+        const response = await window.fetch(src);
+        text = await response.text();
+    } catch {
+        // In some tours, the tour finishes before the fetch is done
+        // and when a tour is finished, the python side will ask the
+        // browser to stop loading resources. This causes the fetch
+        // to fail and throw an error which crashes the test even
+        // though it completed successfully.
+        // So return an empty SVG to ensure everything completes
+        // correctly.
+        text = "<svg></svg>";
+    }
+    const parser = new window.DOMParser();
+    const xmlDoc = parser.parseFromString(text, "text/xml");
+    return xmlDoc.getElementsByTagName("svg")[0];
+}, JSON.stringify);
 
 export class Img extends Component {
     static props = {
@@ -8,9 +29,51 @@ export class Img extends Component {
         alt: { type: String, optional: true },
         attrs: { type: Object, optional: true },
     };
-    static template = xml`<img t-att-src="props.src" t-att-class="props.class" t-att-style="props.style" t-att-alt="props.alt" t-att="props.attrs"/>`;
+    static template = xml`
+        <svg t-if="isSvg(props.src)" t-ref="svg"
+             xmlns="http://www.w3.org/2000/svg"
+             t-att-width="svg.width"
+             t-att-viewBox="svg.viewBox"
+             t-att-fill="svg.fill"
+             class="hb-svg d-flex m-auto"
+             t-att-class="props.class"
+             t-att-style="props.style"
+             t-att="props.attrs"/>
+        <img t-else=""
+             t-att-src="props.src"
+             t-att-class="props.class"
+             t-att-style="props.style"
+             t-att-alt="props.alt"
+             t-att="props.attrs"/>
+        `;
+
     setup() {
-        onWillStart(async () => this.loadImage());
+        this.svgRef = useRef("svg");
+        this.svg = {};
+
+        onWillStart(async () => {
+            await this.handleImgLoad(this.props.src);
+        });
+        onWillUpdateProps(async (nextProps) => {
+            if (this.props.src !== nextProps.src) {
+                await this.handleImgLoad(nextProps.src);
+            }
+        });
+        useEffect(() => {
+            if (this.isSvg(this.props.src) && this.svg.children.length) {
+                // We can't use t-out with markup because it is parsed as HTML,
+                // but SVG need to be parsed as XML for all features to work.
+                this.svgRef.el.replaceChildren(...this.svg.children);
+            }
+        });
+    }
+
+    async handleImgLoad(src) {
+        if (this.isSvg(src)) {
+            this.svg = await this.getSvg();
+        } else {
+            await this.loadImage(src);
+        }
     }
 
     loadImage() {
@@ -20,5 +83,19 @@ export class Img extends Component {
             img.onerror = () => resolve({ status: "error" });
             img.src = this.props.src;
         });
+    }
+
+    isSvg(src) {
+        return src.split(".").pop() === "svg";
+    }
+
+    async getSvg() {
+        const svgEl = (await svgCache.read(this.props.src)).cloneNode(true);
+        return {
+            viewBox: svgEl.getAttribute("viewBox"),
+            width: svgEl.getAttribute("width") || "",
+            fill: svgEl.getAttribute("fill") || "",
+            children: svgEl.children,
+        };
     }
 }

--- a/addons/html_builder/static/src/sidebar/option_container.scss
+++ b/addons/html_builder/static/src/sidebar/option_container.scss
@@ -1,3 +1,17 @@
+@mixin hb-svg-icon(
+        $graphic: $o-we-sidebar-content-field-color,
+        $subdle: $o-we-sidebar-content-field-color,
+        $subdle-opacity: 0.5) {
+    .hb-svg {
+        .o_graphic {
+            fill: $graphic;
+        }
+        .o_subdle {
+            fill: rgba($subdle, $subdle-opacity);
+        }
+    }
+}
+
 .options-container {
     .btn {
         color: $o-we-fg-light;
@@ -5,11 +19,17 @@
         padding: 1px 6px;
         border: none;
         min-width: min-content;
+        min-height: 1.5rem;
+
+        @include hb-svg-icon($o-we-sidebar-content-field-clickable-color, $o-we-sidebar-content-field-clickable-color);
 
         &.active {
-            color: $o-we-fg-lighter;
             background-color: $o-we-bg-light !important;
+        }
 
+        &:not([disabled]):hover, &.active {
+            color: $o-we-fg-lighter;
+            @include hb-svg-icon($o-we-sidebar-content-field-pressed-color, $subdle-opacity: .75);
         }
 
         &>img {
@@ -28,7 +48,7 @@
     .btn-primary.o_we_bg_danger {
         color: white;
         background-color: #e6586c !important;
-    }   
+    }
 
     .btn-primary.o_we_bg_success {
         color: white;
@@ -74,4 +94,21 @@
 
 .o_we_img_animate:hover img {
     content: image-set(var(--animate-src));
+}
+
+.o_hb_device {
+    .hb-svg {
+        fill: $o-we-sidebar-content-field-clickable-color;
+
+        &:hover {
+            fill: $o-we-sidebar-content-field-pressed-color;
+        }
+    }
+    &.active .hb-svg {
+        fill: $o-we-color-danger;
+
+        &:hover {
+            fill: darken($o-we-color-danger, 7.5%);
+        }
+    }
 }

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -26,6 +26,9 @@ export function patchWithCleanupImg() {
     });
     patchWithCleanup(Img.prototype, {
         loadImage: () => {},
+        getSvg: function () {
+            this.isSvg = false;
+        },
     });
 }
 

--- a/addons/website/static/src/builder/plugins/background_option/background_shape_option.xml
+++ b/addons/website/static/src/builder/plugins/background_option/background_shape_option.xml
@@ -5,11 +5,12 @@
     <BuilderRow label.translate="Shape" level="1" t-if="isActiveItem('toggle_bg_shape_id')">
         <button class="btn btn-primary" t-on-click="this.showBackgroundShapes" t-out="state.shapeName"/>
         <BuilderButton
-            title.translate="Show/Hide on Mobile"
-            preview="false"
-            action="'showOnMobile'"
-            iconImg="'/html_builder/static/img/options/mobile_invisible.svg'"
-        />
+                title.translate="Show/Hide on Mobile"
+                preview="false"
+                action="'showOnMobile'"
+                className="'o_hb_device'">
+            <Img src="'/html_builder/static/img/options/mobile_invisible.svg'" style="'width: 12px'" />
+        </BuilderButton>
         <BuilderButton action="'setBackgroundShape'" actionValue="''" preview="false" icon="'fa-times'"/>
     </BuilderRow>
 

--- a/addons/website/static/src/builder/plugins/options/footer_option.xml
+++ b/addons/website/static/src/builder/plugins/options/footer_option.xml
@@ -7,42 +7,42 @@
             <BuilderSelectItem title.translate="Default"
                 actionParam="{ view: 'website.footer_custom', vars: { 'footer-template': 'default' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_default.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_default.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Descriptive"
                 actionParam="{ view: 'website.template_footer_descriptive', vars: { 'footer-template': 'descriptive' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_descriptive.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_descriptive.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Centered"
                 actionParam="{ view: 'website.template_footer_centered', vars: { 'footer-template': 'centered' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_centered.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_centered.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Links"
                 actionParam="{ view: 'website.template_footer_links', vars: { 'footer-template': 'links' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_links.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_links.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Minimalist"
                 actionParam="{ view: 'website.template_footer_minimalist', vars: { 'footer-template': 'minimalist' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_minimalist.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_minimalist.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Contact"
                 actionParam="{ view: 'website.template_footer_contact', vars: { 'footer-template': 'contact' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_contact.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_contact.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Call-to-action"
                 actionParam="{ view: 'website.template_footer_call_to_action', vars: { 'footer-template': 'call_to_action' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_call_to_action.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_call_to_action.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Headline"
                 actionParam="{ view: 'website.template_footer_headline', vars: { 'footer-template': 'headline' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_headline.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_headline.svg'"/>
             </BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/header_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header_option.xml
@@ -18,7 +18,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_default.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_default.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Hamburger menu"
@@ -33,7 +33,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_hamburger.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_hamburger.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Rounded box menu"
@@ -48,7 +48,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_boxed.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_boxed.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Stretch menu"
@@ -63,7 +63,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_stretch.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_stretch.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Vertical"
@@ -78,7 +78,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_vertical.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_vertical.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu with Search bar"
@@ -93,7 +93,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_search.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_search.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu - Sales 1"
@@ -108,7 +108,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sales_one.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_sales_one.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu - Sales 2"
@@ -123,7 +123,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sales_two.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_sales_two.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu - Sales 3"
@@ -138,7 +138,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sales_three.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_sales_three.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu - Sales "
@@ -153,7 +153,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sales_four.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_sales_four.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 id="'header_sidebar_opt'"
@@ -169,7 +169,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sidebar.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_sidebar.svg'"/>
             </BuilderSelectItem>
 
         </BuilderSelect>

--- a/addons/website/static/src/builder/plugins/options/mega_menu_option.xml
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option.xml
@@ -11,7 +11,7 @@
                     view: `${templatePrefix}s_mega_menu_multi_menus`,
                     templateClass: 's_mega_menu_multi_menus',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_multi_menus.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_multi_menus.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Image Menu"
@@ -19,7 +19,7 @@
                     view: `${templatePrefix}s_mega_menu_menu_image_menu`,
                     templateClass: 's_mega_menu_menu_image_menu',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_menu_image_menu.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_menu_image_menu.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Odoo Menu"
@@ -27,7 +27,7 @@
                     view: `${templatePrefix}s_mega_menu_odoo_menu`,
                     templateClass: 's_mega_menu_odoo_menu',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_odoo_menu.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_odoo_menu.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Little Icons"
@@ -35,7 +35,7 @@
                     view: `${templatePrefix}s_mega_menu_little_icons`,
                     templateClass: 's_mega_menu_little_icons',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_little_icons.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_little_icons.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Big Icons Subtitles"
@@ -43,7 +43,7 @@
                     view: `${templatePrefix}s_mega_menu_big_icons_subtitles`,
                     templateClass: 's_mega_menu_big_icons_subtitles',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_big_icons_subtitles.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_big_icons_subtitles.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Images Subtitles"
@@ -51,7 +51,7 @@
                     view: `${templatePrefix}s_mega_menu_images_subtitles`,
                     templateClass: 's_mega_menu_images_subtitles',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_images_subtitles.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_images_subtitles.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Logos"
@@ -59,7 +59,7 @@
                     view: `${templatePrefix}s_mega_menu_menus_logos`,
                     templateClass: 's_mega_menu_menus_logos',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_menus_logos.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_menus_logos.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Thumbnails"
@@ -67,7 +67,7 @@
                     view: `${templatePrefix}s_mega_menu_thumbnails`,
                     templateClass: 's_mega_menu_thumbnails',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_thumbnails.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_thumbnails.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Cards"
@@ -75,7 +75,7 @@
                     view: `${templatePrefix}s_mega_menu_cards`,
                     templateClass: 's_mega_menu_cards',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_cards.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_cards.svg'"/>
             </BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/visibility_option.xml
+++ b/addons/website/static/src/builder/plugins/options/visibility_option.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.DeviceVisibility">
-    <BuilderButton action="'toggleDeviceVisibility'" actionParam="'no_desktop'" preview="false"><Img src="'/html_builder/static/img/options/desktop_invisible.svg'" style="'width: 12px'"/></BuilderButton>
-    <BuilderButton action="'toggleDeviceVisibility'" actionParam="'no_mobile'" preview="false"><Img src="'/html_builder/static/img/options/mobile_invisible.svg'" style="'width: 12px'" /></BuilderButton>
+    <BuilderButton className="'o_hb_device'" action="'toggleDeviceVisibility'" actionParam="'no_desktop'" preview="false"><Img src="'/html_builder/static/img/options/desktop_invisible.svg'" style="'width: 12px'"/></BuilderButton>
+    <BuilderButton className="'o_hb_device'" action="'toggleDeviceVisibility'" actionParam="'no_mobile'" preview="false"><Img src="'/html_builder/static/img/options/mobile_invisible.svg'" style="'width: 12px'" /></BuilderButton>
 </t>
 
 <t t-name="html_builder.DeviceVisibilityOption">

--- a/addons/website_sale/static/src/website_builder/website_sale_show_empty_option.xml
+++ b/addons/website_sale/static/src/website_builder/website_sale_show_empty_option.xml
@@ -4,7 +4,9 @@
     <t t-name="website_sale.ShowEmptyOption">
         <BuilderContext action="'websiteConfig'">
             <BuilderRow label.translate="Show Empty" id="'show_empty_opt'">
-                <BuilderButton title.translate="Show/hide shopping cart" className="'o_btn_show_empty_cart fa fa-shopping-cart d-flex justify-content-center flex-grow-1'" actionParam="{views: ['website_sale.header_hide_empty_cart_link']}" />
+                <BuilderButton title.translate="Show/hide shopping cart" icon="'fa-shopping-cart'"
+                    className="'o_btn_show_empty_cart flex-grow-1'"
+                    actionParam="{views: ['website_sale.header_hide_empty_cart_link']}"/>
             </BuilderRow>
         </BuilderContext>
     </t>


### PR DESCRIPTION
- use actual `<svg>` elements instead of `img` to be able to update the
colors through CSS
- cache them to avoid flickers when selecting content in
`<BuilderSelect>`s
- correct the `hide on mobile` icon for background shapes
- use `inert` with classes `h-0 w-0` instead of `d-none` to hide
`WithIgnoreItem` content. This allows the use of SVG's gradients and
other elements targeted with their ID. Indeed, when targetting
`#myLinearGradient`, it will first match the one in the ignore slot
because it appears before in the DOM. If it is hidden with `d-none`, it
is ignored. If it is hidden through other means, it will be taken into
account. Furthermore, we can't rely on `visibility: hidden` or
`opacity: 0`, as those also prevent some features from working (e.g.
`<clipPath>`). Setting both height and width to 0 visually hides it, and
using `inert` ensures that we can't interact with it.