### PR TITLE
Handle system and unobserved classes

### DIFF
--- a/addons/html_builder/static/tests/custom_tab/container_buttons.test.js
+++ b/addons/html_builder/static/tests/custom_tab/container_buttons.test.js
@@ -332,7 +332,7 @@ test("applying option container button should wait for actions in progress", asy
 
     undo(editor);
     expect(editable).toHaveInnerHTML(
-        `<div class="test-options-target customAction o-paragraph">plop</div>`
+        `<div class="test-options-target o-paragraph customAction">plop</div>`
     );
 
     undo(editor);

--- a/addons/html_builder/static/tests/options/top_menu_visibility_option.test.js
+++ b/addons/html_builder/static/tests/options/top_menu_visibility_option.test.js
@@ -83,7 +83,7 @@ test("undo hidden and come back to regular", async () => {
         openEditor: true,
         beforeWrapwrapContent: `<input type="hidden" class="o_page_option_data" autocomplete="off" data-oe-model="ir.ui.view" data-oe-id="543" data-oe-field="arch" data-oe-xpath="/data/xpath[13]/t[1]/t[1]/input[1]" name="header_visible" value="True">`,
         headerContent: `
-            <header id="top" data-anchor="true" data-name="Header" class="">   
+            <header id="top" data-anchor="true" data-name="Header">   
                     Menu Content
             </header>`,
     });

--- a/addons/html_builder/static/tests/overlay_buttons.test.js
+++ b/addons/html_builder/static/tests/overlay_buttons.test.js
@@ -292,7 +292,7 @@ test("Applying an overlay button action should wait for the actions in progress"
 
     undo(editor);
     expect(editable).toHaveInnerHTML(
-        `<div class="test-options-target customAction o-paragraph">plop</div>`
+        `<div class="test-options-target o-paragraph customAction">plop</div>`
     );
 
     undo(editor);

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -218,10 +218,18 @@ export function cleanTrailingBR(el, predicates = []) {
     }
 }
 
-export function toggleClass(node, className) {
-    node.classList.toggle(className);
-    if (!node.className) {
-        node.removeAttribute("class");
+/**
+ * Wrapper for classList.toggle that removes the class attribute if the
+ * element has no class name after the toggle.
+ *
+ * @param {Element} element
+ * @param {string} className
+ * @param {boolean} [force]
+ */
+export function toggleClass(element, className, force) {
+    element.classList.toggle(className, force);
+    if (!element.className) {
+        element.removeAttribute("class");
     }
 }
 

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -251,11 +251,12 @@ describe("step", () => {
     });
 });
 
-describe("prevent system classes to be set from history", () => {
+describe("system classes and attributes", () => {
     class TestSystemClassesPlugin extends Plugin {
         static id = "testRenderClasses";
         resources = {
             system_classes: ["x"],
+            system_attributes: ["data-x"],
         };
     }
     const Plugins = [...MAIN_PLUGINS, TestSystemClassesPlugin];
@@ -273,38 +274,44 @@ describe("prevent system classes to be set from history", () => {
         });
     });
 
-    test("should prevent system classes to be added when adding 2 classes", async () => {
+    test("system classes are ignored by history (neither added or removed)", async () => {
+        const { editor, el } = await setupEditor(`<p>a[]</p>`, { config: { Plugins: Plugins } });
+        const p = editor.editable.querySelector("p");
+        p.className = "x y";
+        addStep(editor);
+        undo(editor);
+        expect(getContent(el)).toBe(`<p class="x">a[]</p>`);
+        redo(editor);
+        expect(getContent(el)).toBe(`<p class="x y">a[]</p>`);
+    });
+
+    test("system class with char mutation", async () => {
         await testEditor({
             contentBefore: `<p>a[]</p>`,
             stepFunction: async (editor) => {
                 const p = editor.editable.querySelector("p");
-                p.className = "x y";
+                p.className = "x";
+                p.textContent = "b";
+                editor.shared.selection.setCursorEnd(p);
                 addStep(editor);
                 undo(editor);
                 redo(editor);
             },
-            contentAfter: `<p class="y">a[]</p>`,
+            contentAfter: `<p class="x">b[]</p>`,
             config: { Plugins: Plugins },
         });
     });
 
-    test("should prevent system classes to be added in historyApply", async () => {
-        const { el, plugins } = await setupEditor(`<p>a</p>`, { config: { Plugins } });
-        /** @type import("../src/core/history_plugin").HistoryPlugin") */
-        const historyPlugin = plugins.get("history");
-        const p = el.querySelector("p");
-
-        historyPlugin.applyMutations([
-            {
-                attributeName: "class",
-                id: historyPlugin.nodeToIdMap.get(p),
-                oldValue: null,
-                type: "attributes",
-                value: "x y",
-            },
-        ]);
-
-        expect(getContent(el)).toBe(`<p class="y">a</p>`);
+    test("system attributes mutations are ignored by history", async () => {
+        const { editor, el } = await setupEditor(`<p>a[]</p>`, { config: { Plugins: Plugins } });
+        const p = editor.editable.querySelector("p");
+        p.setAttribute("data-x", "1");
+        p.setAttribute("data-y", "1");
+        addStep(editor);
+        undo(editor);
+        expect(getContent(el)).toBe(`<p data-x="1">a[]</p>`);
+        redo(editor);
+        expect(getContent(el)).toBe(`<p data-x="1" data-y="1">a[]</p>`);
     });
 
     test("should skip the mutations if no changes in state", async () => {
@@ -694,5 +701,28 @@ describe("custom mutation", () => {
 
         restoreSavePoint();
         expect.verifySteps(["custom apply", "custom revert", "custom apply", "custom revert"]);
+    });
+});
+
+describe("unobserved mutations", () => {
+    const withAddStep = (editor, callback) => {
+        callback();
+        editor.shared.history.addStep();
+    };
+
+    describe("classes", () => {
+        test("unobserved class mutations should not be affected by undo/redo", async () => {
+            const { editor } = await setupEditor(`<p>test</p>`);
+            /** @type {HTMLElement} */
+            const p = editor.editable.querySelector("p");
+            withAddStep(editor, () => p.classList.add("a"));
+            editor.shared.history.ignoreDOMMutations(() => p.classList.add("b"));
+            withAddStep(editor, () => p.classList.add("c"));
+            editor.shared.history.undo();
+            expect(p.className).toBe("a b");
+            editor.shared.history.ignoreDOMMutations(() => p.classList.remove("b"));
+            editor.shared.history.redo();
+            expect(p.className).toBe("a c");
+        });
     });
 });


### PR DESCRIPTION
- split classList mutations into individual records (one per class)

- handle system classes mutations (completely ignore them)