### PR TITLE
[FIX] html_builder: fix space between rating stars

### DIFF
--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -1,13 +1,14 @@
 import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { withSequence } from "@html_editor/utils/resource";
 
 export class SetupEditorPlugin extends Plugin {
     static id = "setup_editor_plugin";
     static shared = ["getEditableAreas"];
     resources = {
         clean_for_save_handlers: this.cleanForSave.bind(this),
-        normalize_handlers: this.setContenteditable.bind(this),
+        normalize_handlers: withSequence(0, this.setContenteditable.bind(this)),
     };
 
     setup() {

--- a/addons/website/static/src/builder/plugins/rating_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/rating_option_plugin.js
@@ -111,11 +111,9 @@ function createIcons({ editingElement, nbActiveIcons, nbTotalIcons }) {
     const iconEls = getAllIcons(editingElement);
     [...iconEls].forEach((iconEl) => iconEl.remove());
     for (let i = 0; i < nbTotalIcons; i++) {
-        if (i < nbActiveIcons) {
-            activeIconEl.appendChild(document.createElement("i"));
-        } else {
-            inactiveIconEl.append(document.createElement("i"));
-        }
+        const targetEl = i < nbActiveIcons ? activeIconEl : inactiveIconEl;
+        targetEl.appendChild(document.createElement("i"));
+        targetEl.appendChild(document.createTextNode(" "));
     }
     renderIcons(editingElement);
 }

--- a/addons/website/static/tests/builder/options/rating_option.test.js
+++ b/addons/website/static/tests/builder/options/rating_option.test.js
@@ -5,23 +5,24 @@ import { contains } from "@web/../tests/web_test_helpers";
 
 defineWebsiteModels();
 
+const websiteContent = `
+    <div class="s_rating pt16 pb16" data-icon="fa-star" data-snippet="s_rating" data-name="Rating">
+        <h4 class="s_rating_title">Quality</h4>
+        <div class="s_rating_icons o_not_editable">
+            <span class="s_rating_active_icons">
+                <i class="fa fa-star"></i>
+                <i class="fa fa-star"></i>
+                <i class="fa fa-star"></i>
+            </span>
+            <span class="s_rating_inactive_icons">
+                <i class="fa fa-star-o"></i>
+                <i class="fa fa-star-o"></i>
+            </span>
+        </div>
+    </div>`;
+
 test("change rating score", async () => {
-    await setupWebsiteBuilder(
-        `<div class="s_rating pt16 pb16" data-icon="fa-star" data-snippet="s_rating" data-name="Rating">
-            <h4 class="s_rating_title">Quality</h4>
-            <div class="s_rating_icons">
-                <span class="s_rating_active_icons">
-                    <i class="fa fa-star"></i>
-                    <i class="fa fa-star"></i>
-                    <i class="fa fa-star"></i>
-                </span>
-                <span class="s_rating_inactive_icons">
-                    <i class="fa fa-star-o"></i>
-                    <i class="fa fa-star-o"></i>
-                </span>
-            </div>
-        </div>`
-    );
+    await setupWebsiteBuilder(websiteContent);
     expect(":iframe .s_rating .s_rating_active_icons i").toHaveCount(3);
     expect(":iframe .s_rating .s_rating_inactive_icons i").toHaveCount(2);
     await contains(":iframe .s_rating").click();
@@ -33,24 +34,30 @@ test("change rating score", async () => {
     await clear();
     await fill("4");
     expect(":iframe .s_rating .s_rating_inactive_icons i").toHaveCount(3);
-});
-test("Ensure order of operations when clicking very fast on two options", async () => {
-    await setupWebsiteBuilder(
-        `<div class="s_rating pt16 pb16" data-icon="fa-star" data-snippet="s_rating" data-name="Rating">
-            <h4 class="s_rating_title">Quality</h4>
-            <div class="s_rating_icons">
-                <span class="s_rating_active_icons">
-                    <i class="fa fa-star"></i>
-                    <i class="fa fa-star"></i>
-                    <i class="fa fa-star"></i>
-                </span>
-                <span class="s_rating_inactive_icons">
-                    <i class="fa fa-star-o"></i>
-                    <i class="fa fa-star-o"></i>
-                </span>
-            </div>
+    expect(":iframe .s_rating").toHaveInnerHTML(
+        `<h4 class="s_rating_title">Quality</h4>
+        <div class="s_rating_icons o_not_editable" contenteditable="false">
+            <span class="s_rating_active_icons">
+                <i class="fa fa-star" contenteditable="false">
+                    &ZeroWidthSpace;
+                </i>
+            </span>
+            <span class="s_rating_inactive_icons">
+                <i class="fa fa-star-o" contenteditable="false">
+                    &ZeroWidthSpace;
+                </i>
+                <i class="fa fa-star-o" contenteditable="false">
+                    &ZeroWidthSpace;
+                </i>
+                <i class="fa fa-star-o" contenteditable="false">
+                    &ZeroWidthSpace;
+                </i>
+            </span>
         </div>`
     );
+});
+test("Ensure order of operations when clicking very fast on two options", async () => {
+    await setupWebsiteBuilder(websiteContent);
     await contains(":iframe .s_rating").click();
     await waitFor("[data-label='Icon']");
     expect("[data-label='Icon'] .btn-primary.dropdown-toggle").toHaveText("Stars");


### PR DESCRIPTION
Fixing the following two bugs:

- [CVDE chrome] when modifying ratings star icons size or color, I get a random spacing between the icons: https://drive.google.com/file/d/1gjh-sUBRf603S__RSr1dnj2qjT3X3xOl/view?usp=drive_link
- [BARO] - On a job application page - Changing the rating on a skill set changes the alignment: https://drive.google.com/file/d/1aTLPzcTfG-Axv5au7JbYgQ2sSRL0NEW4/view
