### PR TITLE
[FIX] html_editor: link popover not disappearing when clicking on editor

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -682,17 +682,22 @@ class AccountReportExpression(models.Model):
 
         self._strip_formula(vals)
 
+        tax_tags_expressions = self.filtered(lambda x: x.engine == 'tax_tags')
+
         if vals.get('engine') == 'tax_tags':
-            tag_name = vals.get('formula') or self.formula
-            country = self.report_line_id.report_id.country_id
-            self._create_tax_tags(tag_name, country)
-            return super().write(vals)
+            # We already generate the tags for the expressions receiving a new engine, but keeping the same formula
+            tags_create_vals = []
+            for expression_with_new_engine in self - tax_tags_expressions:
+                tags_create_vals += self.env['account.report.expression']._get_tags_create_vals(
+                    vals.get('formula') or expression_with_new_engine.formula,
+                    expression_with_new_engine.report_line_id.report_id.country_id.id,
+                )
+            self.env['account.account.tag'].create(tags_create_vals)
 
         # In case the engine is changed we don't propagate any change to the tags themselves
         if 'formula' not in vals or (vals.get('engine') and vals['engine'] != 'tax_tags'):
             return super().write(vals)
 
-        tax_tags_expressions = self.filtered(lambda x: x.engine == 'tax_tags')
         former_formulas_by_country = defaultdict(lambda: [])
         for expr in tax_tags_expressions:
             former_formulas_by_country[expr.report_line_id.report_id.country_id].append(expr.formula)

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -685,13 +685,17 @@ class AccountReportExpression(models.Model):
         tax_tags_expressions = self.filtered(lambda x: x.engine == 'tax_tags')
 
         if vals.get('engine') == 'tax_tags':
-            # We already generate the tags for the expressions receiving a new engine, but keeping the same formula
+            # We already generate the tags for the expressions receiving a new engine
             tags_create_vals = []
             for expression_with_new_engine in self - tax_tags_expressions:
-                tags_create_vals += self.env['account.report.expression']._get_tags_create_vals(
-                    vals.get('formula') or expression_with_new_engine.formula,
-                    expression_with_new_engine.report_line_id.report_id.country_id.id,
-                )
+                tag_name = vals.get('formula') or expression_with_new_engine.formula
+                country = expression_with_new_engine.report_line_id.report_id.country_id
+                if not self.env['account.account.tag']._get_tax_tags(tag_name, country.id):
+                    tags_create_vals += self.env['account.report.expression']._get_tags_create_vals(
+                        tag_name,
+                        country.id,
+                    )
+
             self.env['account.account.tag'].create(tags_create_vals)
 
         # In case the engine is changed we don't propagate any change to the tags themselves

--- a/addons/account/tests/test_tax_report.py
+++ b/addons/account/tests/test_tax_report.py
@@ -280,6 +280,27 @@ class TaxReportTest(AccountTestInvoicingCommon):
         self.assertEqual(len(tags_after), 2, "Changing the engine should have created tags")
         self.assertEqual(tags_after.mapped('name'), ['-Dudu', '+Dudu'])
 
+    def test_change_engine_shared_tags(self):
+        aggregation_line = self.env['account.report.line'].create({
+            'name': "Je ne mange pas de graines !!!",
+            'report_id': self.tax_report_1.id,
+            'expression_ids': [
+                Command.create({
+                    'label': 'balance',
+                    'engine': 'aggregation',
+                    'formula': 'Dudu',
+                }),
+            ],
+        })
+
+        tags_before = self._get_tax_tags(self.test_country_1, tag_name='01')
+        self.assertEqual(len(tags_before), 2, "The tags should already exist because of another expression")
+
+        aggregation_line.expression_ids.write({'engine': 'tax_tags', 'formula': '01'})
+
+        tags_after = self._get_tax_tags(self.test_country_1, tag_name='01')
+        self.assertEqual(tags_after, tags_before, "No new tag should have been created")
+
     def test_change_formula_multiple_fields(self):
         tags_before = self._get_tax_tags(self.test_country_1, tag_name='Buny')
         self.assertFalse(tags_before, "The tags shouldn't exist yet")

--- a/addons/account/tests/test_tax_report.py
+++ b/addons/account/tests/test_tax_report.py
@@ -257,3 +257,41 @@ class TaxReportTest(AccountTestInvoicingCommon):
         tags_after = self._get_tax_tags(self.test_country_1, tag_name=tag_name, active_test=False)
         self.assertEqual(len(tags_after), 2, "When creating a tax report line with an archived tag and it's complement doesn't exist, it should be re-created.")
         self.assertEqual(tags_after.mapped('name'), ['+' + tag_name, '-' + tag_name], "After creating a tax report line with an archived tag and when its complement doesn't exist, both a negative and a positive tag should be created.")
+
+    def test_change_engine_without_formula(self):
+        aggregation_line = self.env['account.report.line'].create({
+            'name': "Je ne mange pas de graines !!!",
+            'report_id': self.tax_report_1.id,
+            'expression_ids': [
+                Command.create({
+                    'label': 'balance',
+                    'engine': 'aggregation',
+                    'formula': 'Dudu',
+                }),
+            ],
+        })
+
+        tags_before = self._get_tax_tags(self.test_country_1, tag_name='Dudu')
+        self.assertFalse(tags_before, "The tags shouldn't exist yet")
+
+        aggregation_line.expression_ids.engine = 'tax_tags'
+
+        tags_after = self._get_tax_tags(self.test_country_1, tag_name='Dudu')
+        self.assertEqual(len(tags_after), 2, "Changing the engine should have created tags")
+        self.assertEqual(tags_after.mapped('name'), ['-Dudu', '+Dudu'])
+
+    def test_change_formula_multiple_fields(self):
+        tags_before = self._get_tax_tags(self.test_country_1, tag_name='Buny')
+        self.assertFalse(tags_before, "The tags shouldn't exist yet")
+
+        tags_to_rename = self._get_tax_tags(self.test_country_1, tag_name='55')
+
+        self.tax_report_line_1_55.expression_ids.write({
+            'engine': 'tax_tags',  # Same value as before
+            'formula': 'Buny',
+        })
+
+        tags_after = self._get_tax_tags(self.test_country_1, tag_name='Buny')
+        self.assertEqual(len(tags_after), 2, "Changing the formula should have renamed the tags")
+        self.assertEqual(tags_after.mapped('name'), ['-Buny', '+Buny'])
+        self.assertEqual(tags_after, tags_to_rename, "Changing the formula should have renamed the tags")

--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
@@ -4,7 +4,7 @@ from requests import Response
 from unittest.mock import patch
 
 import odoo
-from odoo.tools.misc import file_open, limited_field_access_token
+from odoo.tools.misc import file_open
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.cloud_storage_azure.tests.test_cloud_storage_azure import TestCloudStorageAzureCommon
 
@@ -65,9 +65,7 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
                                     "id": attachment.id,
                                     "mimetype": "text/x-python",
                                     "name": "__init__.py",
-                                    "raw_access_token": limited_field_access_token(
-                                        attachment, "raw"
-                                    ),
+                                    "raw_access_token": attachment._get_raw_access_token(),
                                     "res_name": False,
                                     "thread": False,
                                     "voice": False,

--- a/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
+++ b/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
@@ -2,7 +2,7 @@ import json
 import re
 
 import odoo
-from odoo.tools.misc import file_open, limited_field_access_token
+from odoo.tools.misc import file_open
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.cloud_storage_google.tests.test_cloud_storage_google import TestCloudStorageGoogleCommon
 
@@ -50,7 +50,7 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
                                 "id": attachment.id,
                                 "mimetype": "text/x-python",
                                 "name": "__init__.py",
-                                "raw_access_token": limited_field_access_token(attachment, "raw"),
+                                "raw_access_token": attachment._get_raw_access_token(),
                                 "res_name": False,
                                 "thread": False,
                                 "voice": False,

--- a/addons/html_builder/static/src/core/color_style_plugin.js
+++ b/addons/html_builder/static/src/core/color_style_plugin.js
@@ -8,8 +8,8 @@ class ColorStylePlugin extends Plugin {
     static dependencies = ["color"];
     resources = {
         builder_style_actions: this.getStyleActions(),
-        apply_color_style: withSequence(5, (element, mode, color) => {
-            applyNeededCss(element, mode === "backgroundColor" ? "background-color" : mode, color);
+        apply_style: withSequence(5, (element, cssProp, color) => {
+            applyNeededCss(element, cssProp, color);
             return true;
         }),
     };

--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -531,13 +531,8 @@ export function applyNeededCss(
     computedStyle = window.getComputedStyle(el),
     { force = false, allowImportant = true } = {}
 ) {
-    const classes = [1, 2, 3, 4, 5].map((i) => `o_cc${i}`);
-    el.classList.remove(...classes);
-    if (cssValue.startsWith("o_cc")) {
-        el.style.removeProperty(cssProp);
-        el.classList.add(cssValue);
-        return;
-    }
+    // Change camelCase to kebab-case.
+    cssProp = cssProp.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
     if (force) {
         el.style.setProperty(cssProp, cssValue, allowImportant ? "important" : "");
         return true;

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -237,6 +237,7 @@ export class LinkPlugin extends Plugin {
         before_paste_handlers: this.updateCurrentLinkSyncState.bind(this),
         after_paste_handlers: this.onPasteNormalizeLink.bind(this),
         selectionchange_handlers: this.handleSelectionChange.bind(this),
+        selection_leave_handlers: this.handleSelectionLeave.bind(this),
         clean_for_save_handlers: ({ root }) => this.removeEmptyLinks(root),
         normalize_handlers: this.normalizeLink.bind(this),
         after_insert_handlers: this.handleAfterInsert.bind(this),
@@ -706,7 +707,7 @@ export class LinkPlugin extends Plugin {
         } else {
             const closestLinkElement = closestElement(selection.anchorNode, "A");
             if (closestLinkElement && closestLinkElement.isContentEditable) {
-                if (closestLinkElement !== this.linkInDocument) {
+                if (closestLinkElement !== this.linkInDocument || !this.currentOverlay.isOpen) {
                     this.openLinkTools(closestLinkElement);
                 }
             } else if (
@@ -721,6 +722,10 @@ export class LinkPlugin extends Plugin {
                 this.closeLinkTools();
             }
         }
+    }
+
+    handleSelectionLeave() {
+        this.currentOverlay?.isOpen && this.currentOverlay.close();
     }
 
     /**

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -2,7 +2,7 @@
 
     <t t-name="html_editor.linkPopover">
         <div class="o-we-linkpopover d-flex bg-white overflow-auto shadow" t-on-keydown="onKeydown">
-            <div t-if="state.editing" class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper">
+            <div t-if="state.editing" class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper" data-prevent-closing-overlay="true">
                 <div t-if="state.isImage" class="col p-2" style="max-width: 250px;">
                     <div class="input-group mb-1">
                         <input t-ref="url" class="o_we_href_input_link form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL" t-on-keydown="onKeydownEnter"/>

--- a/addons/html_editor/static/src/utils/image.js
+++ b/addons/html_editor/static/src/utils/image.js
@@ -6,9 +6,8 @@ import { isColorGradient } from "@web/core/utils/colors";
  * @param {string} CSS 'background-image' property value
  * @returns {Object} contains the separated 'url' and 'gradient' parts
  */
-export function backgroundImageCssToParts(css) {
+export function backgroundImageCssToParts(css = "") {
     const parts = {};
-    css = css || "";
     if (css.startsWith("url(")) {
         const urlEnd = css.indexOf(")") + 1;
         parts.url = css.substring(0, urlEnd).trim();

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -6,7 +6,7 @@ import json
 from odoo import Command, fields
 from odoo.addons.im_livechat.tests import chatbot_common
 from odoo.tests.common import JsonRpcException, new_test_user, tagged
-from odoo.tools.misc import limited_field_access_token, mute_logger
+from odoo.tools.misc import mute_logger
 from odoo.addons.bus.models.bus import json_dump
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
@@ -232,16 +232,17 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                 0,
                 {
                     "active": False,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.chatbot_script.operator_partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": self.chatbot_script.operator_partner_id._get_avatar_128_access_token(),
                     "country_id": False,
                     "id": self.chatbot_script.operator_partner_id.id,
                     "im_status": "im_partner",
+                    "im_status_access_token": self.chatbot_script.operator_partner_id._get_im_status_access_token(),
                     "is_public": False,
                     "name": "Testing Bot",
                     "user_livechat_username": False,
-                    "write_date": fields.Datetime.to_string(self.chatbot_script.operator_partner_id.write_date),
+                    "write_date": fields.Datetime.to_string(
+                        self.chatbot_script.operator_partner_id.write_date
+                    ),
                 },
             )
             channel_data = Store(discuss_channel).get_result()
@@ -330,12 +331,11 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                             "res.partner": self._filter_partners_fields(
                                 {
                                     "active": True,
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.partner_employee, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.partner_employee._get_avatar_128_access_token(),
                                     "country_id": self.env.ref("base.be").id,
                                     "id": self.partner_employee.id,
                                     "im_status": "offline",
+                                    "im_status_access_token": self.partner_employee._get_im_status_access_token(),
                                     "is_public": False,
                                     "name": "Ernest Employee",
                                     "user_livechat_username": False,
@@ -392,9 +392,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                             ],
                             "res.partner": self._filter_partners_fields(
                                 {
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.partner_employee, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.partner_employee._get_avatar_128_access_token(),
                                     "id": self.partner_employee.id,
                                     "name": "Ernest Employee",
                                     "user_livechat_username": False,

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -5,7 +5,6 @@ from freezegun import freeze_time
 from unittest.mock import patch, PropertyMock
 
 from odoo import fields
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.tests import new_test_user, tagged
@@ -53,10 +52,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             data["mail.guest"],
             [
                 {
-                    "avatar_128_access_token": limited_field_access_token(guest, "avatar_128"),
+                    "avatar_128_access_token": guest._get_avatar_128_access_token(),
                     "country_id": belgium.id,
                     "id": guest.id,
                     "im_status": "offline",
+                    "im_status_access_token": guest._get_im_status_access_token(),
                     "name": "Visitor",
                     "offline_since": False,
                     "write_date": fields.Datetime.to_string(guest.write_date),
@@ -68,11 +68,10 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             self._filter_partners_fields(
               {
                     "active": False,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.partner_root, "avatar_128"
-                    ),
+                    "avatar_128_access_token": self.partner_root._get_avatar_128_access_token(),
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",
+                    "im_status_access_token": self.partner_root._get_im_status_access_token(),
                     "isInternalUser": True,
                     "is_company": False,
                     "name": "OdooBot",
@@ -82,12 +81,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "active": True,
-                    "avatar_128_access_token": limited_field_access_token(
-                        operator.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": operator.partner_id._get_avatar_128_access_token(),
                     "country_id": False,
                     "id": operator.partner_id.id,
                     "im_status": "offline",
+                    "im_status_access_token": operator.partner_id._get_im_status_access_token(),
                     "is_public": False,
                     "user_livechat_username": "Michel Operator",
                     "write_date": fields.Datetime.to_string(operator.write_date),
@@ -121,12 +119,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             self._filter_partners_fields(
                 {
                     "active": False,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.partner_root, "avatar_128"
-                    ),
+                    "avatar_128_access_token": self.partner_root._get_avatar_128_access_token(),
                     "email": "odoobot@example.com",
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",
+                    "im_status_access_token": self.partner_root._get_im_status_access_token(),
                     "isInternalUser": True,
                     "is_company": False,
                     "name": "OdooBot",
@@ -136,12 +133,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "active": True,
-                    "avatar_128_access_token": limited_field_access_token(
-                        test_user.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": test_user.partner_id._get_avatar_128_access_token(),
                     "country_id": belgium.id,
                     "id": test_user.partner_id.id,
                     "im_status": "offline",
+                    "im_status_access_token": test_user.partner_id._get_im_status_access_token(),
                     "isAdmin": False,
                     "isInternalUser": True,
                     "is_public": False,
@@ -155,12 +151,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                {
                     "active": True,
-                    "avatar_128_access_token": limited_field_access_token(
-                        operator.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": operator.partner_id._get_avatar_128_access_token(),
                     "country_id": False,
                     "id": operator.partner_id.id,
                     "im_status": "offline",
+                    "im_status_access_token": operator.partner_id._get_im_status_access_token(),
                     "is_public": False,
                     "user_livechat_username": "Michel Operator",
                     "write_date": fields.Datetime.to_string(operator.write_date),
@@ -222,12 +217,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             self._filter_partners_fields(
                 {
                     "active": False,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.partner_root, "avatar_128"
-                    ),
+                    "avatar_128_access_token": self.partner_root._get_avatar_128_access_token(),
                     "email": "odoobot@example.com",
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",
+                    "im_status_access_token": self.partner_root._get_im_status_access_token(),
                     "isInternalUser": True,
                     "is_company": False,
                     "name": "OdooBot",
@@ -237,12 +231,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "active": True,
-                    "avatar_128_access_token": limited_field_access_token(
-                        operator.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": operator.partner_id._get_avatar_128_access_token(),
                     "country_id": False,
                     "id": operator.partner_id.id,
                     "im_status": "offline",
+                    "im_status_access_token": operator.partner_id._get_im_status_access_token(),
                     "isAdmin": False,
                     "isInternalUser": True,
                     "is_public": False,

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -5,7 +5,6 @@ from markupsafe import Markup
 
 from odoo import Command, fields
 from odoo.exceptions import AccessError
-from odoo.tools.misc import limited_field_access_token
 from odoo.tests.common import users, tagged
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
@@ -210,9 +209,9 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                 ],
                 "res.partner": self._filter_partners_fields(
                     {
-                        "avatar_128_access_token": limited_field_access_token(
-                            self.users[1].partner_id, "avatar_128"
-                        ),
+                        "avatar_128_access_token": self.users[
+                            1
+                        ].partner_id._get_avatar_128_access_token(),
                         "id": self.users[1].partner_id.id,
                         "is_company": False,
                         "isInternalUser": True,
@@ -322,9 +321,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                                 ],
                                 "res.partner": self._filter_partners_fields(
                                     {
-                                        "avatar_128_access_token": limited_field_access_token(
-                                            self.env.user.partner_id, "avatar_128"
-                                        ),
+                                        "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
                                         "id": self.env.user.partner_id.id,
                                         "isInternalUser": False,
                                         "is_company": False,

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -1,6 +1,5 @@
 from odoo import fields
 from odoo.tests.common import tagged
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
 
 
@@ -52,9 +51,7 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
         self.assertEqual(
             data["res.partner"][0],
             {
-                "avatar_128_access_token": limited_field_access_token(
-                    john.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": john.partner_id._get_avatar_128_access_token(),
                 "id": john.partner_id.id,
                 "user_livechat_username": "ELOPERADOR",
                 "write_date": fields.Datetime.to_string(john.partner_id.write_date),

--- a/addons/l10n_cz/i18n/cs.po
+++ b/addons/l10n_cz/i18n/cs.po
@@ -10,11 +10,11 @@ msgstr ""
 "PO-Revision-Date: 2025-02-06 14:57+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #. module: l10n_cz
 #: model_terms:ir.ui.view,arch_db:l10n_cz.report_invoice_document
@@ -92,7 +92,7 @@ msgstr "IČO společnosti"
 #: model_terms:ir.ui.view,arch_db:l10n_cz.registry_vat_external_layout
 #: model_terms:ir.ui.view,arch_db:l10n_cz.report_invoice_document
 msgid "Company ID:"
-msgstr "IČO:"
+msgstr "IČO společnosti:"
 
 #. module: l10n_cz
 #: model:ir.model.fields,field_description:l10n_cz.field_l10n_cz_tax_office__create_uid
@@ -164,7 +164,7 @@ msgstr "Královéhradecký kraj"
 #: model:ir.model.fields,field_description:l10n_cz.field_l10n_cz_tax_office__id
 #: model:ir.model.fields,field_description:l10n_cz.field_res_company__id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: l10n_cz
 #: model:ir.model,name:l10n_cz.model_account_move
@@ -306,7 +306,7 @@ msgstr "Praha"
 #. module: l10n_cz
 #: model:ir.model.fields,field_description:l10n_cz.field_l10n_cz_tax_office__region
 msgid "Region"
-msgstr ""
+msgstr "Region"
 
 #. module: l10n_cz
 #: model:l10n_cz.tax_office,name:l10n_cz.tax_office_156
@@ -951,12 +951,12 @@ msgstr "Územní pracoviště v Pacově"
 #. module: l10n_cz
 #: model:l10n_cz.tax_office,name:l10n_cz.tax_office_125
 msgid "Regional office in Pardubice"
-msgstr ""
+msgstr "Územní pracoviště v Pardubicích"
 
 #. module: l10n_cz
 #: model:l10n_cz.tax_office,name:l10n_cz.tax_office_146
 msgid "Regional office in Pelhřimov"
-msgstr "Územní pracoviště v Pardubicích"
+msgstr "Územní pracoviště v Pelhřimov"
 
 #. module: l10n_cz
 #: model:l10n_cz.tax_office,name:l10n_cz.tax_office_59
@@ -1307,7 +1307,7 @@ msgstr "Územní pracoviště ve Žďáru nad Sázavou"
 #. module: l10n_cz
 #: model:l10n_cz.tax_office,name:l10n_cz.tax_office_36
 msgid "Regional office of the Town"
-msgstr ""
+msgstr "Územní pracoviště města"
 
 #. module: l10n_cz
 #: model:l10n_cz.tax_office,region:l10n_cz.tax_office_40
@@ -1398,7 +1398,7 @@ msgstr "Územní pracoviště v Českých Budějovicích"
 #. module: l10n_cz
 #: model:l10n_cz.tax_office,name:l10n_cz.tax_office_151
 msgid "Tax Office for South Moravian Region"
-msgstr ""
+msgstr "Finanční úřad pro Jihomoravský kraj"
 
 #. module: l10n_cz
 #: model:l10n_cz.tax_office,name:l10n_cz.tax_office_13
@@ -1452,7 +1452,8 @@ msgid ""
 "The registry number of the company. Use it if it is different from the Tax "
 "ID. It must be unique across all partners of a same country"
 msgstr ""
-"IČO společnosti.Musí být unikátní v rámci všech kontaktů pod danou zemí."
+"Registrační číslo společnosti. Použijte jej, pokud se liší od IČO "
+"společnosti. Musí být unikátní v rámci všech kontaktů pod danou zemí."
 
 #. module: l10n_cz
 #: model:ir.model.constraint,message:l10n_cz.constraint_l10n_cz_tax_office_workplace_code_unique

--- a/addons/l10n_cz/i18n/l10n_cz.pot
+++ b/addons/l10n_cz/i18n/l10n_cz.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.2a1+e\n"
+"Project-Id-Version: Odoo Server saas~18.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-14 14:04+0000\n"
-"PO-Revision-Date: 2025-02-14 14:04+0000\n"
+"POT-Creation-Date: 2025-05-26 08:12+0000\n"
+"PO-Revision-Date: 2025-05-26 08:12+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -5,7 +5,6 @@ import contextlib
 from odoo import _, models, SUPERUSER_ID
 from odoo.exceptions import AccessError, MissingError, UserError
 from odoo.tools import consteq
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.mail.tools.discuss import Store
 
 
@@ -84,7 +83,7 @@ class IrAttachment(models.Model):
             "file_size",
             "mimetype",
             "name",
-            Store.Attr("raw_access_token", lambda a: limited_field_access_token(a, "raw")),
+            Store.Attr("raw_access_token", lambda a: a._get_raw_access_token()),
             "res_name",
             Store.One("thread", [], as_thread=True),
             "type",

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -232,13 +232,25 @@ class ResPartner(models.Model):
     # DISCUSS
     # ------------------------------------------------------------
 
+    def _get_im_status_access_token(self):
+        """Return a scoped access token for the `im_status` field. The token is used in
+        `ir_websocket._prepare_subscribe_data` to grant access to presence channels.
+
+        :rtype: str
+        """
+        self.ensure_one()
+        return limited_field_access_token(self, "im_status", scope="mail.presence")
+
     def _field_store_repr(self, field_name):
         if field_name == "avatar_128":
             return [
-                Store.Attr(
-                    "avatar_128_access_token", lambda p: limited_field_access_token(p, "avatar_128")
-                ),
+                Store.Attr("avatar_128_access_token", lambda p: p._get_avatar_128_access_token()),
                 "write_date",
+            ]
+        if field_name == "im_status":
+            return [
+                "im_status",
+                Store.Attr("im_status_access_token", lambda p: p._get_im_status_access_token()),
             ]
         return [field_name]
 

--- a/addons/mail/static/src/core/common/im_status_service.js
+++ b/addons/mail/static/src/core/common/im_status_service.js
@@ -8,9 +8,13 @@ export const AWAY_DELAY = 30 * 60 * 1000; // 30 minutes
  * connection to the server is established, the user's presence is updated. If
  * another device or browser updates the user's presence, the presence is sent to
  * the server if relevant (e.g., another device is away or offline, but this one
- * is online). To receive updates through the bus, subscribe to presence channels
- * (e.g., subscribe to `odoo-presence-res.partner_3` to receive updates about
- * this partner).
+ * is online).
+ *
+ * To receive updates through the bus, subscribe to presence channels
+ * (e.g., subscribe to `odoo-presence-res.partner_3-token` to receive updates about
+ * this partner). Token is optional and can be used to grant access to the presence
+ * channel if the user is not allowed to read the partner's presence.
+ * See `_get_im_status_access_token`.
  */
 export const imStatusService = {
     dependencies: ["bus_service", "presence"],

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -83,9 +83,6 @@ export class Store extends BaseStore {
     mt_note = fields.One("mail.message.subtype");
     /** @type {boolean} */
     hasMessageTranslationFeature;
-    imStatusTrackedPersonas = fields.Many("Persona", {
-        inverse: "storeAsTrackedImStatus",
-    });
     hasLinkPreviewFeature = true;
     // messaging menu
     menu = { counter: 0 };
@@ -353,10 +350,9 @@ export class Store extends BaseStore {
                 if (thread) {
                     thread.open({ focus: true });
                 } else {
-                    this.env.services.notification.add(
-                        _t("This thread is no longer available."),
-                        { type: "danger" }
-                    );
+                    this.env.services.notification.add(_t("This thread is no longer available."), {
+                        type: "danger",
+                    });
                 }
             });
             return true;

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -17,15 +17,6 @@ export class DiscussCoreCommon {
     }
 
     setup() {
-        this.busService.addEventListener(
-            "connect",
-            () =>
-                this.store.imStatusTrackedPersonas.forEach((p) => {
-                    const model = p.type === "partner" ? "res.partner" : "mail.guest";
-                    this.busService.addChannel(`odoo-presence-${model}_${p.id}`);
-                }),
-            { once: true }
-        );
         this.busService.subscribe("discuss.channel/delete", (payload, metadata) => {
             const thread = this.store.Thread.insert({
                 id: payload.id,

--- a/addons/mail/static/tests/discuss/core/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss.test.js
@@ -8,9 +8,10 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
+import { tick } from "@odoo/hoot-dom";
 import { mockDate } from "@odoo/hoot-mock";
-import { asyncStep, Command, serverState, waitForSteps } from "@web/../tests/web_test_helpers";
+import { asyncStep, makeMockEnv, waitForSteps } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -26,28 +27,31 @@ test("Member list and Pinned Messages Panel menu are exclusive", async () => {
     await contains(".o-discuss-ChannelMemberList", { count: 0 });
 });
 
-test("subscribe to known partner presences", async () => {
-    onWebsocketEvent("subscribe", (data) => asyncStep(`subscribe - [${data.channels}]`));
-    const pyEnv = await startServer();
-    const bobPartnerId = pyEnv["res.partner"].create({
-        name: "Bob",
-        user_ids: [Command.create({ name: "bob" })],
-    });
-    const later = luxon.DateTime.now().plus({ seconds: 2 });
-    mockDate(
-        `${later.year}-${later.month}-${later.day} ${later.hour}:${later.minute}:${later.second}`
-    );
-    await start();
-    await openDiscuss();
-    const expectedPresences = [
-        `odoo-presence-res.partner_${serverState.partnerId}`,
-        `odoo-presence-res.partner_${serverState.odoobotId}`,
-    ];
-    await waitForSteps([`subscribe - [${expectedPresences.join(",")}]`]);
-    await click("[placeholder='Find or start a conversation']");
-    await click(".o-mail-DiscussCommand", { text: "Bob" });
-    expectedPresences.push(`odoo-presence-res.partner_${bobPartnerId}`);
-    await waitForSteps([`subscribe - [${expectedPresences.join(",")}]`]);
+test("subscribe to presence channels according to store data", async () => {
+    const env = await makeMockEnv();
+    const store = env.services["mail.store"];
+    onWebsocketEvent("subscribe", (data) => expect.step(`subscribe - [${data.channels}]`));
+    expect(env.services.bus_service.isActive).toBe(false);
+    // Should not subscribe to presences as bus service is not started.
+    store["Persona"].insert({ id: 1, type: "partner", name: "Partner 1" });
+    store["Persona"].insert({ id: 2, type: "partner", name: "Partner 2" });
+    await tick();
+    expect.waitForSteps([]);
+    // Starting the bus should subscribe to known presence channels.
+    env.services.bus_service.start();
+    await expect.waitForSteps([
+        "subscribe - [odoo-presence-res.partner_1,odoo-presence-res.partner_2]",
+    ]);
+    // Discovering new presence channels should refresh the subscription.
+    store["Persona"].insert({ id: 1, type: "guest" });
+    await expect.waitForSteps([
+        "subscribe - [odoo-presence-mail.guest_1,odoo-presence-res.partner_1,odoo-presence-res.partner_2]",
+    ]);
+    // Updating "im_status_access_token" should refresh the subscription.
+    store["Persona"].insert({ id: 1, type: "guest", im_status_access_token: "token" });
+    await expect.waitForSteps([
+        "subscribe - [odoo-presence-mail.guest_1-token,odoo-presence-res.partner_1,odoo-presence-res.partner_2]",
+    ]);
 });
 
 test("bus subscription is refreshed when channel is joined", async () => {

--- a/addons/mail/static/tests/discuss_app/bus_connection_alert.test.js
+++ b/addons/mail/static/tests/discuss_app/bus_connection_alert.test.js
@@ -20,7 +20,9 @@ test("show warning when bus connection encounters issues", async () => {
     const unlockWebsocket = lockWebsocketConnect();
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
     await waitForSteps(["reconnecting"]);
-    expect(await waitFor(".o-bus-ConnectionAlert")).toHaveText("Real-time connection lost...");
+    expect(await waitFor(".o-bus-ConnectionAlert", { timeout: 2500 })).toHaveText(
+        "Real-time connection lost..."
+    );
     await runAllTimers();
     await animationFrame();
     expect(".o-bus-ConnectionAlert").toHaveText("Real-time connection lost...");

--- a/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
@@ -28,6 +28,9 @@ export class MailGuest extends models.ServerModel {
                 data.avatar_128_access_token = guest.id;
                 data.write_date = guest.write_date;
             }
+            if (fields.includes("im_status")) {
+                data.im_status_access_token = guest.id;
+            }
             store.add(this.browse(guest.id), data);
         }
     }

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -270,6 +270,7 @@ export class ResPartner extends webModels.ResPartner {
             }
             if (fields.includes("im_status")) {
                 data.im_status = this.compute_im_status(partner);
+                data.im_status_access_token = partner.id;
             }
             if (fields.includes("user")) {
                 const users = ResUsers.browse(partner.user_ids);

--- a/addons/mail/tests/discuss/test_avatar_acl.py
+++ b/addons/mail/tests/discuss/test_avatar_acl.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, Command
-from odoo.tools.misc import limited_field_access_token
 from odoo.tests import HttpCase
 from odoo.tests.common import tagged
 
@@ -11,7 +10,7 @@ class TestAvatarAcl(HttpCase):
     def get_avatar_url(self, record, add_token=False):
         access_token = ""
         if add_token:
-            access_token = f"&access_token={limited_field_access_token(record, 'avatar_128')}"
+            access_token = f"&access_token={record._get_avatar_128_access_token()}"
         return f"/web/image?field=avatar_128&id={record.id}&model={record._name}&unique={fields.Datetime.to_string(record.write_date)}{access_token}"
 
     def test_partner_open_guest_avatar(self):

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from markupsafe import Markup
 
 from odoo import Command, fields
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.mail.models.discuss.discuss_channel import channel_avatar, group_avatar
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail.tests.common import MailCommon
@@ -138,9 +137,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 ),
                                 "res.partner": self._filter_partners_fields(
                                     {
-                                        "avatar_128_access_token": limited_field_access_token(
-                                            self.env.user.partner_id, "avatar_128"
-                                        ),
+                                        "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
                                         "id": self.env.user.partner_id.id,
                                         "isInternalUser": True,
                                         "is_company": False,
@@ -171,12 +168,11 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "res.partner": self._filter_partners_fields(
                                 {
                                     "active": True,
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.test_partner, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.test_partner._get_avatar_128_access_token(),
                                     "email": "test_customer@example.com",
                                     "id": self.test_partner.id,
                                     "im_status": "im_partner",
+                                    "im_status_access_token": self.test_partner._get_im_status_access_token(),
                                     "isInternalUser": False,
                                     "is_company": False,
                                     "name": "Test Partner",
@@ -218,12 +214,11 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "res.partner": self._filter_partners_fields(
                                 {
                                     "active": True,
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.test_partner, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.test_partner._get_avatar_128_access_token(),
                                     "email": "test_customer@example.com",
                                     "id": self.test_partner.id,
                                     "im_status": "im_partner",
+                                    "im_status_access_token": self.test_partner._get_im_status_access_token(),
                                     "isInternalUser": False,
                                     "is_company": False,
                                     "name": "Test Partner",
@@ -453,11 +448,10 @@ class TestChannelInternals(MailCommon, HttpCase):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    self.user_admin.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": self.user_admin.partner_id._get_avatar_128_access_token(),
                                 "id": self.user_admin.partner_id.id,
                                 "im_status": self.user_admin.im_status,
+                                "im_status_access_token": self.user_admin.partner_id._get_im_status_access_token(),
                                 "name": self.user_admin.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     self.user_admin.partner_id.write_date

--- a/addons/mail/tests/discuss/test_discuss_mail_presence.py
+++ b/addons/mail/tests/discuss/test_discuss_mail_presence.py
@@ -7,6 +7,8 @@ try:
 except ImportError:
     ws = None
 
+from itertools import product
+
 from odoo.tests import tagged, new_test_user
 from odoo.addons.bus.tests.common import WebsocketCase
 from odoo.addons.mail.tests.common import MailCommon
@@ -15,86 +17,59 @@ from odoo.addons.bus.models.bus import channel_with_db, json_dump
 
 @tagged("post_install", "-at_install")
 class TestMailPresence(WebsocketCase, MailCommon):
-    def _receive_presence(self, sender, recipient):
-        self._reset_bus()
-        sent_from_user = isinstance(sender, self.env.registry["res.users"])
-        receive_to_user = isinstance(recipient, self.env.registry["res.users"])
-        if receive_to_user:
-            session = self.authenticate(recipient.login, recipient.login)
+    def _receive_presence(self, requested_by, target, has_token=False):
+        self.env["mail.presence"].search([]).unlink()
+        target_user = isinstance(target, self.env.registry["res.users"])
+        if isinstance(requested_by, self.env.registry["res.users"]):
+            session = self.authenticate(requested_by.login, requested_by.login)
             auth_cookie = f"session_id={session.sid};"
         else:
             self.authenticate(None, None)
-            auth_cookie = f"{recipient._cookie_name}={recipient._format_auth_cookie()};"
+            auth_cookie = f"{requested_by._cookie_name}={requested_by._format_auth_cookie()};"
         websocket = self.websocket_connect(cookie=auth_cookie)
-        sender_bus_target = sender.partner_id if sent_from_user else sender
-        self.subscribe(
-            websocket,
-            [f"odoo-presence-{sender_bus_target._name}_{sender_bus_target.id}"],
-            self.env["bus.bus"]._bus_last_id(),
-        )
-        self.env["mail.presence"]._update_presence(sender)
-        self.trigger_notification_dispatching([(sender_bus_target, "presence")])
+        target_channel = target.partner_id if target_user else target
+        channel_parts = ["odoo-presence", f"{target_channel._name}_{target_channel.id}"]
+        if has_token:
+            channel_parts.append(target_channel._get_im_status_access_token())
+        self.subscribe(websocket, ["-".join(channel_parts)], self.env["bus.bus"]._bus_last_id())
+        self.env["mail.presence"]._update_presence(target)
+        self.trigger_notification_dispatching([(target_channel, "presence")])
         notifications = json.loads(websocket.recv())
         self._close_websockets()
         bus_record = self.env["bus.bus"].search([("id", "=", int(notifications[0]["id"]))])
         self.assertEqual(
             bus_record.channel,
-            json_dump(channel_with_db(self.env.cr.dbname, (sender_bus_target, "presence"))),
+            json_dump(channel_with_db(self.env.cr.dbname, (target_channel, "presence"))),
         )
         self.assertEqual(notifications[0]["message"]["type"], "bus.bus/im_status_updated")
         self.assertEqual(notifications[0]["message"]["payload"]["im_status"], "online")
         self.assertEqual(notifications[0]["message"]["payload"]["presence_status"], "online")
         self.assertEqual(
-            notifications[0]["message"]["payload"]["partner_id" if sent_from_user else "guest_id"],
-            sender_bus_target.id,
+            notifications[0]["message"]["payload"]["partner_id" if target_user else "guest_id"],
+            target_channel.id,
         )
 
-    def test_receive_presences_as_guest(self):
-        guest = self.env["mail.guest"].create({"name": "Guest"})
-        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
-        # Guest should not receive users's presence: no common channel.
-        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
-            self._receive_presence(sender=bob, recipient=guest)
-        channel = self.env["discuss.channel"]._create_channel(group_id=None, name="General")
-        channel._add_members(guests=guest, users=bob)
-        # Now that they share a channel, guest should receive users's presence.
-        self._receive_presence(sender=bob, recipient=guest)
-
-        other_guest = self.env["mail.guest"].create({"name": "OtherGuest"})
-        # Guest should not receive guest's presence: no common channel.
-        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
-            self._receive_presence(sender=other_guest, recipient=guest)
-        channel._add_members(guests=other_guest)
-        # Now that they share a channel, guest should receive guest's presence.
-        self._receive_presence(sender=other_guest, recipient=guest)
-        self.assertEqual(other_guest.im_status, "online")
-
-    def test_receive_presences_as_portal(self):
-        portal = new_test_user(self.env, login="portal_user", groups="base.group_portal")
-        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
-        # Portal should not receive users's presence: no common channel.
-        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
-            self._receive_presence(sender=bob, recipient=portal)
-        channel = self.env["discuss.channel"]._create_channel(group_id=None, name="General")
-        channel._add_members(users=portal | bob)
-        # Now that they share a channel, portal should receive users's presence.
-        self._receive_presence(sender=bob, recipient=portal)
-
-        guest = self.env["mail.guest"].create({"name": "Guest"})
-        # Portal should not receive guest's presence: no common channel.
-        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
-            self._receive_presence(sender=guest, recipient=portal)
-        channel._add_members(guests=guest)
-        # Now that they share a channel, portal should receive guest's presence.
-        self._receive_presence(sender=guest, recipient=portal)
-        self.assertEqual(guest.im_status, "online")
-
-    def test_receive_presences_as_internal(self):
+    def test_presence_access(self):
         internal = new_test_user(self.env, login="internal_user", groups="base.group_user")
+        other_internal = new_test_user(
+            self.env, login="other_internal_user", groups="base.group_user"
+        )
+        portal = new_test_user(self.env, login="portal_user", groups="base.group_portal")
+        other_portal = new_test_user(
+            self.env, login="other_portal_user", groups="base.group_portal"
+        )
         guest = self.env["mail.guest"].create({"name": "Guest"})
-        # Internal can access guest's presence regardless of their channels.
-        self._receive_presence(sender=guest, recipient=internal)
-        # Internal can access users's presence regardless of their channels.
-        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
-        self._receive_presence(sender=bob, recipient=internal)
-        self.assertEqual(bob.im_status, "online")
+        other_guest = self.env["mail.guest"].create({"name": "Other Guest"})
+        for requested_by, target, has_token, allowed in [
+            *product([internal], [guest, other_internal, portal], [True, False], [True]),
+            *product([guest, portal], [internal, other_guest, other_portal], [False], [False]),
+            *product([guest, portal], [internal, other_guest, other_portal], [True], [True]),
+        ]:
+            with self.subTest(
+                f"test presence access, requested_by={requested_by.name}, target={target.name}, has_token={has_token}, allowed={allowed}"
+            ):
+                if allowed:
+                    self._receive_presence(requested_by, target, has_token=has_token)
+                else:
+                    with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+                        self._receive_presence(requested_by, target, has_token=has_token)

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -5,7 +5,6 @@ import json
 import odoo
 from odoo.tests import tagged, users
 from odoo.tools import mute_logger
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.base.tests.common import HttpCase, HttpCaseWithUserDemo
 from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
 from odoo.http import STATIC_CACHE_LONG
@@ -106,7 +105,7 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "file_size": 0,
                     "id": self.attachments[0].id,
                     "name": "File 1",
-                    "raw_access_token": limited_field_access_token(self.attachments[0], "raw"),
+                    "raw_access_token": self.attachments[0]._get_raw_access_token(),
                     "res_name": "Test channel",
                     "mimetype": "application/octet-stream",
                     "thread": {"id": self.channel.id, "model": "discuss.channel"},
@@ -164,7 +163,7 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "file_size": 0,
                     "id": self.attachments[0].id,
                     "name": "File 1",
-                    "raw_access_token": limited_field_access_token(self.attachments[0], "raw"),
+                    "raw_access_token": self.attachments[0]._get_raw_access_token(),
                     "res_name": "Test channel",
                     "mimetype": "application/octet-stream",
                     "thread": {"id": self.channel.id, "model": "discuss.channel"},
@@ -178,7 +177,7 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "file_size": 0,
                     "id": self.attachments[1].id,
                     "name": "File 2",
-                    "raw_access_token": limited_field_access_token(self.attachments[1], "raw"),
+                    "raw_access_token": self.attachments[1]._get_raw_access_token(),
                     "res_name": "Test channel",
                     "mimetype": "application/octet-stream",
                     "thread": {"id": self.channel.id, "model": "discuss.channel"},
@@ -214,7 +213,7 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "file_size": 0,
                     "id": self.attachments[0].id,
                     "name": "File 1",
-                    "raw_access_token": limited_field_access_token(self.attachments[0], "raw"),
+                    "raw_access_token": self.attachments[0]._get_raw_access_token(),
                     "res_name": "Test channel",
                     "mimetype": "application/octet-stream",
                     "thread": {"id": self.channel.id, "model": "discuss.channel"},
@@ -228,7 +227,7 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "file_size": 0,
                     "id": self.attachments[1].id,
                     "name": "File 2",
-                    "raw_access_token": limited_field_access_token(self.attachments[1], "raw"),
+                    "raw_access_token": self.attachments[1]._get_raw_access_token(),
                     "res_name": "Test channel",
                     "mimetype": "application/octet-stream",
                     "thread": {"id": self.channel.id, "model": "discuss.channel"},

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -8,7 +8,7 @@ from odoo import fields
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tests.common import tagged, users
-from odoo.tools.misc import limited_field_access_token, mute_logger
+from odoo.tools.misc import mute_logger
 
 
 @tagged("RTC", "post_install", "-at_install")
@@ -86,11 +86,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -152,11 +151,10 @@ class TestChannelRTC(MailCommon):
                 ],
                 "res.partner": self._filter_partners_fields(
                     {
-                        "avatar_128_access_token": limited_field_access_token(
-                            channel_member.partner_id, "avatar_128"
-                        ),
+                        "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                         "id": channel_member.partner_id.id,
                         "im_status": channel_member.partner_id.im_status,
+                        "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                         "name": channel_member.partner_id.name,
                         "write_date": fields.Datetime.to_string(
                             channel_member.partner_id.write_date
@@ -230,11 +228,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -267,11 +264,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -350,11 +346,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token":  channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -390,11 +385,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -443,11 +437,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -456,11 +449,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -527,11 +519,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -570,11 +561,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -629,11 +619,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -648,7 +637,9 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtc_session_ids": [("ADD", [channel_member.rtc_session_ids.id + 2])],
+                                "rtc_session_ids": [
+                                    ("ADD", [channel_member.rtc_session_ids.id + 2])
+                                ],
                             },
                         ],
                         "discuss.channel.member": [
@@ -672,11 +663,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -739,11 +729,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -796,11 +785,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -898,11 +886,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -911,11 +898,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -1018,11 +1004,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -1062,11 +1047,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -1115,11 +1099,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -1128,11 +1111,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date

--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -123,10 +123,33 @@
         </field>
     </record>
 
+    <record id="payment_transaction_graph" model="ir.ui.view">
+        <field name="name">payment.transaction.graph</field>
+        <field name="model">payment.transaction</field>
+        <field name="arch" type="xml">
+            <graph string="Payment Transactions">
+                <field name="create_date" interval="month"/>
+                <field name="state"/>
+            </graph>
+        </field>
+    </record>
+
+    <record id="payment_transaction_pivot" model="ir.ui.view">
+        <field name="name">payment.transaction.pivot</field>
+        <field name="model">payment.transaction</field>
+        <field name="arch" type="xml">
+            <pivot string="Payment Transactions" display_quantity="1">
+                <field name="create_date" interval="month" type="row"/>
+                <field name="state" type="col"/>
+                <field name="amount" type="measure"/>
+            </pivot>
+        </field>
+    </record>
+
     <record id="action_payment_transaction" model="ir.actions.act_window">
         <field name="name">Payment Transactions</field>
         <field name="res_model">payment.transaction</field>
-        <field name="view_mode">list,kanban,form</field>
+        <field name="view_mode">list,kanban,form,graph,pivot</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_neutral_face">
                 There are no transactions to show

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -56,7 +56,6 @@ export class PaymentScreen extends Component {
 
     onMounted() {
         const order = this.pos.getOrder();
-        this.pos.addPendingOrder([order.id]);
 
         for (const payment of order.payment_ids) {
             const pmid = payment.payment_method_id.id;

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -63,7 +63,6 @@ export class ProductScreen extends Component {
         onMounted(() => {
             this.currentOrder.deselectOrderline();
             this.pos.openOpeningControl();
-            this.pos.addPendingOrder([this.currentOrder.id]);
             // Call `reset` when the `onMounted` callback in `numberBuffer.use` is done.
             // We don't do this in the `mounted` lifecycle method because it is called before
             // the callbacks in `onMounted` hook.

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1054,7 +1054,6 @@ export class PosStore extends WithLazyGetterTrap {
             this.hasJustAddedProduct = false;
         }, 3000);
 
-        this.addPendingOrder([order.id]);
         return order.getSelectedOrderline();
     }
 

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -666,6 +666,23 @@ registry.category("web_tour.tours").add("test_product_create_update_from_fronten
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_draft_orders_not_syncing", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.orderIsEmpty(),
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            Chrome.createFloatingOrder(),
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            Chrome.endTour(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_fiscal_position_tax_group_labels", {
     steps: () =>
         [

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1948,6 +1948,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'test_fiscal_position_tax_group_labels', login="pos_user")
 
+    def test_draft_orders_not_syncing(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_draft_orders_not_syncing', login="pos_user")
+        n_draft_order = self.env['pos.order'].search_count([('state', '=', 'draft')], limit=1)
+        self.assertEqual(n_draft_order, 0, 'There should be no draft orders created')
+
     def test_product_long_press(self):
         """ Test the long press on product to open the product info """
         archive_products(self.env)

--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -3,7 +3,6 @@
 from odoo import models
 from odoo.http import request
 from odoo.tools import format_datetime, groupby
-from odoo.tools.misc import limited_field_access_token
 
 
 class MailMessage(models.Model):
@@ -80,7 +79,7 @@ class MailMessage(models.Model):
             related_attachments = {
                 att_read_values["id"]: {
                     **att_read_values,
-                    "raw_access_token": limited_field_access_token(att, "raw"),
+                    "raw_access_token": att._get_raw_access_token(),
                 }
                 for att, att_read_values in zip(
                     attachments_sudo,

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -503,7 +503,9 @@ patch(PosStore.prototype, {
     //@override
     addNewOrder(data = {}) {
         const order = super.addNewOrder(...arguments);
-        this.addPendingOrder([order.id]);
+        if (this.config.module_pos_restaurant) {
+            this.addPendingOrder([order.id]);
+        }
         return order;
     },
     createOrderIfNeeded(data) {
@@ -520,6 +522,7 @@ patch(PosStore.prototype, {
         let currentCourse;
         if (this.config.module_pos_restaurant) {
             const order = this.getOrder();
+            this.addPendingOrder([order.id]);
             if (!order.uiState.booked) {
                 order.setBooked(true);
             }

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -119,7 +119,7 @@ class PosSelfOrderController(http.Controller):
                 lst_price = 0
 
     @http.route('/pos-self-order/validate-partner', auth='public', type='jsonrpc', website=True)
-    def validate_partner(self, access_token, name, phone, street, zip, city, country_id, state_id=None, partner_id=None):
+    def validate_partner(self, access_token, name, phone, street, zip, city, country_id, state_id=None, partner_id=None, email=None):
         pos_config = self._verify_pos_config(access_token)
         existing_partner = pos_config.env['res.partner'].sudo().browse(int(partner_id)) if partner_id else False
 
@@ -132,6 +132,7 @@ class PosSelfOrderController(http.Controller):
         country_id = pos_config.env['res.country'].browse(int(country_id))
         partner_sudo = request.env['res.partner'].sudo().create({
             'name': name,
+            'email': email,
             'phone': phone,
             'street': street,
             'zip': zip,

--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
@@ -35,6 +35,7 @@ export class PresetInfoPopup extends Component {
                 access_token: this.selfOrder.access_token,
                 partner_id: this.state.selectedPartnerId,
                 name: this.state.name,
+                email: this.state.email,
                 phone: this.state.phone,
                 street: this.state.street,
                 city: this.state.city,
@@ -61,6 +62,7 @@ export class PresetInfoPopup extends Component {
     selectExistingPartner(event) {
         const partner = this.selfOrder.models["res.partner"].get(event.target.value);
         this.state.name = partner?.name || "";
+        this.state.email = partner?.email || "";
         this.state.phone = partner?.phone || "";
         this.state.street = partner?.street || "";
         this.state.city = partner?.city || "";

--- a/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
@@ -43,6 +43,7 @@ registry.category("web_tour.tours").add("self_order_preset_delivery_tour", {
         CartPage.checkProduct("Free", "0", "1"),
         Utils.clickBtn("Pay"),
         CartPage.fillInput("Name", "Dr Dre"),
+        CartPage.fillInput("Email", "dre@dr.com"),
         CartPage.fillInput("Phone", "0490 90 43 90"),
         CartPage.fillInput("Street and Number", "Rue du Bronx 90"),
         CartPage.fillInput("Zip", "9999"),

--- a/addons/pos_self_order/tests/test_self_order_preset.py
+++ b/addons/pos_self_order/tests/test_self_order_preset.py
@@ -51,6 +51,7 @@ class TestSelfOrderPreset(SelfOrderCommonTest):
 
         last_order = self.env["pos.order"].search([], limit=1, order="id desc")
         self.assertEqual(last_order.partner_id.name, 'Dr Dre')
+        self.assertEqual(last_order.partner_id.email, 'dre@dr.com')
         self.assertEqual(last_order.partner_id.street, 'Rue du Bronx 90')
         self.assertEqual(last_order.partner_id.zip, '9999')
         self.assertEqual(last_order.partner_id.city, 'New York')

--- a/addons/purchase_requisition/tests/test_purchase_requisition.py
+++ b/addons/purchase_requisition/tests/test_purchase_requisition.py
@@ -172,7 +172,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # first flow: check that creating an alt PO correctly auto-links both POs to each other
         action = orig_po.action_create_alternative()
         alt_po_wiz = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wiz.partner_id = self.res_partner_1
+        alt_po_wiz.partner_ids = self.res_partner_1
         alt_po_wiz.copy_products = True
         alt_po_wiz = alt_po_wiz.save()
         alt_po_wiz.action_create_alternative()
@@ -203,7 +203,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # second flow: create extra alt PO, check that all 3 POs are correctly auto-linked
         action = orig_po.action_create_alternative()
         alt_po_wiz = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wiz.partner_id = self.res_partner_1
+        alt_po_wiz.partner_ids = self.res_partner_1
         alt_po_wiz.copy_products = True
         alt_po_wiz = alt_po_wiz.save()
         alt_po_wiz.action_create_alternative()
@@ -276,7 +276,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # Creates an alternative PO.
         action = po_1.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard_form.partner_id = self.res_partner_1
+        alt_po_wizard_form.partner_ids = self.res_partner_1
         alt_po_wizard_form.copy_products = True
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_wizard.action_create_alternative()
@@ -310,7 +310,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # Creates an alternative PO.
         action = po_1.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard_form.partner_id = self.res_partner_1
+        alt_po_wizard_form.partner_ids = self.res_partner_1
         alt_po_wizard_form.copy_products = True
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_wizard.action_create_alternative()
@@ -345,7 +345,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # Creates an alternative PO.
         action = po_1.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard_form.partner_id = self.res_partner_1
+        alt_po_wizard_form.partner_ids = self.res_partner_1
         alt_po_wizard_form.copy_products = True
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_wizard.action_create_alternative()
@@ -403,7 +403,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # Creates an alternative PO
         action = po_orig.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard_form.partner_id = vendor_usd
+        alt_po_wizard_form.partner_ids = vendor_usd
         alt_po_wizard_form.copy_products = True
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_wizard.action_create_alternative()
@@ -461,7 +461,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # Creates an alternative PO
         action = po_orig.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard_form.partner_id = vendor_b
+        alt_po_wizard_form.partner_ids = vendor_b
         alt_po_wizard_form.copy_products = True
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_wizard.action_create_alternative()
@@ -544,7 +544,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # 1. Create an alternative PO with Supplier B (should use 'Custom Name B')
         action = po_orig.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard_form.partner_id = vendor_b
+        alt_po_wizard_form.partner_ids = vendor_b
         alt_po_wizard_form.copy_products = True
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_wizard.action_create_alternative()
@@ -554,7 +554,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # 2. Create an alternative PO with Supplier C (should use '[Code C] Product')
         action = po_orig.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard_form.partner_id = vendor_c
+        alt_po_wizard_form.partner_ids = vendor_c
         alt_po_wizard_form.copy_products = True
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_wizard.action_create_alternative()
@@ -573,7 +573,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # 3. Create an alternative PO with Supplier C (should NOT copy description, uses default product name)
         action = po_single_qty.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard_form.partner_id = vendor_c
+        alt_po_wizard_form.partner_ids = vendor_c
         alt_po_wizard_form.copy_products = True
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_wizard.action_create_alternative()
@@ -583,7 +583,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # 4. Create an alternative PO with Supplier D (should copy description from Supplier A as no custom product_code/name exists)
         action = po_single_qty.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard_form.partner_id = vendor_d
+        alt_po_wizard_form.partner_ids = vendor_d
         alt_po_wizard_form.copy_products = True
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_wizard.action_create_alternative()
@@ -672,7 +672,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         # Creates an alternative PO
         action = orig_po.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard_form.partner_id = vendor
+        alt_po_wizard_form.partner_ids = vendor
         alt_po_wizard_form.copy_products = True
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_id = alt_po_wizard.action_create_alternative()['res_id']
@@ -694,7 +694,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
 
         action = po_1.action_create_alternative()
         alt_po_wiz = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wiz.partner_id = res_partner_2
+        alt_po_wiz.partner_ids = res_partner_2
         alt_po_wiz.copy_products = True
         alt_po_wiz = alt_po_wiz.save()
         alt_po_wiz.action_create_alternative()
@@ -708,7 +708,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
 
         action = po_2.action_create_alternative()
         alt_po_wiz = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wiz.partner_id = res_partner_2
+        alt_po_wiz.partner_ids = res_partner_2
         alt_po_wiz.copy_products = True
         alt_po_wiz = alt_po_wiz.save()
         alt_po_wiz.action_create_alternative()
@@ -716,3 +716,66 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         merger_alternative_orders = po_orders[0] | po_orders[1]
         merger_alternative_orders.action_merge()
         self.assertEqual(len(po_orders[0].alternative_po_ids), 4)
+
+    def test_create_alternatives_for_multiple_vendors(self):
+        """
+            Ensure that adding multiple vendors in the Alternatives wizard
+            creates a separate alternative purchase order for each vendor.
+        """
+        res_partner_2 = self.env['res.partner'].create({'name': 'Vendor 2'})
+        res_partner_3 = self.env['res.partner'].create({'name': 'Vendor 3'})
+        res_partner_4 = self.env['res.partner'].create({'name': 'Vendor 4'})
+        # Create original purchase order (PO) with a vendor.
+        orig_po = self.env['purchase.order'].create({
+            'partner_id': self.res_partner_1.id,
+        })
+
+        po_form = Form(orig_po)
+        with po_form.order_line.new() as line:
+            line.product_id = self.product_09
+            line.product_qty = 5.0
+        po_form.save()
+
+        # Create alternatives PO's and check that all PO's (including the original) are auto-linked to each other.
+        alt_po_wiz = Form.from_action(self.env, orig_po.action_create_alternative())
+        alt_po_wiz.partner_ids = res_partner_2 | res_partner_3 | res_partner_4
+        alt_po_wiz = alt_po_wiz.save()
+        alt_po_wiz.action_create_alternative()
+        self.assertEqual(len(orig_po.alternative_po_ids), 4, "There should be exactly 4 linked PO's: 1 original + 3 alternatives (one for each selected vendor.)")
+
+    def test_alternative_purchase_vendor_currency(self):
+        """
+            Ensure that the currency on the alternative RFQ is correctly set
+            based on the selected vendor purchase currency when creating
+            an alternative RFQ from an existing purchase order.
+        """
+        currency_eur = self.env.ref("base.EUR")
+        currency_usd = self.env.ref("base.USD")
+
+        self.res_partner_1.write({'property_purchase_currency_id': currency_usd.id})
+        res_partner_2 = self.env['res.partner'].create({'name': 'Vendor 2', 'property_purchase_currency_id': currency_eur.id})
+
+        orig_po = self.env['purchase.order'].create({
+            'partner_id': self.res_partner_1.id,
+        })
+        po_form = Form(orig_po)
+        with po_form.order_line.new() as line:
+            line.product_id = self.product_09
+            line.product_qty = 1.0
+        po_form.save()
+
+        # Check that the currency is correctly set based on the selected vendor.
+        self.assertEqual(orig_po.currency_id, self.res_partner_1.property_purchase_currency_id,
+            "The original PO currency should match with the vendor purchase currency (USD)."
+        )
+
+        alt_po_wiz = Form.from_action(self.env, orig_po.action_create_alternative())
+        alt_po_wiz.partner_ids = res_partner_2
+        alt_po_wizard = alt_po_wiz.save()
+        alt_po_wizard.action_create_alternative()
+        alt_po = orig_po.alternative_po_ids.filtered(lambda po: po.partner_id == res_partner_2)
+
+        # Check that the currency is correctly set on the alternative PO based on the selected vendor.
+        self.assertEqual(alt_po.currency_id, res_partner_2.property_purchase_currency_id,
+            "The alternative PO currency should match with vendor 2 purchase currency (EUR)."
+        )

--- a/addons/purchase_requisition/views/purchase_views.xml
+++ b/addons/purchase_requisition/views/purchase_views.xml
@@ -17,20 +17,15 @@
             <xpath expr="//page[@name='purchase_delivery_invoice']" position="after">
                 <page string="Alternatives" name="alternative_pos" groups="purchase_requisition.group_purchase_alternatives">
                     <group>
-                        <group>
-                            <p colspan="2">Create a call for tender by adding alternative requests for quotation to different vendors.
-                            Make your choice by selecting the best combination of lead time, OTD and/or total amount.
-                            By comparing product lines you can also decide to order some products from one vendor and others from another vendor.</p>
-                        </group>
-                        <group>
-                            <p colspan="2">
-                                <button name="action_create_alternative" type="object" class="btn-link d-block" string="Create Alternative" icon="fa-copy"/>
-                                <button name="action_compare_alternative_lines" type="object" class="btn-link d-block" string="Compare Product Lines" icon="fa-bar-chart" invisible="not alternative_po_ids"/>
-                            </p>
-                        </group>
+                        <div class="d-flex gap-5">
+                            <button name="action_create_alternative" type="object" class="btn-link d-block" help="Create a call for tender by adding alternative requests for quotation to different vendors.
+                                Make your choice by selecting the best combination of lead time, OTD and/or total amount.
+                                By comparing product lines you can also decide to order some products from one vendor and others from another vendor." string="Create Alternative" icon="fa-copy"/>
+                            <button name="action_compare_alternative_lines" type="object" class="btn-link d-block" string="Compare Product Lines" icon="fa-bar-chart" invisible="not alternative_po_ids"/>
+                        </div>
                     </group>
                     <field name="alternative_po_ids" readonly="not id" widget="many2many_alt_pos" context="{'quotation_only': True}">
-                        <list string="Alternative Purchase Order" decoration-muted="state in ['cancel', 'purchase']" decoration-bf="id == parent.id">
+                        <list string="Alternative Purchase Order" decoration-muted="state in ['cancel', 'purchase']" default_order="amount_total_cc, date_planned, id">
                             <control>
                                 <create string="Link to Existing RfQ"/>
                             </control>

--- a/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
@@ -11,7 +11,7 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
     origin_po_id = fields.Many2one(
         'purchase.order', help="The original PO that this alternative PO is being created for."
     )
-    partner_id = fields.Many2one(
+    partner_ids = fields.Many2many(
         'res.partner', string='Vendor', required=True,
         help="Choose a vendor for alternative PO")
     purchase_warn_msg = fields.Text(
@@ -22,52 +22,68 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
         "Copy Products", default=True,
         help="If this is checked, the product quantities of the original PO will be copied")
 
-    @api.depends('partner_id', 'copy_products')
+    @api.depends('partner_ids', 'copy_products')
     def _compute_purchase_warn_msg(self):
         self.purchase_warn_msg = ''
         # follows partner warning logic from PurchaseOrder
         if not self.env.user.has_group('purchase.group_warning_purchase'):
             return
-        partner = self.partner_id
-        # If partner has no warning, check its company
-        if not partner.purchase_warn_msg:
-            partner = partner.parent_id
-        if partner and partner.purchase_warn_msg:
-            self.purchase_warn_msg = _("Warning for %(partner)s:\n%(warning_message)s\n", partner=partner.name, warning_message=partner.purchase_warn_msg)
-        if self.copy_products and self.origin_po_id.order_line:
-            for line in self.origin_po_id.order_line:
-                if line.product_id.purchase_line_warn_msg:
-                    self.purchase_warn_msg += _("Warning for %(product)s:\n%(warning_message)s\n", product=line.product_id.name, warning_message=line.product_id.purchase_line_warn_msg)
+        for partner in self.partner_ids:
+            # If partner has no warning, check its company
+            if not partner.purchase_warn_msg:
+                partner = partner.parent_id
+            if partner and partner.purchase_warn_msg:
+                self.purchase_warn_msg = _("Warning for %(partner)s:\n%(warning_message)s\n", partner=partner.name, warning_message=partner.purchase_warn_msg)
+            if self.copy_products and self.origin_po_id.order_line:
+                for line in self.origin_po_id.order_line:
+                    if line.product_id.purchase_line_warn_msg:
+                        self.purchase_warn_msg += _("Warning for %(product)s:\n%(warning_message)s\n", product=line.product_id.name, warning_message=line.product_id.purchase_line_warn_msg)
 
     def action_create_alternative(self):
         vals = self._get_alternative_values()
-        alt_po = self.env['purchase.order'].with_context(origin_po_id=self.origin_po_id.id, default_requisition_id=False).create(vals)
-        alt_po.order_line._compute_tax_id()
-        return {
+        alt_purchase_orders = self.env['purchase.order'].with_context(origin_po_id=self.origin_po_id.id, default_requisition_id=False).create(vals)
+        alt_purchase_orders.order_line._compute_tax_id()
+        action = {
             'type': 'ir.actions.act_window',
-            'view_mode': 'form',
+            'view_mode': 'list,kanban,form,calendar',
             'res_model': 'purchase.order',
-            'res_id': alt_po.id,
-            'context': {
-                'active_id': alt_po.id,
-            },
         }
+        if len(alt_purchase_orders) == 1:
+            action['res_id'] = alt_purchase_orders.id
+            action['view_mode'] = 'form'
+        else:
+            action['name'] = _('Alternative Purchase Orders')
+            action['domain'] = [('id', 'in', alt_purchase_orders.ids)]
+        return action
 
     def _get_alternative_values(self):
-        vals = {
-            'date_order': self.origin_po_id.date_order,
-            'partner_id': self.partner_id.id,
-            'user_id': self.origin_po_id.user_id.id,
-            'dest_address_id': self.origin_po_id.dest_address_id.id,
-            'origin': self.origin_po_id.origin,
-        }
-        if self.copy_products and self.origin_po_id:
-            product_tmpl_ids_with_description = set(self.env['product.supplierinfo'].search_fetch([
-                ('product_tmpl_id', 'in', self.origin_po_id.order_line.product_id.product_tmpl_id.ids),
-                ('partner_id', '=', self.partner_id.id),
+        vals = []
+        origin_po = self.origin_po_id
+        partner_product_tmpl_dict = {}
+        if self.copy_products and origin_po:
+            supplierinfo = self.env['product.supplierinfo'].search([
+                ('product_tmpl_id', 'in', origin_po.order_line.product_id.product_tmpl_id.ids),
+                ('partner_id', 'in', self.partner_ids.ids),
                 '|', ('product_code', '!=', False), ('product_name', '!=', False)
-            ], ['product_tmpl_id']).product_tmpl_id.ids)
-            vals['order_line'] = [Command.create(self._get_alternative_line_value(line, product_tmpl_ids_with_description)) for line in self.origin_po_id.order_line]
+            ])
+            # Build dict: {partner: set(product_tmpl_ids)}
+            for info in supplierinfo:
+                partner_product_tmpl_dict.setdefault(info.partner_id.id, set()).add(info.product_tmpl_id.id)
+
+        for partner in self.partner_ids:
+            product_tmpl_ids_with_description = partner_product_tmpl_dict.get(partner.id, set())
+            val = {
+                'date_order': origin_po.date_order,
+                'partner_id': partner.id,
+                'user_id': origin_po.user_id.id,
+                'dest_address_id': origin_po.dest_address_id.id,
+                'origin': origin_po.origin,
+                'currency_id': partner.property_purchase_currency_id.id or self.env.company.currency_id.id,
+            }
+            if self.copy_products and origin_po:
+                val['order_line'] = [Command.create(self._get_alternative_line_value(line, product_tmpl_ids_with_description)) for line in origin_po.order_line]
+            vals.append(val)
+
         return vals
 
     @api.model
@@ -78,5 +94,6 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
             'product_qty': order_line.product_qty,
             'product_uom_id': order_line.product_uom_id.id,
             'display_type': order_line.display_type,
+            'analytic_distribution': order_line.analytic_distribution,
             **({'name': order_line.name} if order_line.display_type in ('line_section', 'line_note') or not has_product_description else {}),
         }

--- a/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.xml
+++ b/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.xml
@@ -9,9 +9,7 @@
                     <group>
                         <field name="origin_po_id" invisible="1"/>
                         <group>
-                            <field name="partner_id"/>
-                        </group>
-                        <group>
+                            <field name="partner_ids" widget="many2many_tags" />
                             <field name="copy_products"/>
                         </group>
                         <group groups="purchase.group_warning_purchase" invisible="purchase_warn_msg == ''">

--- a/addons/purchase_requisition_sale/tests/test_purchase_requisition_sale.py
+++ b/addons/purchase_requisition_sale/tests/test_purchase_requisition_sale.py
@@ -49,7 +49,7 @@ class TestPurchaseRequisitionSale(TransactionCase):
         # Create an alternative RFQ for another vendor
         action = purchase_order.action_create_alternative()
         alt_po_wizard = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard.partner_id = self.vendor_2
+        alt_po_wizard.partner_ids = self.vendor_2
         alt_po_wizard.copy_products = True
         alt_po_wizard = alt_po_wizard.save()
         alt_po_wizard.action_create_alternative()

--- a/addons/purchase_requisition_stock/tests/test_purchase_requisition_stock.py
+++ b/addons/purchase_requisition_stock/tests/test_purchase_requisition_stock.py
@@ -206,7 +206,7 @@ class TestPurchaseRequisitionStock(TestPurchaseRequisitionCommon):
         # create an alt PO
         action = orig_po.action_create_alternative()
         alt_po_wiz = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wiz.partner_id = self.res_partner_1
+        alt_po_wiz.partner_ids = self.res_partner_1
         alt_po_wiz.copy_products = True
         alt_po_wiz = alt_po_wiz.save()
         alt_po_wiz.action_create_alternative()
@@ -279,7 +279,7 @@ class TestPurchaseRequisitionStock(TestPurchaseRequisitionCommon):
         # Create an alternative RFQ for another vendor
         action = orig_po.action_create_alternative()
         alt_po_wizard = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard.partner_id = vendor_2
+        alt_po_wizard.partner_ids = vendor_2
         alt_po_wizard.copy_products = True
         alt_po_wizard = alt_po_wizard.save()
         alt_po_wizard.action_create_alternative()
@@ -313,7 +313,7 @@ class TestPurchaseRequisitionStock(TestPurchaseRequisitionCommon):
         # Creates an alternative PO
         action = orig_po.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
-        alt_po_wizard_form.partner_id = self.res_partner_1
+        alt_po_wizard_form.partner_ids = self.res_partner_1
         alt_po_wizard_form.copy_products = True
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_id = alt_po_wizard.action_create_alternative()['res_id']

--- a/addons/purchase_requisition_stock/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition_stock/wizard/purchase_requisition_create_alternative.py
@@ -9,10 +9,11 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
 
     def _get_alternative_values(self):
         vals = super(PurchaseRequisitionCreateAlternative, self)._get_alternative_values()
-        vals.update({
-            'picking_type_id': self.origin_po_id.picking_type_id.id,
-            'group_id': self.origin_po_id.group_id.id,
-        })
+        for val in vals:
+            val.update({
+                'picking_type_id': self.origin_po_id.picking_type_id.id,
+                'group_id': self.origin_po_id.group_id.id,
+            })
         return vals
 
     @api.model

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -6,7 +6,6 @@ from unittest.mock import patch, PropertyMock
 
 from odoo import Command, fields
 from odoo.fields import Domain
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tests.common import users, tagged, HttpCase, warmup
@@ -377,16 +376,16 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         The point of having a separate getter is to allow it to be overriden.
         """
         xmlid_to_res_id = self.env["ir.model.data"]._xmlid_to_res_id
+        partner_0 = self.users[0].partner_id
         return {
             "res.partner": self._filter_partners_fields(
                 {
                     "active": False,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.user_root.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": self.user_root.partner_id._get_avatar_128_access_token(),
                     "email": "odoobot@example.com",
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",
+                    "im_status_access_token": self.user_root.partner_id._get_im_status_access_token(),
                     "isInternalUser": True,
                     "is_company": False,
                     "name": "OdooBot",
@@ -396,9 +395,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 },
                 {
                     "active": True,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.users[0].partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": partner_0._get_avatar_128_access_token(),
                     "id": self.users[0].partner_id.id,
                     "isAdmin": False,
                     "isInternalUser": True,
@@ -1616,12 +1613,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[0]:
             res = {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": "e.e@example.com",
                 "id": user.partner_id.id,
                 "im_status": "online",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "Ernest Employee",
@@ -1643,12 +1639,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[1]:
             res = {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "country_id": self.env.ref("base.in").id,
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "isInternalUser": True,
                 "is_company": False,
                 "is_public": False,
@@ -1663,22 +1658,20 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[2]:
             if only_inviting:
                 return {
-                    "avatar_128_access_token": limited_field_access_token(
-                        user.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                     "id": user.partner_id.id,
                     "im_status": "offline",
+                    "im_status_access_token": user.partner_id._get_im_status_access_token(),
                     "name": "test2",
                     "write_date": fields.Datetime.to_string(user.partner_id.write_date),
                 }
             return {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": "test2@example.com",
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "test2",
@@ -1689,12 +1682,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[3]:
             return {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "test3",
@@ -1705,12 +1697,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[12]:
             return {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "test12",
@@ -1721,12 +1712,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[14]:
             return {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "test14",
@@ -1737,12 +1727,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[15]:
             return {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "test15",
@@ -1752,9 +1741,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if user == self.user_root:
             return {
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "id": user.partner_id.id,
                 "isInternalUser": True,
                 "is_company": False,
@@ -1764,10 +1751,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if guest:
             return {
-                "avatar_128_access_token": limited_field_access_token(self.guest, "avatar_128"),
+                "avatar_128_access_token": self.guest._get_avatar_128_access_token(),
                 "country_id": self.guest.country_id.id,
                 "id": self.guest.id,
                 "im_status": "offline",
+                "im_status_access_token": self.guest._get_im_status_access_token(),
                 "name": "Visitor",
                 "offline_since": False,
                 "write_date": fields.Datetime.to_string(self.guest.write_date),

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -4,7 +4,6 @@ from markupsafe import Markup
 from unittest.mock import patch
 
 from odoo import Command, fields
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
@@ -1565,9 +1564,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "name": "Jeannette Testouille",
                                 },
                                 {
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.env.user.partner_id, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
                                     "id": self.env.user.partner_id.id,
                                     "isInternalUser": True,
                                     "is_company": False,
@@ -1679,9 +1676,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "name": "Jeannette Testouille",
                                 },
                                 {
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.env.user.partner_id, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
                                     "id": self.env.user.partner_id.id,
                                     "isInternalUser": True,
                                     "is_company": False,

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -9,7 +9,6 @@ from odoo.addons.test_mail.tests.test_performance import BaseMailPerformance
 from odoo.tests.common import users, warmup
 from odoo.tests import tagged
 from odoo.tools import mute_logger
-from odoo.tools.misc import limited_field_access_token
 
 
 @tagged('mail_performance', 'post_install', '-at_install')
@@ -260,9 +259,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
                         'id': message.attachment_ids[0].id,
                         'mimetype': 'application/octet-stream',
                         'name': 'Test file 1',
-                        'raw_access_token': limited_field_access_token(
-                            message.attachment_ids[0], 'raw'
-                        ),
+                        'raw_access_token': message.attachment_ids[0]._get_raw_access_token(),
                         'res_id': record.id,
                         'res_model': record._name,
                     }, {
@@ -272,9 +269,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
                         'id': message.attachment_ids[1].id,
                         'mimetype': 'application/octet-stream',
                         'name': 'Test file 0',
-                        'raw_access_token': limited_field_access_token(
-                            message.attachment_ids[1], 'raw'
-                        ),
+                        'raw_access_token': message.attachment_ids[1]._get_raw_access_token(),
                         'res_id': record.id,
                         'res_model': record._name,
                     }

--- a/addons/web/static/src/model/model.js
+++ b/addons/web/static/src/model/model.js
@@ -111,10 +111,10 @@ export function useModel(ModelClass, params, options = {}) {
     const model = new ModelClass(component.env, params, services);
     onWillStart(async () => {
         await options.beforeFirstLoad?.();
-        await model.load(component.props);
+        await model.load(getSearchParams(component.props));
         model.whenReady.resolve();
     });
-    onWillUpdateProps((nextProps) => model.load(nextProps));
+    onWillUpdateProps((nextProps) => model.load(getSearchParams(nextProps)));
     return model;
 }
 

--- a/addons/website/static/src/builder/plugins/size_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/size_option_plugin.js
@@ -1,5 +1,5 @@
 import { after } from "@html_builder/utils/option_sequence";
-import { WIDTH } from "@website/builder/option_sequence";
+import { BLOCK_ALIGN } from "@website/builder/option_sequence";
 import { withSequence } from "@html_editor/utils/resource";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
@@ -8,7 +8,7 @@ class SizeOptionPlugin extends Plugin {
     static id = "sizeOption";
     resources = {
         builder_options: [
-            withSequence(after(WIDTH), {
+            withSequence(after(BLOCK_ALIGN), {
                 template: "html_builder.SizeOption",
                 selector: ".s_alert",
             }),

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -7,7 +7,6 @@ from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.website_livechat.tests.common import TestLivechatCommon
 from odoo.tests.common import new_test_user
-from odoo.tools.misc import limited_field_access_token
 
 
 @tests.tagged('post_install', '-at_install')
@@ -243,10 +242,11 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                 ],
                 "mail.guest": [
                     {
-                        "avatar_128_access_token": limited_field_access_token(guest, "avatar_128"),
+                        "avatar_128_access_token": guest._get_avatar_128_access_token(),
                         "country_id": False,
                         "id": guest.id,
                         "im_status": "offline",
+                        "im_status_access_token": guest._get_im_status_access_token(),
                         "name": f"Visitor #{self.visitor.id}",
                         "offline_since": False,
                         "write_date": fields.Datetime.to_string(guest.write_date),
@@ -259,12 +259,11 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                 "res.partner": self._filter_partners_fields(
                     {
                         "active": True,
-                        "avatar_128_access_token": limited_field_access_token(
-                            self.operator.partner_id, "avatar_128"
-                        ),
+                        "avatar_128_access_token": self.operator.partner_id._get_avatar_128_access_token(),
                         "country_id": False,
                         "id": self.operator.partner_id.id,
                         "im_status": "online",
+                        "im_status_access_token": self.operator.partner_id._get_im_status_access_token(),
                         "is_public": False,
                         "user_livechat_username": "El Deboulonnator",
                         "write_date": fields.Datetime.to_string(

--- a/odoo/addons/base/models/avatar_mixin.py
+++ b/odoo/addons/base/models/avatar_mixin.py
@@ -5,6 +5,7 @@ from base64 import b64encode
 from hashlib import sha512
 from odoo import models, fields, api
 from odoo.tools import html_escape, file_open
+from odoo.tools.misc import limited_field_access_token
 
 
 def get_hsl_from_seed(seed):
@@ -77,3 +78,12 @@ class AvatarMixin(models.AbstractModel):
 
     def _avatar_get_placeholder(self):
         return file_open(self._avatar_get_placeholder_path(), 'rb').read()
+
+    def _get_avatar_128_access_token(self):
+        """Return a scoped access token for the `avatar_128` field. The token can be
+        used with `ir_binary._find_record` to bypass access rights.
+
+        :rtype: str
+        """
+        self.ensure_one()
+        return limited_field_access_token(self, "avatar_128", scope="binary")

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -20,6 +20,7 @@ from odoo.fields import Domain
 from odoo.http import Stream, root, request
 from odoo.tools import config, consteq, human_size, image, split_every, str2bool
 from odoo.tools.mimetypes import guess_mimetype, fix_filename_extension
+from odoo.tools.misc import limited_field_access_token
 
 _logger = logging.getLogger(__name__)
 
@@ -673,6 +674,15 @@ class IrAttachment(models.Model):
             attachment.write({'access_token': access_token})
             tokens.append(access_token)
         return tokens
+
+    def _get_raw_access_token(self):
+        """Return a scoped access token for the `raw` field. The token can be
+        used with `ir_binary._find_record` to bypass access rights.
+
+        :rtype: str
+        """
+        self.ensure_one()
+        return limited_field_access_token(self, "raw", scope="binary")
 
     @api.model
     def create_unique(self, values_list):

--- a/odoo/addons/base/models/ir_binary.py
+++ b/odoo/addons/base/models/ir_binary.py
@@ -47,7 +47,7 @@ class IrBinary(models.AbstractModel):
             record = self.env[res_model].browse(res_id).exists()
         if not record:
             raise MissingError(f"No record found for xmlid={xmlid}, res_model={res_model}, id={res_id}")  # pylint: disable=missing-gettext
-        if access_token and verify_limited_field_access_token(record, field, access_token):
+        if access_token and verify_limited_field_access_token(record, field, access_token, scope="binary"):
             return record.sudo()
         if record._can_return_content(field, access_token):
             return record.sudo()


### PR DESCRIPTION
Before this commit clicking on the editor with a link popover open
would not cause the link popover to close.

Steps to reproduce:
- go to the website homepage
- open the editor
- click on any top menu links like Home or Contact Us
- click anywere on the editor
- the popover from the first click is still open

After the change clicking anywhere on the editor will cause the
popover to close.