### PR TITLE
[FIX] html_editor: whitespaces and style bug in link_popover overlay

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -435,7 +435,10 @@ export class LinkPlugin extends Plugin {
                     } else {
                         this.linkInDocument.removeAttribute("style");
                     }
-                    if (cleanZWChars(this.linkInDocument.innerText) !== label) {
+                    if (
+                        this.linkInDocument.childElementCount == 0 &&
+                        cleanZWChars(this.linkInDocument.innerText) !== label
+                    ) {
                         this.linkInDocument.innerText = label;
                         cursorsToRestore = null;
                     }
@@ -490,7 +493,7 @@ export class LinkPlugin extends Plugin {
             }
         };
 
-        const restoreSavePoint = this.dependencies.history.makeSavePoint();
+        this.restoreSavePoint = this.dependencies.history.makeSavePoint();
         const props = {
             document: this.document,
             linkElement,
@@ -504,7 +507,7 @@ export class LinkPlugin extends Plugin {
             },
             onChange: applyCallback,
             onDiscard: () => {
-                restoreSavePoint();
+                this.restoreSavePoint();
                 this.openLinkTools(linkElement);
                 this.dependencies.selection.focusEditable();
             },
@@ -520,6 +523,9 @@ export class LinkPlugin extends Plugin {
             onClose: () => {
                 this.linkInDocument = null;
                 this.currentOverlay.close();
+            },
+            onEdit: () => {
+                this.restoreSavePoint = this.dependencies.history.makeSavePoint();
             },
             getInternalMetaData: this.getInternalMetaData,
             getExternalMetaData: this.getExternalMetaData,

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -19,6 +19,7 @@ export class LinkPopover extends Component {
         onRemove: Function,
         onCopy: Function,
         onClose: Function,
+        onEdit: Function,
         getInternalMetaData: Function,
         getExternalMetaData: Function,
         getAttachmentMetadata: Function,
@@ -91,6 +92,7 @@ export class LinkPopover extends Component {
             customBorderSize: computedStyle.borderWidth.replace("px", "") || "1",
             customBorderStyle: computedStyle.borderStyle || "solid",
             isImage: this.props.isImage,
+            isLabelHidden: !!this.props.linkElement.childElementCount,
         });
 
         this.customTextColorState = useState({
@@ -214,6 +216,7 @@ export class LinkPopover extends Component {
     }
     onClickEdit() {
         this.state.editing = true;
+        this.props.onEdit();
         this.updateUrlAndLabel();
     }
     updateUrlAndLabel() {
@@ -406,15 +409,19 @@ export class LinkPopover extends Component {
     }
 
     get classes() {
-        if (!this.state.type) {
-            return "";
+        let classes = [...this.props.linkElement.classList]
+            .filter((value) => value != "btn" && !value.match(/btn-(sm|lg|fill)/))
+            .join(" ");
+
+        if (this.state.type) {
+            classes += ` btn btn-fill-${this.state.type}`;
         }
-        let classes = `btn btn-fill-${this.state.type}`;
 
         if (this.state.buttonSize) {
             classes += ` btn-${this.state.buttonSize}`;
         }
-        return classes;
+
+        return classes.trim();
     }
 
     get customStyles() {

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -11,7 +11,7 @@
                 </div>
                 <div t-else="" class="d-flex">
                     <div class="col p-2" style="max-width: 250px;">
-                        <div class="input-group mb-1">
+                        <div class="input-group mb-1" t-att-class="{'d-none': state.isLabelHidden}">
                             <input t-ref="label"
                                 class="o_we_label_link form-control form-control-sm"
                                 t-model="state.label"

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1189,3 +1189,16 @@ describe("upload file via link popover", () => {
         expect(favIcon).toHaveAttribute("data-mimetype", "text/plain");
     });
 });
+
+describe("hidden label field", () => {
+    test("label field should be hidden if <a> content is not text only", async () => {
+        await setupEditor(`<a href="http://test.com/"><img src="${base64Img}">te[]xt</a>`);
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover").toHaveCount(1);
+        // open edit mode and check if label input is hidden
+        await click(".o_we_edit_link");
+        await waitFor(".input-group");
+        expect(".o_we_label_link").not.toBeVisible();
+        expect(".o_we_href_input_link").toHaveValue("http://test.com/");
+    });
+});


### PR DESCRIPTION
Original issue:
Link editing from link popover > Label displayed with spacing... > see: https://drive.google.com/file/d/1Co-HQKU3br59wIDg0L20HgACJmRABvU8/view?usp=drive_link