### PR TITLE
Refresh Dynamic Snippet Carousel when scrolling mode is changed

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel.edit.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel.edit.js
@@ -1,0 +1,20 @@
+import { DynamicSnippetCarousel } from "@website/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel";
+import { registry } from "@web/core/registry";
+
+const DynamicSnippetCarouselEdit = (I) =>
+    class extends I {
+        getConfigurationSnapshot() {
+            let snapshot = super.getConfigurationSnapshot();
+            if (this.el.classList.contains("o_carousel_multi_items")) {
+                snapshot = JSON.parse(snapshot || "{}");
+                snapshot.multi_items = true;
+                snapshot = JSON.stringify(snapshot);
+            }
+            return snapshot;
+        }
+    };
+
+registry.category("public.interactions.edit").add("website.dynamic_snippet_carousel", {
+    Interaction: DynamicSnippetCarousel,
+    mixin: DynamicSnippetCarouselEdit,
+});

--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel.js
@@ -28,9 +28,3 @@ export class DynamicSnippetCarousel extends DynamicSnippet {
 registry
     .category("public.interactions")
     .add("website.dynamic_snippet_carousel", DynamicSnippetCarousel);
-
-registry
-    .category("public.interactions.edit")
-    .add("website.dynamic_snippet_carousel", {
-        Interaction: DynamicSnippetCarousel,
-    });


### PR DESCRIPTION
This commit fixes the following bug:
> [QSM] Add the dynamic products snippet -> Change the "scrolling mode" to "single" => It does not change anything