### PR TITLE
[FIX] remove the unnecessary link preview loading and notification

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -215,7 +215,6 @@ export class LinkPopover extends Component {
         this.state.url = deducedUrl
             ? this.correctLink(deducedUrl)
             : this.correctLink(this.state.url);
-        this.loadAsyncLinkPreview();
     }
     onClickEdit() {
         this.state.editing = true;


### PR DESCRIPTION
Because when we change the link element in the popover and apply, we always close the current one and open a new one, the loading at the apply is redundant. We do the reopening to let the overlay plugin reposition popover, and let browser handle the relative/root-relative url to add the domain.