### PR TITLE
[FIX] html_editor: link popover icon size fix

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.scss
+++ b/addons/html_editor/static/src/main/link/link_popover.scss
@@ -1,6 +1,13 @@
-.o_we_preview_favicon .o_image {
-    max-width: 100%;
-    max-height: 100%;
-    background-position: top;
-    margin-top: 0.3em
+.o_we_preview_favicon {
+    .o_image {
+        max-width: 100%;
+        max-height: 100%;
+        background-position: top;
+        margin-top: 0.3em;
+    }
+
+    > img {
+        max-height: 16px;
+        max-width: 16px;
+    }
 }


### PR DESCRIPTION
Original issue:
If I put a big favicon in backend, when edit the header in front-end and click on a navigation item, my favicon takes 100% width of the tooltip background. https://drive.google.com/file/d/1SjM12aCz-Ogq6fwkubYcqvl2T7y3W58l/view?usp=sharing