### PR TITLE
add message + image when no snippets found in snippet dialog

### DIFF
--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.js
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.js
@@ -17,14 +17,17 @@ export class AddSnippetDialog extends Component {
 
     setup() {
         this.iframeRef = useRef("iframe");
-
         this.state = useState({
             search: "",
             groupSelected: this.props.selectedSnippet.groupName,
             showIframe: false,
+            hasNoSearchResults: false,
         });
         this.snippetViewerProps = {
             state: this.state,
+            hasSearchResults: (has) => {
+                this.state.hasNoSearchResults = !has;
+            },
             selectSnippet: (...args) => {
                 this.props.selectSnippet(...args);
                 this.props.close();

--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.xml
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.xml
@@ -28,9 +28,18 @@
                     </div>
                 </aside>
                 <div class="position-relative flex-grow-1 flex-shrink-1">
-                    <div class="spinner-grow position-absolute top-50 start-50 translate-middle" role="status">
-                        <span class="visually-hidden">Loading...</span>
-                    </div>
+                    <t t-if="state.hasNoSearchResults">
+                        <div class="d-flex flex-column justify-content-center text-center h-100 p-4" role="status">
+                            <img src="/web/static/img/smiling_face.svg" alt="No snippets found" class="h-25 mb-3"/>
+                            <p class="h2 mb-2">Oops! No snippets found.</p>
+                            <p class="h4">Take a look at the search bar, there might be a small typo!</p>
+                        </div>
+                    </t>
+                    <t t-else="">
+                        <div class="spinner-grow position-absolute top-50 start-50 translate-middle" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    </t>
                     <iframe class="border-0 fade bg-200 position-relative o_add_snippet_iframe" t-att-class="state.showIframe ? ' show' : '' " tabindex="-1" t-ref="iframe" src="about:blank" height="333%" width="333%" />
                 </div>
             </div>

--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -16,6 +16,7 @@ export class SnippetViewer extends Component {
     static props = {
         state: { type: Object },
         selectSnippet: { type: Function },
+        hasSearchResults: Function,
         snippetModel: { type: Object },
     };
 
@@ -74,6 +75,11 @@ export class SnippetViewer extends Component {
                 columns[1].push(snippets[index]);
             }
         }
+        let numResults = 0;
+        for (const column of columns) {
+            numResults += column.length;
+        }
+        this.props.hasSearchResults(numResults > 0);
         return columns;
     }
 


### PR DESCRIPTION
[QSM] Enter edit mode -> add snippet dialog -> Type something random that does not match anything => The screen is gray, instead of a message in the modal to explain nothing was found