### PR TITLE
[FIX]: html_builder: Fix TypeError in form field option loading

### DIFF
--- a/addons/html_builder/static/src/website_builder/plugins/form/utils.js
+++ b/addons/html_builder/static/src/website_builder/plugins/form/utils.js
@@ -426,10 +426,10 @@ export function findCircular(dependentFieldEl, targetFieldEl) {
         // Get all the fields that have the same label as the dependent
         // field.
         let dependentFieldEls = Array.from(
-            formEl.querySelectorAll(
+            formEl?.querySelectorAll(
                 `.s_website_form_input[name="${CSS.escape(dependentFieldName)}"]`
             )
-        ).map((el) => el.closest(".s_website_form_field"));
+        )?.map((el) => el.closest(".s_website_form_field"));
         // Remove the duplicated fields. This could happen if the field has
         // multiple inputs ("Multiple Checkboxes" for example.)
         dependentFieldEls = new Set(dependentFieldEls);


### PR DESCRIPTION
Resolve issue TypeError: Cannot read properties of null (reading 'querySelectorAll')
    at recursiveFindCircular(http://127.0.0.1:8069/web/assets/2b5440c/html_builder.assets.min.js:1976:323)
    at findCircular (http://127.0.0.1:8069/web/assets/2b5440c/html_builder.assets.min.js:1978:23)
    at FormOptionPlugin.loadFieldOptionData (http://127.0.0.1:8069/web/assets/2b5440c/html_builder.assets.min.js:1923:626)
    at async FormFieldOption.<anonymous> (http://127.0.0.1:8069/web/assets/2b5440c/html_builder.assets.min.js:1838:1640)