### PR TITLE
close color picker on click after opened

### DIFF
--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -195,7 +195,7 @@ export function useColorPicker(refName, props, options = {}) {
     const root = useRef(refName);
 
     function onClick() {
-        colorPicker.open(root.el, props);
+        colorPicker.isOpen ? colorPicker.close() : colorPicker.open(root.el, props);
     }
 
     useEffect(


### PR DESCRIPTION
[QSM, firefox] Clicking twice on a colorpicker should open it then close it, now it opens it twice.