### PR TITLE
[FIX] html_builder: page creation does not re-ask url

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.xml
+++ b/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.xml
@@ -24,7 +24,7 @@
                 <DropdownItem onSelected.bind="() => this.translatable ? this.editFromTranslate() : this.onClickEditPage()" class="'o_edit_website_dropdown_item'">
                     Edit 404 page<t t-if="translatable" t-translation="off"> - <span class="text-muted" t-out="this.currentWebsiteInfo.defaultLangName"/></t>
                 </DropdownItem>
-                <DropdownItem onSelected.bind="() => this.props.onNewPage()" class="'o_edit_website_dropdown_item'">
+                <DropdownItem onSelected.bind="() => this.props.onNewPage(true)" class="'o_edit_website_dropdown_item'">
                     <t t-set="url" t-value="this.websiteService.currentLocation"/>
                     Create <span class="text-muted" t-out="url"/> page
                 </DropdownItem>

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -190,13 +190,17 @@ export class WebsiteBuilder extends Component {
         }
     }
 
-    onNewPage() {
-        this.dialog.add(AddPageDialog, {
+    onNewPage(keepUrl = false) {
+        const params = {
             onAddPage: () => {
                 this.websiteService.context.showNewContentModal = false;
             },
             websiteId: this.websiteService.currentWebsite.id,
-        });
+        };
+        if (keepUrl) {
+            params.forcedURL = this.websiteService.currentLocation;
+        }
+        this.dialog.add(AddPageDialog, params);
     }
 
     async onEditPage() {


### PR DESCRIPTION
Original issue:
- Create a new menu with a new URL that does not exist
- Click on that menu
- Click Edit (note that the edit button design in that case is not colored)
- You are suggested to either edit the 404 page or create the page
- Create the page
- Choose a template
- You are re-asked the name of the page and if you want to add it in the menu... you should not