### PR TITLE
[REF] html_builder: highlight: use classes instead of dataset

### DIFF
--- a/addons/html_builder/static/src/website_builder/plugins/highlight/highlight_configurator.xml
+++ b/addons/html_builder/static/src/website_builder/plugins/highlight/highlight_configurator.xml
@@ -23,7 +23,7 @@
         </div>
 
         <div class="fs-2 mt-3 p-5 text-center fw-bolder border" style="padding: 20px 5px;">
-            <span t-attf-style="--text-highlight-color: {{this.state.color}}; --text-highlight-width: {{this.state.thickness}};" t-ref="preview" t-att-data-highlight-text="this.state.highlightId">Text</span>
+            <span t-attf-style="--text-highlight-color: {{this.state.color}}; --text-highlight-width: {{this.state.thickness}};" t-ref="preview" t-attf-class="o_text_highlight o_text_highlight_{{this.state.highlightId}}">Text</span>
         </div>
     </div>
 </t>

--- a/addons/html_builder/static/src/website_builder/plugins/highlight/highlight_picker.js
+++ b/addons/html_builder/static/src/website_builder/plugins/highlight/highlight_picker.js
@@ -1,5 +1,9 @@
 import { onMounted, useRef, Component, onWillDestroy } from "@odoo/owl";
-import { applyTextHighlight, textHighlightFactory } from "@website/js/highlight_utils";
+import {
+    applyTextHighlight,
+    textHighlightFactory,
+    getCurrentTextHighlight,
+} from "@website/js/highlight_utils";
 
 export class HighlightPicker extends Component {
     static template = "website.highlightPicker";
@@ -12,8 +16,9 @@ export class HighlightPicker extends Component {
     setup() {
         const root = useRef("root");
         onMounted(() => {
-            for (const textEl of root.el.querySelectorAll("[data-highlight-text]")) {
-                applyTextHighlight(textEl, textEl.dataset.highlightText);
+            for (const textEl of root.el.querySelectorAll(".o_text_highlight")) {
+                const highlightId = getCurrentTextHighlight(textEl);
+                applyTextHighlight(textEl, highlightId);
             }
         });
 

--- a/addons/html_builder/static/src/website_builder/plugins/highlight/highlight_picker.xml
+++ b/addons/html_builder/static/src/website_builder/plugins/highlight/highlight_picker.xml
@@ -10,7 +10,7 @@
                     t-on-mouseenter="() => this.props.previewHighlight(highlight)"
                     t-on-mouseleave="() => this.props.revertHighlight()">
                 <div class="overflow-visible position-relative fw-bolder fs-3 text-center">
-                    <span t-att-data-highlight-text="highlight">Text</span>
+                    <span t-attf-class="o_text_highlight o_text_highlight_{{highlight}}">Text</span>
                 </div>
             </div>
         </t>

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -13,7 +13,7 @@ import {
     previousLeaf,
 } from "../utils/dom_info";
 import { childNodes, closestElement, descendants, selectElements } from "../utils/dom_traversal";
-import { FONT_SIZE_CLASSES, formatsSpecs } from "../utils/formatting";
+import { formatsSpecs } from "../utils/formatting";
 import { boundariesIn, boundariesOut, DIRECTIONS, leftPos, rightPos } from "../utils/position";
 import { prepareUpdate } from "@html_editor/utils/dom_state";
 import { _t } from "@web/core/l10n/translation";
@@ -281,15 +281,17 @@ export class FormatPlugin extends Plugin {
             let parentNode = node.parentElement;
 
             // Remove the format on all inline ancestors until a block or an element
-            // with a class that is not related to font size (in case the formatting
-            // comes from the class).
+            // with a class that is not indicated as splittable.
+            const isClassListSplittable = (classList) =>
+                [...classList].every((className) =>
+                    this.getResource("format_splittable_class").some((cb) => cb(className))
+                );
 
             while (
                 parentNode &&
                 !isBlock(parentNode) &&
                 !this.dependencies.split.isUnsplittable(parentNode) &&
-                (parentNode.classList.length === 0 ||
-                    [...parentNode.classList].every((cls) => FONT_SIZE_CLASSES.includes(cls)))
+                (parentNode.classList.length === 0 || isClassListSplittable(parentNode.classList))
             ) {
                 const isUselessZws =
                     parentNode.tagName === "SPAN" &&

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -20,6 +20,7 @@ import {
     getCSSVariableValue,
     getHtmlStyle,
     getFontSizeDisplayValue,
+    FONT_SIZE_CLASSES,
 } from "@html_editor/utils/formatting";
 import { DIRECTIONS } from "@html_editor/utils/position";
 import { _t } from "@web/core/l10n/translation";
@@ -279,6 +280,8 @@ export class FontPlugin extends Plugin {
 
         /** Processors */
         clipboard_content_processors: this.processContentForClipboard.bind(this),
+
+        format_splittable_class: (className) => FONT_SIZE_CLASSES.includes(className),
     };
 
     setup() {

--- a/addons/website/static/src/interactions/text_highlights.js
+++ b/addons/website/static/src/interactions/text_highlights.js
@@ -18,7 +18,7 @@ export class TextHighlight extends Interaction {
     }
 
     start() {
-        for (const textEl of this.el.querySelectorAll("[data-highlight-text]")) {
+        for (const textEl of this.el.querySelectorAll(".o_text_highlight")) {
             this.handleEl(textEl);
         }
     }
@@ -51,7 +51,7 @@ export class TextHighlight extends Interaction {
             closestToObserves.add(this.closestToObserve(target));
         }
         for (const closestToObserve of closestToObserves) {
-            for (const el of closestToObserve.querySelectorAll("[data-highlight-text]")) {
+            for (const el of closestToObserve.querySelectorAll(".o_text_highlight")) {
                 switchTextHighlight(el);
             }
         }

--- a/addons/website/static/src/js/highlight_utils.js
+++ b/addons/website/static/src/js/highlight_utils.js
@@ -388,8 +388,14 @@ function buildPath(templates, options) {
  * @param {HTMLElement} el
  * @returns {String}
  */
-function getCurrentTextHighlight(el) {
-    return el.closest("[data-highlight-text]").getAttribute("data-highlight-text");
+export function getCurrentTextHighlight(el) {
+    const highlightEl = el.closest(".o_text_highlight");
+    if (!highlightEl) {
+        return;
+    }
+    return Array.from(highlightEl.classList)
+        .find((cls) => cls.startsWith("o_text_highlight_"))
+        ?.replace("o_text_highlight_", "");
 }
 function rectToBatch(rects) {
     if (!rects.length) {

--- a/addons/website/static/src/scss/website_common.scss
+++ b/addons/website/static/src/scss/website_common.scss
@@ -2,7 +2,7 @@
 // Website Text Highlight Effects
 //------------------------------------------------------------------------------
 
-[data-highlight-text] {
+.o_text_highlight {
     position: relative;
     --text-highlight-color: currentColor;
     isolation: isolate;

--- a/addons/website/static/tests/interactions/text_highlight.test.js
+++ b/addons/website/static/tests/interactions/text_highlight.test.js
@@ -13,7 +13,7 @@ describe.current.tags("interaction_dev");
 const highlightTemplate = `
     <p>
         Great stories have a <b>personality</b>.
-        <span data-highlight-text="circle_1" style="--text-highlight-width: 2px;">
+        <span class="o_text_highlight o_text_highlight_circle_1" style="--text-highlight-width: 2px;">
             Consider telling a great story that provides personality.
             <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible pe-none">
                 <path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 142.36111111111111,18.18181818181818 C 372.7272727272727,19.047619047619047 430.5,18.18181818181818 419.42999999999995,8.620689655172415C 410, 1.36986301369863 290.5740609496811,0 205,0 S -2,1.36986301369863 -2,9.09090909090909S 96.69811320754717,20 301.4705882352941,20.8" class="o_text_highlight_path_circle_1"></path>
@@ -35,14 +35,14 @@ test("[resize] update the number of highlight items when necessary", async () =>
     // Ensure the update is finished
     await animationFrame();
     await animationFrame();
-    const numberOfItems1 = queryAll("[data-highlight-text] svg").length;
+    const numberOfItems1 = queryAll(".o_text_highlight svg").length;
 
     queryFirst("div").style.width = "200px";
 
     // Ensure the update is finished
     await animationFrame();
     await animationFrame();
-    const numberOfItems2 = queryAll("[data-highlight-text] svg").length;
+    const numberOfItems2 = queryAll(".o_text_highlight svg").length;
 
     expect(numberOfItems1).toBeLessThan(numberOfItems2);
 });


### PR DESCRIPTION
During the highlight refactoring, we've decided to refactor highlight classes (`o_text_highlight`, `o_text_highlight_{id}`) into dataset (`data-highlight-text: highlightId`).

This decision has been made because before formatting the selection, the format plugin split the selection and unformat all inline node until a class is encountered.
A hardcoded exception was made for the font classes formatting.

This commit allows plugin to indicate with a resources which classes can be splittable. Which avoid a migration script for text highlight