### PR TITLE
[REF] pos_loyalty, pos*: real time syncing adaptation for loyalty

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -50,6 +50,7 @@ export class DataServiceOptions {
             "pos.pack.operation.lot": ["uuid"],
             "event.registration": ["uuid"],
             "event.registration.answer": ["uuid"],
+            "loyalty.card": ["uuid"],
         };
 
         for (const model in databaseTable) {

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -346,6 +346,9 @@ export class PaymentScreen extends Component {
         }
 
         // 3. Post process.
+        if (this.currentOrder.waitForPushOrder()) {
+            await this.postPushOrderResolve([this.currentOrder.id]);
+        }
         await this.afterOrderValidation();
     }
     handleValidationError(error) {

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -280,7 +280,10 @@ export class PosData extends Reactive {
                 if (!ids.length) {
                     return;
                 }
-                const vals = models[modelName].getBy("uuid", ids[0]).raw;
+                let vals = models[modelName].getBy("uuid", ids[0]).raw;
+                vals = Object.fromEntries(
+                    Object.entries(vals).filter(([key, val]) => !key.startsWith("_"))
+                );
                 // Skip IndexedDB calls if it hasn't been initialized (e.g., in prepDisplay, kiosk)
                 this.indexedDB?.create(modelName, [vals]);
                 this.queue.push(["CREATE", modelName, omit(vals, "id")]);
@@ -668,7 +671,7 @@ export class PosData extends Reactive {
         }
         await this.flush();
         if (this.queue.length > 0) {
-            throw new Error("There are unsynced changes in the queue.");
+            console.info("There are unsynced changes in the queue.");
         }
         if (Array.isArray(args) && args.length == 0) {
             // This is for static (api.model) methods.

--- a/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
@@ -238,17 +238,26 @@ patch(ProductScreen.prototype, {
                 });
 
                 // TODO: Remove redundant field `registration_answer_choice_ids`; data can be derived from `registration_answer_ids` using a domain.
-                // No need to separate record creation here, domain filtering of field will handle it.
                 Object.entries({
                     ...textAnswer,
                     ...globalTextAnswer,
+                }).forEach(([questionId, answer]) => {
+                    this.pos.models["event.registration.answer"].create({
+                        registration_id: eventRegistraton.id,
+                        question_id: this.pos.models["event.question"].get(parseInt(questionId)),
+                        value_text_box: answer,
+                    });
+                });
+                Object.entries({
                     ...simpleChoice,
                     ...globalSimpleChoice,
                 }).forEach(([questionId, answer]) => {
                     this.pos.models["event.registration.answer"].create({
                         registration_id: eventRegistraton.id,
                         question_id: this.pos.models["event.question"].get(parseInt(questionId)),
-                        value_text_box: answer,
+                        value_answer_id: this.pos.models["event.question.answer"].get(
+                            parseInt(answer)
+                        ),
                     });
                 });
             }

--- a/addons/pos_event/static/tests/tours/pos_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_event_tour.js
@@ -33,6 +33,5 @@ registry.category("web_tour.tours").add("SellingEventInPos", {
             ReceiptScreen.isShown(),
             EventTourUtils.printTicket("full"),
             EventTourUtils.printTicket("badge"),
-            ReceiptScreen.clickNextOrder(),
         ].flat(),
 });

--- a/addons/pos_event/tests/test_frontend.py
+++ b/addons/pos_event/tests/test_frontend.py
@@ -129,7 +129,8 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('SellingMultiSlotEventInPos')
 
-        order = self.env['pos.order'].search([], order='id desc', limit=1)
+        # Here, an extra order has been created at the end of the tour
+        order = self.env['pos.order'].search([])[1]
         self.assertEqual(len(order.lines), 1)
 
         registrations = order.lines.event_registration_ids

--- a/addons/pos_loyalty/models/loyalty_card.py
+++ b/addons/pos_loyalty/models/loyalty_card.py
@@ -3,6 +3,8 @@
 
 from odoo import fields, models, api
 
+from uuid import uuid4
+
 
 class LoyaltyCard(models.Model):
     _name = 'loyalty.card'
@@ -13,6 +15,7 @@ class LoyaltyCard(models.Model):
     source_pos_order_partner_id = fields.Many2one(
         'res.partner', "PoS Order Customer",
         related="source_pos_order_id.partner_id")
+    uuid = fields.Char(string='Uuid', readonly=True, default=lambda self: str(uuid4()), copy=False)
 
     @api.model
     def _load_pos_data_domain(self, data):
@@ -20,7 +23,7 @@ class LoyaltyCard(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['partner_id', 'code', 'points', 'program_id', 'expiration_date']
+        return ['partner_id', 'code', 'points', 'program_id', 'expiration_date', 'uuid']
 
     def _has_source_order(self):
         return super()._has_source_order() or bool(self.source_pos_order_id)

--- a/addons/pos_loyalty/models/pos_config.py
+++ b/addons/pos_loyalty/models/pos_config.py
@@ -115,5 +115,6 @@ class PosConfig(models.Model):
                 'coupon_partner_id': coupon.partner_id.id,
                 'points': coupon.points,
                 'has_source_order': coupon._has_source_order(),
+                'uuid': coupon.uuid,
             },
         }

--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -86,68 +86,44 @@ class PosOrder(models.Model):
         coupon_data = {int(k): v for k, v in coupon_data.items()}
 
         self._check_existing_loyalty_cards(coupon_data)
-        # Map negative id to newly created ids.
-        coupon_new_id_map = {k: k for k in coupon_data.keys() if k > 0}
 
-        # Create the coupons that were awarded by the order.
-        coupons_to_create = {k: v for k, v in coupon_data.items() if k < 0 and not v.get('giftCardId')}
-        coupon_create_vals = [{
-            'program_id': p['program_id'],
-            'partner_id': get_partner_id(p.get('partner_id', False)),
-            'code': p.get('code') or p.get('barcode') or self.env['loyalty.card']._generate_code(),
-            'points': 0,
-            'expiration_date': p.get('date_to', False),
-            'source_pos_order_id': self.id,
-            'expiration_date': p.get('expiration_date')
-        } for p in coupons_to_create.values()]
-
-        # Pos users don't have the create permission
-        new_coupons = self.env['loyalty.card'].with_context(action_no_send_mail=True).sudo().create(coupon_create_vals)
-
-        # We update the gift card that we sold when the gift_card_settings = 'scan_use'.
-        gift_cards_to_update = [v for v in coupon_data.values() if v.get('giftCardId')]
-        updated_gift_cards = self.env['loyalty.card']
-        for coupon_vals in gift_cards_to_update:
-            gift_card = self.env['loyalty.card'].browse(coupon_vals.get('giftCardId'))
-            gift_card.write({
-                'points': coupon_vals['points'],
-                'source_pos_order_id': self.id,
+        # Update the coupons sold and used in the order
+        loyalty_cards_to_update = coupon_data.values()
+        updated_loyalty_cards = self.env['loyalty.card']
+        for coupon_vals in loyalty_cards_to_update:
+            loyalty_card = self.env['loyalty.card'].browse(coupon_vals.get('coupon_id'))
+            if not loyalty_card.exists():
+                continue
+            loyalty_card.sudo().write({
+                'points': loyalty_card.points + coupon_vals['points'],
+                'source_pos_order_id': self.id if coupon_vals['points'] >= 0 and not loyalty_card.source_pos_order_id else loyalty_card.source_pos_order_id,
                 'partner_id': get_partner_id(coupon_vals.get('partner_id', False)),
+                'expiration_date': coupon_vals.get('expiration_date', False),
             })
-            updated_gift_cards |= gift_card
-
-        # Map the newly created coupons
-        for old_id, new_id in zip(coupons_to_create.keys(), new_coupons):
-            coupon_new_id_map[new_id.id] = old_id
+            # Update the coupon code if it is a physical gift card coupon
+            if coupon_vals.get('barcode') and coupon_vals.get('manual'):
+                loyalty_card.sudo().write({
+                    'code': coupon_vals['barcode'],
+                })
+            updated_loyalty_cards |= loyalty_card
 
         # We need a sudo here because this can trigger `_compute_order_count` that require access to `sale.order.line`
-        all_coupons = self.env['loyalty.card'].sudo().browse(coupon_new_id_map.keys()).exists()
-        lines_per_reward_code = defaultdict(lambda: self.env['pos.order.line'])
-        for line in self.lines:
-            if not line.reward_identifier_code:
-                continue
-            lines_per_reward_code[line.reward_identifier_code] |= line
-        for coupon in all_coupons:
-            if coupon.id in coupon_new_id_map:
-                # Coupon existed previously, update amount of points.
-                coupon.points += coupon_data[coupon_new_id_map[coupon.id]]['points']
-            for reward_code in coupon_data[coupon_new_id_map[coupon.id]].get('line_codes', []):
-                lines_per_reward_code[reward_code].coupon_id = coupon
-        # Send creation email
-        new_coupons.with_context(action_no_send_mail=False)._send_creation_communication()
+        all_coupons = self.env['loyalty.card'].sudo().browse(updated_loyalty_cards.ids).exists()
+
         # Reports per program
         report_per_program = {}
         coupon_per_report = defaultdict(list)
         # Important to include the updated gift cards so that it can be printed. Check coupon_report.
-        for coupon in new_coupons | updated_gift_cards:
+        printReportCards = updated_loyalty_cards.filtered(lambda c: coupon_data[c.id]['points'] > 0)
+        for coupon in printReportCards:
             if coupon.program_id not in report_per_program:
-                report_per_program[coupon.program_id] = coupon.program_id.communication_plan_ids.\
+                report_per_program[coupon.program_id.id] = coupon.program_id.communication_plan_ids.\
                     filtered(lambda c: c.trigger == 'create').pos_report_print_id
-            for report in report_per_program[coupon.program_id]:
+            for report in report_per_program.get(coupon.program_id.id):
                 coupon_per_report[report.id].append(coupon.id)
         return {
             'coupon_updates': [{
-                'old_id': coupon_new_id_map[coupon.id],
+                'old_id': coupon.id,
                 'id': coupon.id,
                 'points': coupon.points,
                 'code': coupon.code,
@@ -162,7 +138,7 @@ class PosOrder(models.Model):
                 'program_name': coupon.program_id.name,
                 'expiration_date': coupon.expiration_date,
                 'code': coupon.code,
-            } for coupon in new_coupons if (
+            } for coupon in updated_loyalty_cards if (
                 coupon.program_id.applies_on == 'future'
                 # Don't send the coupon code for the gift card and ewallet programs.
                 # It should not be printed in the ticket.

--- a/addons/pos_loyalty/security/ir.model.access.csv
+++ b/addons/pos_loyalty/security/ir.model.access.csv
@@ -3,7 +3,7 @@ access_program_pos_user,Loyalty Program (PoS User),loyalty.model_loyalty_program
 access_program_pos_manager,Loyalty Program (PoS Manager),loyalty.model_loyalty_program,point_of_sale.group_pos_manager,1,1,1,1
 access_applicability_pos_user,Loyalty Rule (PoS User),loyalty.model_loyalty_rule,point_of_sale.group_pos_user,1,0,0,0
 access_applicability_pos_manager,Loyalty Rule (PoS Manager),loyalty.model_loyalty_rule,point_of_sale.group_pos_manager,1,1,1,1
-access_coupon_pos_user,Loyalty (PoS User),loyalty.model_loyalty_card,point_of_sale.group_pos_user,1,1,0,0
+access_coupon_pos_user,Loyalty (PoS User),loyalty.model_loyalty_card,point_of_sale.group_pos_user,1,1,1,0
 access_coupon_pos_manager,Loyalty (PoS Manager),loyalty.model_loyalty_card,point_of_sale.group_pos_manager,1,1,1,0
 access_reward_pos_user,Loyalty Reward (PoS User),loyalty.model_loyalty_reward,point_of_sale.group_pos_user,1,0,0,0
 access_reward_pos_manager,Loyalty Reward (PoS Manager),loyalty.model_loyalty_reward,point_of_sale.group_pos_manager,1,1,1,1

--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -142,7 +142,7 @@ patch(PosOrder.prototype, {
     waitForPushOrder() {
         return (
             Object.keys(this.uiState.couponPointChanges || {}).length > 0 ||
-            this._get_reward_lines().length ||
+            this._getRewardLines().length ||
             super.waitForPushOrder(...arguments)
         );
     },
@@ -175,13 +175,13 @@ patch(PosOrder.prototype, {
 
         return [...nonRewardLines, ...rewardLines];
     },
-    _get_reward_lines() {
+    _getRewardLines() {
         if (this.lines) {
             return this.lines.filter((line) => line.is_reward_line);
         }
         return this.lines;
     },
-    _get_regular_order_lines() {
+    _getRegularOrderLines() {
         if (this.lines) {
             return this.lines.filter((line) => !line.is_reward_line && !line.refunded_orderline_id);
         }
@@ -230,7 +230,7 @@ patch(PosOrder.prototype, {
         if (!this.lines.length) {
             return;
         }
-        const rewardLines = this._get_reward_lines();
+        const rewardLines = this._getRewardLines();
         if (!rewardLines.length) {
             return;
         }
@@ -334,7 +334,7 @@ patch(PosOrder.prototype, {
             const balance = loyaltyCard.points;
             won += points - this._getPointsCorrection(program);
             if (coupon_id !== 0) {
-                for (const line of this._get_reward_lines()) {
+                for (const line of this._getRewardLines()) {
                     if (line.coupon_id.id === coupon_id) {
                         spent += line.points_cost;
                     }
@@ -680,7 +680,7 @@ patch(PosOrder.prototype, {
      * @param {*} rule
      */
     _computeNItems(rule) {
-        return this._get_regular_order_lines().reduce((nItems, line) => {
+        return this._getRegularOrderLines().reduce((nItems, line) => {
             let increment = 0;
             if (rule.any_product || rule.validProductIds.has(line.product_id.id)) {
                 increment = line.getQuantity();
@@ -1223,7 +1223,7 @@ patch(PosOrder.prototype, {
                 reward.reward_product_ids.map((reward) => reward.id).includes(product.id) &&
                 reward.reward_product_ids.map((reward) => reward.id).includes(line.getProduct().id)
             ) {
-                if (this._get_reward_lines() == 0) {
+                if (this._getRewardLines() == 0) {
                     if (line.getProduct() === product) {
                         available += line.getQuantity();
                     }
@@ -1385,7 +1385,7 @@ patch(PosOrder.prototype, {
             this.uiState.disabledRewards,
             this.uiState.codeActivatedProgramRules,
             Object.keys(this.uiState.couponPointChanges),
-            this._get_reward_lines(),
+            this._getRewardLines(),
         ];
         return array.some((elem) => elem.length > 0);
     },

--- a/addons/pos_loyalty/static/src/app/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order_line.js
@@ -5,32 +5,6 @@ import { patch } from "@web/core/utils/patch";
 patch(PosOrderline, {
     extraFields: {
         ...(PosOrderline.extraFields || {}),
-        _e_wallet_program_id: {
-            model: "pos.order.line",
-            name: "_e_wallet_program_id",
-            relation: "loyalty.program",
-            type: "many2one",
-            local: true,
-        },
-        gift_code: {
-            model: "pos.order.line",
-            name: "gift_code",
-            type: "char",
-            local: true,
-        },
-        _gift_barcode: {
-            model: "pos.order.line",
-            name: "_gift_barcode",
-            type: "char",
-            local: true,
-        },
-        _gift_card_id: {
-            model: "pos.order.line",
-            name: "_gift_card_id",
-            relation: "loyalty.card",
-            type: "many2one",
-            local: true,
-        },
         _reward_product_id: {
             model: "pos.order.line",
             name: "_reward_product_id",
@@ -42,25 +16,30 @@ patch(PosOrderline, {
 });
 
 patch(PosOrderline.prototype, {
+    initState() {
+        super.initState();
+        this.uiState = {
+            ...this.uiState,
+            programType: null,
+            giftCode: null,
+            eWalletId: null,
+            giftCardExpirationDate: null,
+        };
+    },
     setOptions(options) {
         if (options.eWalletGiftCardProgram) {
-            this._e_wallet_program_id = options.eWalletGiftCardProgram;
-        }
-        if (options.giftBarcode) {
-            this._gift_barcode = options.giftBarcode;
-        }
-        if (options.giftCardId) {
-            this._gift_card_id = options.giftCardId;
+            this.uiState.eWalletId = options.eWalletGiftCardProgram.id;
+            this.uiState.programType = options.eWalletGiftCardProgram.program_type;
         }
         return super.setOptions(...arguments);
     },
     getEWalletGiftCardProgramType() {
-        return this._e_wallet_program_id && this._e_wallet_program_id.program_type;
+        return this.uiState.programType;
     },
     ignoreLoyaltyPoints({ program }) {
         return (
             ["gift_card", "ewallet"].includes(program.program_type) &&
-            this._e_wallet_program_id?.id !== program.id
+            this.uiState.eWalletId !== program.id
         );
     },
     isGiftCardOrEWalletReward() {

--- a/addons/pos_loyalty/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/app/screens/payment_screen/payment_screen.js
@@ -30,7 +30,7 @@ patch(PaymentScreen.prototype, {
                 newCodes.push(pe.barcode);
             }
         }
-        for (const line of this.currentOrder._get_reward_lines()) {
+        for (const line of this.currentOrder._getRewardLines()) {
             let couponId = line.coupon_id.id;
             if (isNaN(Number(line.coupon_id.id))) {
                 couponId = this.pos.data.mapUuidToId(line.coupon_id.id);
@@ -96,7 +96,7 @@ patch(PaymentScreen.prototype, {
     async _postProcessLoyalty(order) {
         // Compile data for our function
         const ProgramModel = this.pos.models["loyalty.program"];
-        const rewardLines = order._get_reward_lines();
+        const rewardLines = order._getRewardLines();
         const partner = order.getPartner();
 
         let couponData = Object.values(order.uiState.couponPointChanges).reduce((agg, pe) => {

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -63,7 +63,6 @@ patch(ControlButtons.prototype, {
                     {
                         product_id: selectedProgram.trigger_product_ids[0],
                         product_tmpl_id: selectedProgram.trigger_product_ids[0].product_tmpl_id,
-                        _e_wallet_program_id: selectedProgram,
                         price_unit: -orderTotal,
                     },
                     {}

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -14,7 +14,7 @@ patch(OrderSummary.prototype, {
     async updateSelectedOrderline({ buffer, key }) {
         const selectedLine = this.currentOrder.getSelectedOrderline();
         if (key === "-") {
-            if (selectedLine && selectedLine._e_wallet_program_id) {
+            if (selectedLine && this.uiState.eWalletId) {
                 // Do not allow negative quantity or price in a gift card or ewallet orderline.
                 // Refunding gift card or ewallet is not supported.
                 this.notification.add(
@@ -73,7 +73,9 @@ patch(OrderSummary.prototype, {
                 coupon.id > 0 &&
                 this.currentOrder._code_activated_coupon_ids.find((c) => c.code === coupon.code)
             ) {
-                coupon.delete();
+                this.pos.data.withoutSyncing(() => {
+                    coupon.delete();
+                });
             }
         }
         if (
@@ -100,7 +102,7 @@ patch(OrderSummary.prototype, {
      * 1. Reduce the quantity if greater than one, otherwise remove the order line.
      * 2. Add a new order line with updated gift card code and points, removing any existing related couponPointChanges.
      */
-    async _updateGiftCardOrderline(code, points) {
+    async _updateGiftCardOrderline(code, points, expirationDate) {
         let selectedLine = this.currentOrder.getSelectedOrderline();
         const product = selectedLine.product_id;
 
@@ -134,7 +136,8 @@ patch(OrderSummary.prototype, {
             { price_unit: points }
         );
         selectedLine = this.currentOrder.getSelectedOrderline();
-        selectedLine.gift_code = code;
+        selectedLine.uiState.giftCode = code;
+        selectedLine.uiState.giftCardExpirationDate = expirationDate;
     },
 
     manageGiftCard() {
@@ -169,8 +172,8 @@ patch(OrderSummary.prototype, {
                     return;
                 }
 
-                await this._updateGiftCardOrderline(code, points);
                 this.currentOrder.processGiftCard(code, points, expirationDate);
+                await this._updateGiftCardOrderline(code, points, expirationDate);
             },
         });
     },

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -6,8 +6,8 @@
                 Current Balance: <t t-esc="line.getGiftCardOrEWalletBalance()"/>
             </li>
             <t t-if="!line.isGiftCardOrEWalletReward() and line.getEWalletGiftCardProgramType() === 'gift_card'">
-                <a t-if="!line.gift_code" class="text-wrap text-action" t-on-click="manageGiftCard">Sell physical gift card?</a>
-                <div t-if="line.gift_code" class="text-wrap" t-esc="line.gift_code"/>
+                <a t-if="!line.uiState.giftCode" class="text-wrap text-action" t-on-click="manageGiftCard">Sell physical gift card?</a>
+                <div t-if="line.uiState.giftCode" class="text-wrap" t-esc="line.uiState.giftCode"/>
             </t>
         </xpath>
         <xpath expr="//OrderDisplay/t[@t-set-slot='details']" position="inside">

--- a/addons/pos_loyalty/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_loyalty/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -42,7 +42,7 @@ patch(TicketScreen.prototype, {
         );
     },
     _isEWalletGiftCard(orderline) {
-        if (orderline.is_reward_line) {
+        if (orderline?.is_reward_line) {
             const reward = orderline.reward_id;
             const program = reward && reward.program_id;
             if (program && ["gift_card", "ewallet"].includes(program.program_type)) {

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -6,7 +6,6 @@ import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { Domain, InvalidDomainError } from "@web/core/domain";
 import { ask, makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { Mutex } from "@web/core/utils/concurrency";
-import { serializeDate } from "@web/core/l10n/dates";
 
 let nextId = -1;
 const mutex = new Mutex();
@@ -101,19 +100,22 @@ patch(PosStore.prototype, {
             })
         );
     },
-    async couponForProgram(program) {
+    async couponForProgram(program, code, expiration_date) {
         const order = this.getOrder();
-        if (program.is_nominative) {
+        // Use the available coupon for the program with is_nominative
+        if (program.is_nominative && order?.getPartner()) {
             return await this.fetchLoyaltyCard(program.id, order.getPartner().id);
         }
-        // This type of coupons don't need to really exist up until validating the order, so no need to cache
-        return this.models["loyalty.card"].create({
-            id: loyaltyIdsGenerator(),
-            code: null,
+        const createCouponData = {
             program_id: program,
             partner_id: order.partner_id,
             points: 0,
-        });
+            expiration_date: expiration_date,
+        };
+        if (code) {
+            createCouponData.code = code;
+        }
+        return this.models["loyalty.card"].create(createCouponData);
     },
     /**
      * Update our couponPointChanges, meaning the points/coupons each program give etc.
@@ -158,31 +160,42 @@ patch(PosStore.prototype, {
             }
             const oldChanges = changesPerProgram[program.id] || [];
             // Update point changes for those that exist
-            for (
-                let idx = 0;
-                idx < Math.min(pointsAdded.length, oldChanges.length) && !oldChanges[idx].manual;
-                idx++
-            ) {
+            for (let idx = 0; idx < Math.min(pointsAdded.length, oldChanges.length); idx++) {
                 Object.assign(oldChanges[idx], pointsAdded[idx]);
             }
             if (pointsAdded.length < oldChanges.length) {
-                const removedIds = oldChanges.map((pe) => pe.coupon_id);
+                const removedIds = oldChanges.map(
+                    (pe) => !pointsAdded.includes(pe.points) && pe.coupon_id
+                );
+                const autoGiftCardPoints = pointsAdded
+                    .filter((pa) => !pa.barcode)
+                    .map((pa) => pa.points);
+                const giftCodes = pointsAdded.filter((pa) => pa.barcode).map((pa) => pa.barcode);
                 order.uiState.couponPointChanges = Object.fromEntries(
-                    Object.entries(order.uiState.couponPointChanges).filter(
-                        ([k, pe]) => !removedIds.includes(pe.coupon_id)
-                    )
+                    Object.entries(order.uiState.couponPointChanges).filter(([k, pe]) => {
+                        if (pe.program_id !== program.id) {
+                            return true;
+                        } else if (pe.barcode && pe.manual && giftCodes.includes(pe.barcode)) {
+                            return true;
+                        } else if (!pe.barcode && autoGiftCardPoints.length) {
+                            autoGiftCardPoints.pop();
+                            return true;
+                        } else if (!removedIds.includes(pe.coupon_id)) {
+                            return true;
+                        }
+                    })
                 );
             } else if (pointsAdded.length > oldChanges.length) {
                 const pointsCount = pointsAdded.reduce((acc, pointObj) => {
-                    const { points, barcode = "" } = pointObj;
-                    const key = barcode ? `${points}-${barcode}` : `${points}`;
+                    const { points, barcode = "", expiration_date = "" } = pointObj;
+                    const key = barcode ? `${points}_${barcode}_${expiration_date}` : `${points}`;
                     acc[key] = (acc[key] || 0) + 1;
                     return acc;
                 }, {});
 
                 oldChanges.forEach((pointObj) => {
-                    const { points, barcode = "" } = pointObj;
-                    const key = barcode ? `${points}-${barcode}` : `${points}`;
+                    const { points, barcode = "", expiration_date = "" } = pointObj;
+                    const key = barcode ? `${points}_${barcode}_${expiration_date}` : `${points}`;
                     if (pointsCount[key] && pointsCount[key] > 0) {
                         pointsCount[key]--;
                     }
@@ -191,28 +204,30 @@ patch(PosStore.prototype, {
                 // Get new points added which are not in oldChanges
                 const newPointsAdded = [];
                 Object.keys(pointsCount).forEach((key) => {
-                    const [points, barcode = ""] = key.split("-");
+                    const [points, barcode = false, expiration_date = false] = key.split("-");
                     while (pointsCount[key] > 0) {
-                        newPointsAdded.push({ points: Number(points), barcode });
+                        newPointsAdded.push({ points: Number(points), barcode, expiration_date });
                         pointsCount[key]--;
                     }
                 });
 
                 for (const pa of newPointsAdded) {
-                    const coupon = await this.couponForProgram(program);
+                    const coupon = await this.couponForProgram(
+                        program,
+                        pa.barcode,
+                        pa.expiration_date
+                    );
                     const couponPointChange = {
                         points: pa.points,
                         program_id: program.id,
                         coupon_id: coupon.id,
-                        barcode: pa.barcode,
                         appliedRules: pointsForProgramsCountedRules[program.id],
+                        couponUuid: coupon.uuid,
                     };
                     if (program && program.program_type === "gift_card") {
                         couponPointChange.product_id = order.getSelectedOrderline()?.product_id.id;
-                        couponPointChange.expiration_date = serializeDate(
-                            luxon.DateTime.now().plus({ year: 1 })
-                        );
-                        couponPointChange.code = order.getSelectedOrderline()?.gift_code;
+                        couponPointChange.expiration_date = pa.expiration_date;
+                        couponPointChange.barcode = pa.barcode;
                         couponPointChange.partner_id = order.getPartner()?.id;
                     }
 
@@ -295,17 +310,10 @@ patch(PosStore.prototype, {
                         return _t("Unpaid gift card rejected.");
                     }
                 }
-                // TODO JCB: It's possible that the coupon is already loaded. We should check for that.
-                //   - At the moment, creating a new one with existing id creates a duplicate.
-                coupon = this.models["loyalty.card"].create({
-                    id: payload.coupon_id,
-                    code: code,
-                    program_id: this.models["loyalty.program"].get(payload.program_id),
-                    partner_id: this.models["res.partner"].get(payload.partner_id),
-                    points: payload.points,
-                    // TODO JCB: make the expiration_date work.
-                    // expiration_date: payload.expiration_date,
-                });
+
+                [coupon] = await this.data.searchRead("loyalty.card", [
+                    ["uuid", "=", payload.uuid],
+                ]);
                 order._code_activated_coupon_ids = [["link", coupon]];
                 await this.orderUpdateLoyaltyPrograms();
                 claimableRewards = order.getClaimableRewards(coupon.id);
@@ -588,9 +596,11 @@ patch(PosStore.prototype, {
         const domain = new Domain(reward_product_domain);
 
         try {
-            reward.all_discount_product_ids = [
-                ["link", ...products.filter((p) => domain.contains(p.raw))],
-            ];
+            this.data.withoutSyncing(() => {
+                reward.all_discount_product_ids = [
+                    ["link", ...products.filter((p) => domain.contains(p.raw))],
+                ];
+            });
         } catch (error) {
             if (!(error instanceof InvalidDomainError || error instanceof TypeError)) {
                 throw error;
@@ -651,8 +661,6 @@ patch(PosStore.prototype, {
         let dbCoupon = fetchedCoupons.length > 0 ? fetchedCoupons[0] : null;
         if (!dbCoupon) {
             dbCoupon = await this.models["loyalty.card"].create({
-                id: loyaltyIdsGenerator(),
-                code: null,
                 program_id: this.models["loyalty.program"].get(programId),
                 partner_id: this.models["res.partner"].get(partnerId),
                 points: 0,

--- a/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
@@ -1,9 +1,11 @@
 import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
+import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("EWalletProgramTour1", {
@@ -26,7 +28,8 @@ registry.category("web_tour.tours").add("EWalletProgramTour1", {
             ProductScreen.clickCustomer("BBBBBBB"),
             ProductScreen.addOrderline("Top-up eWallet", "1", "10"),
             PosLoyalty.orderTotalIs("10.00"),
-            PosLoyalty.finalizeOrder("Cash", "10"),
+            PosLoyalty.finalizeOrder("Cash", "10", false),
+            ReceiptScreen.isShown(),
         ].flat(),
 });
 
@@ -98,7 +101,11 @@ registry.category("web_tour.tours").add("EWalletProgramTour2", {
             // - Refund order.
             ...ProductScreen.clickRefund(),
             TicketScreen.filterIs("Paid"),
-            TicketScreen.selectOrder("007"),
+            TicketScreen.selectOrder("006"),
+            Order.hasLine({
+                run: "click",
+                productName: "Whiteboard Pen",
+            }),
             TicketScreen.confirmRefund(),
             ProductScreen.isShown(),
             PosLoyalty.eWalletButtonState({

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -41,7 +41,7 @@ registry.category("web_tour.tours").add("GiftCardWithRefundtTour", {
             ...ProductScreen.clickRefund(),
             TicketScreen.selectOrder("001"),
             Order.hasLine({
-                withClass: ".selected",
+                run: "click",
                 productName: "Magnetic Board",
             }),
             ProductScreen.clickNumpad("1"),

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -5,6 +5,7 @@ import * as SelectionPopup from "@point_of_sale/../tests/generic_helpers/selecti
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as Notification from "@point_of_sale/../tests/generic_helpers/notification_util";
+import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import { registry } from "@web/core/registry";
 import { scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 
@@ -75,7 +76,7 @@ registry.category("web_tour.tours").add("PosLoyaltyTour1", {
             PosLoyalty.enterCode("promocode"),
             PosLoyalty.hasRewardLine("50% on specific products", "-16.66"), // 17.55 - 1.78*0.5
             PosLoyalty.orderTotalIs("37.78"),
-            PosLoyalty.finalizeOrder("Cash", "50"),
+            PosLoyalty.finalizeOrder("Cash", "50", false),
         ].flat(),
 });
 
@@ -460,7 +461,7 @@ registry.category("web_tour.tours").add("PosLoyaltyArchivedRewardProductsInactiv
             ProductScreen.clickCustomer("AAAA"),
             PosLoyalty.isRewardButtonHighlighted(false, true),
             ProductScreen.selectedOrderlineHas("Test Product A", "1", "100.00"),
-            PosLoyalty.finalizeOrder("Cash", "100"),
+            PosLoyalty.finalizeOrder("Cash", "100", false),
         ].flat(),
 });
 
@@ -468,12 +469,14 @@ registry.category("web_tour.tours").add("PosLoyaltyArchivedRewardProductsActive"
     steps: () =>
         [
             Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
             ProductScreen.clickDisplayedProduct("Test Product A"),
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("AAAA"),
             PosLoyalty.isRewardButtonHighlighted(true),
             ProductScreen.selectedOrderlineHas("Test Product A", "1", "100.00"),
-            PosLoyalty.finalizeOrder("Cash", "100"),
+            PosLoyalty.finalizeOrder("Cash", "100", false),
         ].flat(),
 });
 
@@ -533,12 +536,11 @@ registry.category("web_tour.tours").add("PosRewardProductScan", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-
             scan_barcode("95412427100283"),
             ProductScreen.selectedOrderlineHas("product_a", "1", "1,150.00"),
             PosLoyalty.hasRewardLine("50% on your order", "-575.00"),
             PosLoyalty.orderTotalIs("575.00"),
-            PosLoyalty.finalizeOrder("Cash", "575.00"),
+            PosLoyalty.finalizeOrder("Cash", "575.00", false),
         ].flat(),
 });
 
@@ -546,6 +548,7 @@ registry.category("web_tour.tours").add("PosRewardProductScanGS1", {
     steps: () =>
         [
             Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
             scan_barcode("0195412427100283"),
             ProductScreen.selectedOrderlineHas("product_a", "1", "1,150.00"),
             PosLoyalty.hasRewardLine("50% on your order", "-575.00"),
@@ -576,6 +579,10 @@ registry.category("web_tour.tours").add("RefundRulesProduct", {
             ...ProductScreen.clickRefund(),
             TicketScreen.filterIs("Paid"),
             TicketScreen.selectOrder("001"),
+            Order.hasLine({
+                run: "click",
+                productName: "product_a",
+            }),
             ProductScreen.clickNumpad("1"),
             TicketScreen.confirmRefund(),
             ProductScreen.isShown(),

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -119,14 +119,17 @@ export function pointsAwardedAre(points_str) {
         },
     ];
 }
-export function finalizeOrder(paymentMethod, amount) {
-    return [
+export function finalizeOrder(paymentMethod, amount, nextOrder = true) {
+    const steps = [
         ...ProductScreen.clickPayButton(),
         ...PaymentScreen.clickPaymentMethod(paymentMethod),
         ...PaymentScreen.clickNumpad([...amount].join(" ")),
         ...PaymentScreen.clickValidate(),
-        ...ReceiptScreen.clickNextOrder(),
     ];
+    if (nextOrder) {
+        steps.push(...ReceiptScreen.clickNextOrder());
+    }
+    return steps;
 }
 export function removeRewardLine(name) {
     return [selectRewardLine(name), ProductScreen.clickNumpad("⌫"), Dialog.confirm()].flat();

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -360,11 +360,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'points': 100,
         })
 
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyChangeRewardQty",
-            login="pos_user",
-        )
+        self.start_pos_tour("PosLoyaltyChangeRewardQty")
 
     def test_loyalty_free_product_zero_sale_price_loyalty_program(self):
         # In this program, each $ spent gives 1 point.
@@ -1340,7 +1336,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
 
-        self.start_pos_tour("PosLoyaltyPromotion", login="pos_admin")
+        self.start_pos_tour("PosLoyaltyPromotion")
 
     def test_promo_with_free_product(self):
         self.env['loyalty.program'].search([]).write({'active': False})
@@ -1669,11 +1665,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyTour12",
-            login="pos_user",
-        )
+        self.start_pos_tour("PosLoyaltyTour12")
 
     def test_promotion_with_min_amount_and_specific_product_rule(self):
         """
@@ -1714,11 +1706,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.open_ui()
-        self.start_tour(
-            '/pos/ui/%d' % self.main_pos_config.id,
-            'PosLoyaltyMinAmountAndSpecificProductTour',
-            login='pos_user',
-        )
+        self.start_pos_tour('PosLoyaltyMinAmountAndSpecificProductTour')
 
     def test_gift_card_price_no_tax(self):
         """
@@ -1748,11 +1736,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         gift_card_program.coupon_ids.code = '043123456'
 
         # Run the tour. It will use the gift card.
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "GiftCardProgramPriceNoTaxTour",
-            login="pos_user"
-        )
+        self.start_pos_tour("GiftCardProgramPriceNoTaxTour")
 
     def test_physical_gift_card_sale(self):
         """
@@ -1767,11 +1751,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         gift_card_program = self.create_programs([('arbitrary_name', 'gift_card')])['arbitrary_name']
 
         # Run the tour
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PhysicalGiftCardProgramSaleTour",
-            login="pos_user"
-        )
+        self.start_pos_tour("PhysicalGiftCardProgramSaleTour")
 
         expected_coupons = {
             "test-card-0000": 125,
@@ -1833,11 +1813,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyDontGrantPointsForRewardOrderLines",
-            login="pos_user",
-        )
+        self.start_pos_tour("PosLoyaltyDontGrantPointsForRewardOrderLines")
 
         loyalty_card = loyalty_program.coupon_ids.filtered(lambda coupon: coupon.partner_id.id == partner.id)
 
@@ -1874,11 +1850,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyPointsGlobalDiscountProgramNoDomain",
-            login="pos_user",
-        )
+        self.start_pos_tour("PosLoyaltyPointsGlobalDiscountProgramNoDomain")
         self.assertEqual(loyalty_card.points, 90)
 
     def test_points_awarded_discount_code_no_domain_program(self):
@@ -1921,11 +1893,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             })
 
         self.main_pos_config.open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyPointsDiscountNoDomainProgramNoDomain",
-            login="pos_user",
-        )
+        self.start_pos_tour("PosLoyaltyPointsDiscountNoDomainProgramNoDomain")
         self.assertEqual(loyalty_card.points, 135)
 
     def test_points_awarded_general_discount_code_specific_domain_program(self):
@@ -1978,11 +1946,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             })
 
         self.main_pos_config.open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyPointsDiscountNoDomainProgramDomain",
-            login="pos_user",
-        )
+        self.start_pos_tour("PosLoyaltyPointsDiscountNoDomainProgramDomain")
         self.assertEqual(loyalty_card.points, 100)
 
     def test_points_awarded_specific_discount_code_specific_domain_program(self):
@@ -2040,11 +2004,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         discount_product.available_in_pos = True
 
         self.main_pos_config.open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyPointsDiscountWithDomainProgramDomain",
-            login="pos_user",
-        )
+        self.start_pos_tour("PosLoyaltyPointsDiscountWithDomainProgramDomain")
         self.assertEqual(loyalty_card.points, 90)
 
     def test_points_awarded_ewallet(self):
@@ -2130,11 +2090,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyPointsGiftcard",
-            login="pos_user",
-        )
+        self.start_pos_tour("PosLoyaltyPointsGiftcard")
         self.assertEqual(loyalty_card.points, 100)
 
     def test_archived_reward_products(self):
@@ -2191,20 +2147,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.product_b.active = False
         product_c.active = False
 
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyArchivedRewardProductsInactive",
-            login="pos_user",
-        )
+        self.start_pos_tour("PosLoyaltyArchivedRewardProductsInactive")
         current_session_id = self.main_pos_config.current_session_id
         current_session_id.post_closing_cash_details(100.0)
         current_session_id.close_session_from_ui()
         product_c.active = True
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyArchivedRewardProductsActive",
-            login="pos_user"
-        )
+        self.start_pos_tour("PosLoyaltyArchivedRewardProductsActive")
 
     def test_change_reward_value_with_language(self):
         """
@@ -2243,11 +2191,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         loyalty_program.reward_ids.update_field_translations('description', {'en_US': 'A en_US name which should not be displayed'})
 
         self.main_pos_config.open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "ChangeRewardValueWithLanguage",
-            login="pos_user",
-        )
+        self.start_pos_tour("ChangeRewardValueWithLanguage")
 
     def test_loyalty_reward_product_tag(self):
         """
@@ -2280,11 +2224,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyRewardProductTag",
-            login="pos_user",
-        )
+        self.start_pos_tour("PosLoyaltyRewardProductTag")
 
     def test_gift_card_rewards_using_taxes(self):
         """
@@ -2308,11 +2248,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         gift_card_program.payment_program_discount_product_id.taxes_id = self.tax01
 
         self.main_pos_config.open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyGiftCardTaxes",
-            login="accountman",
-        )
+        self.start_pos_tour("PosLoyaltyGiftCardTaxes", login="accountman")
         self.main_pos_config.current_session_id.close_session_from_ui()
 
     def test_customer_loyalty_points_displayed(self):
@@ -2425,11 +2361,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'pos_config_ids': [Command.link(self.main_pos_config.id)],
         })
         self.main_pos_config.with_user(self.pos_admin).open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosRewardProductScan",
-            login="pos_admin"
-        )
+        self.start_pos_tour("PosRewardProductScan", login="pos_admin")
 
         # Check that there should be one paid order with reward line and not draft order
         current_session_id = self.main_pos_config.current_session_id
@@ -2444,11 +2376,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         # check the same flow with gs1 nomenclature
         self.env.company.nomenclature_id = self.env.ref('barcodes_gs1_nomenclature.default_gs1_nomenclature')
         self.main_pos_config.with_user(self.pos_admin).open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosRewardProductScanGS1",
-            login="pos_admin"
-        )
+        self.start_pos_tour("PosRewardProductScanGS1", login="pos_admin")
 
         # Check that there should be one paid order with reward line and not draft order
         current_session_id = self.main_pos_config.current_session_id
@@ -2531,11 +2459,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.env['res.partner'].create({'name': 'A Test Partner'})
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "GiftCardProgramInvoice",
-            login="pos_user",
-        )
+        self.start_pos_tour("GiftCardProgramInvoice")
         self.assertEqual(len(gift_card_program.coupon_ids), 1)
 
     def test_refund_product_part_of_rules(self):
@@ -2561,11 +2485,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "RefundRulesProduct",
-            login="pos_user",
-        )
+        self.start_pos_tour("RefundRulesProduct")
 
     def test_cheapest_product_tax_included(self):
         tax_01 = self.env['account.tax'].create({
@@ -2623,11 +2543,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(
-            "/pos/ui/%d" % self.main_pos_config.id,
-            "PosLoyaltyNextOrderCouponExpirationDate",
-            login="pos_user",
-        )
+        self.start_pos_tour("PosLoyaltyNextOrderCouponExpirationDate")
 
         coupon = loyalty_program.coupon_ids
         self.assertEqual(len(coupon), 1, "Coupon not generated")
@@ -2704,11 +2620,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         gift_card_program = self.create_programs([('arbitrary_name', 'gift_card')])['arbitrary_name']
 
         # Run the tour
-        self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
-            "test_physical_gift_card_invoiced",
-            login="pos_user",
-        )
+        self.start_pos_tour("test_physical_gift_card_invoiced")
 
         self.assertEqual(len(gift_card_program.coupon_ids), 1, "Gift card not generated")
         self.assertEqual(gift_card_program.coupon_ids[0].code, "test-card-1234", "Gift card code not correct")

--- a/addons/pos_loyalty/tests/test_loyalty_history.py
+++ b/addons/pos_loyalty/tests/test_loyalty_history.py
@@ -34,7 +34,7 @@ class TestPOSLoyaltyHistory(TestPointOfSaleHttpCommon):
                 'discount_applicability': 'order',
             })],
         })
-        self.start_pos_tour("LoyaltyHistoryTour")
+        self.start_pos_tour("LoyaltyHistoryTour", login="pos_admin")
         loyalty_card = loyalty_program.coupon_ids.filtered(lambda coupon: coupon.partner_id.id == partner_aaa.id)
         self.assertEqual(len(loyalty_card.history_ids), 1,
                         "Loyalty History line should be created on pos oder confirmation")

--- a/addons/pos_restaurant_loyalty/__manifest__.py
+++ b/addons/pos_restaurant_loyalty/__manifest__.py
@@ -2,7 +2,7 @@
 
 
 {
-    'name': 'POS - Restaurant Loyality',
+    'name': 'POS - Restaurant Loyalty',
     'version': '1.0',
     'category': 'Sales/Point of Sale',
     'sequence': 6,

--- a/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantGiftCardTour.js
+++ b/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantGiftCardTour.js
@@ -1,0 +1,29 @@
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util";
+import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("PosRestaurantGiftCardReturnFromFloor", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("4"),
+            ProductScreen.addOrderline("Gift Card", "1", "50", "50"),
+            PosLoyalty.createManualGiftCard("dummy-card-0000", 125),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1", "125"),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            FloorScreen.clickTable("4"),
+            Order.hasLine({
+                run: "click",
+                productName: "Gift Card",
+            }),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1", "125"),
+            PosLoyalty.orderTotalIs("125"),
+            PosLoyalty.finalizeOrder("Cash", "125"),
+        ].flat(),
+});

--- a/addons/pos_restaurant_loyalty/tests/test_pos_restaurant_loyalty.py
+++ b/addons/pos_restaurant_loyalty/tests/test_pos_restaurant_loyalty.py
@@ -1,12 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.pos_restaurant.tests.test_frontend import TestFrontend
+from odoo.addons.pos_loyalty.tests.test_frontend import TestUi
 from odoo.tests import tagged
 from odoo import Command
 
 
 @tagged("post_install", "-at_install")
-class TestPoSRestaurantLoyalty(TestFrontend):
+class TestPoSRestaurantLoyalty(TestFrontend, TestUi):
     def test_change_table_rewards_stay(self):
         """
         Test that make sure that rewards stay on the order when leaving the table
@@ -28,3 +29,23 @@ class TestPoSRestaurantLoyalty(TestFrontend):
         })
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour("PosRestaurantRewardStay")
+
+    def test_physical_gift_card_return_from_floor(self):
+        """
+        Test that make sure that physical gift card can be generated successfully after returning
+        from floor
+        """
+        LoyaltyProgram = self.env['loyalty.program']
+        # Deactivate all other programs to avoid interference and activate the gift_card_product_50
+        LoyaltyProgram.search([]).write({'pos_ok': False})
+        self.env.ref('loyalty.gift_card_product_50').product_tmpl_id.write({'active': True})
+
+        # Create gift card program
+        gift_card_program = self.create_programs([('arbitrary_name', 'gift_card')])['arbitrary_name']
+
+        # Run the tour
+        self.start_pos_tour("PosRestaurantGiftCardReturnFromFloor", login="pos_user")
+
+        gift_card = self.env['loyalty.card'].search([('program_id', '=', gift_card_program.id)], limit=1)
+        self.assertEqual(gift_card.code, 'dummy-card-0000', "Latest generated gift card code should be 'dummy-card-0000'")
+        self.assertEqual(gift_card.points, 125, "Latest generated gift card points should be 125")

--- a/addons/pos_sale_loyalty/__manifest__.py
+++ b/addons/pos_sale_loyalty/__manifest__.py
@@ -3,7 +3,7 @@
 
 
 {
-    'name': 'POS - Sales Loyality',
+    'name': 'POS - Sales Loyalty',
     'version': '1.0',
     'category': 'Sales/Point of Sale',
     'sequence': 6,


### PR DESCRIPTION
pos*: point_of_sale, pos_event, pos_restaurant_loaylty, pos_sale_loyalty

In this commit:
==========
- We are adding real-time synchronisation for loyalty for real-time loyalty card creation. Created loyalty cards from pos will be updated on order validation with the `confirm_coupon_programs` method call. We will update the loyalty cards' original ID with UUID in order's couponChangePoints uiState before the method call, so that it will be easy to maintain loyalty cards in pos.
- We are removing extra fields from orderlines.
- Updating `start_tour` with `start_pos_tour` in test cases.
- Added test case `test_physical_gift_card_return_from_floor` to test the physical gift card in the restaurant.
- We are replacing module names typo `loyality` with `loyalty` in pos_restaurant_loyalty and pos_sale_loyalty modules.
- Also, we are fixing test cases in the `pos_event` module.

task-4766756