### PR TITLE
[FIX] website: default colorpicker tab = "custom" in theme colors option

### DIFF
--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
@@ -18,16 +18,19 @@
                                 title="Primary"
                                 action="'customizeWebsiteColor'"
                                 actionParam="'o-color-1'"
-                                enabledTabs="['solid', 'custom']"/>
+                                enabledTabs="['solid', 'custom']"
+                                selectedTab="'custom'"/>
                             <BuilderColorPicker
                                 title="Secondary"
                                 action="'customizeWebsiteColor'"
                                 actionParam="'o-color-2'"
-                                enabledTabs="['solid', 'custom']"/>
+                                enabledTabs="['solid', 'custom']"
+                                selectedTab="'custom'"/>
                             <BuilderColorPicker
                                 action="'customizeWebsiteColor'"
                                 actionParam="'o-color-3'"
-                                enabledTabs="['solid', 'custom']"/>
+                                enabledTabs="['solid', 'custom']"
+                                selectedTab="'custom'"/>
                         </div>
                     </div>
                     <div class="d-flex flex-column h-100 justify-content-between">
@@ -36,11 +39,13 @@
                             <BuilderColorPicker
                                 action="'customizeWebsiteColor'"
                                 actionParam="'o-color-4'"
-                                enabledTabs="['solid', 'custom']"/>
+                                enabledTabs="['solid', 'custom']"
+                                selectedTab="'custom'"/>
                             <BuilderColorPicker
                                 action="'customizeWebsiteColor'"
                                 actionParam="'o-color-5'"
-                                enabledTabs="['solid', 'custom']"/>
+                                enabledTabs="['solid', 'custom']"
+                                selectedTab="'custom'"/>
                         </div>
                     </div>
                     <div class="d-flex flex-column h-100">


### PR DESCRIPTION
[QSM, firefox] When configuring a theme color, the custom tab of the colorpicker should be opened by default https://drive.google.com/file/d/1htnIdpQhwQpIHNkhVeLZpadSxo1Zvly5/view?usp=drive_link