### PR TITLE
[FIX] html_builder: highlight: multiple colorpicker fixes

### DIFF
--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -55,6 +55,7 @@ export class ColorPicker extends Component {
         colorPrefix: { type: String },
         noTransparency: { type: Boolean, optional: true },
         close: { type: Function, optional: true },
+        className: { type: String, optional: true },
     };
     static defaultProps = {
         close: () => {},

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -1,6 +1,6 @@
 <templates xml:space="preserve">
 <t t-name="web.ColorPicker">
-    <div class="o_font_color_selector user-select-none" t-on-pointerdown.stop="() => {}" data-prevent-closing-overlay="true" t-ref="root">
+    <div t-attf-class="o_font_color_selector user-select-none {{this.props.className}}" t-on-pointerdown.stop="() => {}" data-prevent-closing-overlay="true" t-ref="root">
         <div class="my-1 d-flex">
             <button class="btn btn-sm btn-light ms-1 text-truncate btn-tab theme-tab"
                 t-if="this.props.enabledTabs.includes('theme')"

--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
@@ -40,6 +40,7 @@ export class HighlightConfigurator extends Component {
         revertHighlight: Function,
         revertHighlightStyle: Function,
         componentStack: Object,
+        getUsedCustomColors: Function,
     };
 
     setup() {
@@ -73,13 +74,18 @@ export class HighlightConfigurator extends Component {
         this.props.componentStack.push(
             ColorPicker,
             {
-                state: { selectedColor: this.state.color },
-                //TODO: implement customColors
-                getUsedCustomColors: () => {},
+                state: { selectedColor: this.state.color, defaultTab: "solid" },
+                colorPrefix: "--",
+                getUsedCustomColors: this.props.getUsedCustomColors,
+                enabledTabs: ["solid", "custom"],
                 applyColor: this.selectHighlightColor.bind(this),
                 applyColorPreview: (color) =>
-                    this.props.previewHighlightStyle("--text-highlight-color", color),
+                    this.props.previewHighlightStyle(
+                        "--text-highlight-color",
+                        this.processColor(color)
+                    ),
                 applyColorResetPreview: this.props.revertHighlightStyle,
+                className: "w-100",
             },
             "Select a color",
             true
@@ -91,9 +97,16 @@ export class HighlightConfigurator extends Component {
         this.props.applyHighlight(highlightId);
     }
 
+    processColor(color) {
+        if (color.startsWith("--")) {
+            return getComputedStyle(document.documentElement).getPropertyValue(color);
+        }
+        return color;
+    }
+
     selectHighlightColor(color) {
         this.props.componentStack.pop();
-        this.props.applyHighlightStyle("--text-highlight-color", color);
+        this.props.applyHighlightStyle("--text-highlight-color", this.processColor(color));
     }
 
     onThicknessChange(ev) {

--- a/addons/website/static/src/builder/plugins/highlight/highlight_picker.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_picker.js
@@ -10,7 +10,7 @@ export class HighlightPicker extends Component {
     static props = {
         selectHighlight: Function,
         previewHighlight: Function,
-        resetHighlightPreview: Function,
+        revertHighlight: Function,
     };
 
     setup() {

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -12,6 +12,7 @@ import { removeStyle } from "@html_editor/utils/dom";
 import { isTextNode } from "@html_editor/utils/dom_info";
 import { omit } from "@web/core/utils/objects";
 import { getCurrentTextHighlight } from "@website/js/highlight_utils";
+import { isCSSColor, rgbaToHex } from "@web/core/utils/colors";
 
 export class HighlightPlugin extends Plugin {
     static id = "highlight";
@@ -32,6 +33,7 @@ export class HighlightPlugin extends Plugin {
                     previewHighlightStyle: this.previewHighlightStyle.bind(this),
                     revertHighlightStyle: this.revertHighlightStyle.bind(this),
                     getHighlightState: () => this.highlightState,
+                    getUsedCustomColors: this.getUsedCustomColors.bind(this),
                 },
             },
         ],
@@ -148,6 +150,18 @@ export class HighlightPlugin extends Plugin {
     revertHighlightStyle() {
         this.previewableApplyHighlightStyle.revert();
     }
+    getUsedCustomColors() {
+        const highlights = this.editable.querySelectorAll(".o_text_highlight");
+        const usedCustomColors = new Set();
+        for (const highlight of highlights) {
+            const style = getComputedStyle(highlight);
+            const color = style.getPropertyValue("--text-highlight-color");
+            if (isCSSColor(color)) {
+                usedCustomColors.add(rgbaToHex(color).toLowerCase());
+            }
+        }
+        return usedCustomColors;
+    }
 }
 registry.category("website-plugins").add(HighlightPlugin.id, HighlightPlugin);
 
@@ -178,10 +192,11 @@ class HighlightToolbarButton extends Component {
         previewHighlightStyle: Function,
         revertHighlight: Function,
         revertHighlightStyle: Function,
+        getUsedCustomColors: Function,
         title: String,
     };
     static template = xml`
-        <button t-ref="root" class="btn btn-light" t-on-click="openHighlightConfigurator">
+        <button t-ref="root" class="btn btn-light o-select-highlight" t-on-click="openHighlightConfigurator" t-att-title="props.title">
             <i class="fa oi oi-text-effect oi-fw py-1"/>
         </button>
     `;

--- a/addons/website/static/src/builder/plugins/highlight/stacking_component.js
+++ b/addons/website/static/src/builder/plugins/highlight/stacking_component.js
@@ -23,6 +23,12 @@ export class StackingComponent extends Component {
             </div>
         </t>
     `;
+    static props = {
+        stackState: { type: Object, required: true },
+        class: { type: String, optional: true },
+        style: { type: String, optional: true },
+        close: { type: Function, optional: true },
+    };
     setup() {
         this.stack = useState(this.props.stackState.stack);
     }

--- a/addons/website/static/tests/builder/website_builder/highlight.test.js
+++ b/addons/website/static/tests/builder/website_builder/highlight.test.js
@@ -1,0 +1,47 @@
+import { expect, test } from "@odoo/hoot";
+import { click, waitFor } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { setupEditor } from "@html_editor/../tests/_helpers/editor";
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+import { expandToolbar } from "@html_editor/../tests/_helpers/toolbar";
+import { HighlightPlugin } from "@html_builder/website_builder/plugins/highlight/highlight_plugin";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+
+defineMailModels();
+
+test("Can highlight a selected text", async () => {
+    await setupEditor("<p>This is [highlighted]</p>", {
+        config: { Plugins: [...MAIN_PLUGINS, HighlightPlugin] },
+    });
+
+    await expandToolbar();
+    expect(".o-select-highlight").toHaveCount(1);
+    await click(".o-we-toolbar .o-select-highlight");
+    await waitFor(".o_popover .o_text_highlight_underline");
+
+    expect("p>.o_text_highlight_underline").toHaveCount(0);
+    await click(".o_popover .o_text_highlight_underline");
+    expect("p>.o_text_highlight_underline").toHaveCount(1);
+});
+
+test("Can set a color to a highlight", async () => {
+    await setupEditor(
+        `
+        <p>
+            <span class="o_text_highlight o_text_highlight_freehand_2">[highlight 3]</span>
+        </p>`,
+        { config: { Plugins: [...MAIN_PLUGINS, HighlightPlugin] } }
+    );
+    await expandToolbar();
+    expect(".o-select-highlight").toHaveCount(1);
+    await click(".o-we-toolbar .o-select-highlight");
+    await animationFrame();
+    await click("#colorButton");
+    await animationFrame();
+    await click("button[style='background-color: var(--o-color-1)']");
+    await animationFrame();
+    const color = getComputedStyle(document.documentElement).getPropertyValue("--o-color-1");
+    expect("span.o_text_highlight_freehand_2").toHaveStyle({
+        "--text-highlight-color": color,
+    });
+});


### PR DESCRIPTION
- No more gradient tab
- "Custom" tab is usable with highlights used custom colors
- First row of "solid" colors apply the color instead of doing nothing
- Width of the colorpicker matches the highlight popover