### PR TITLE
[FIX] account: hide due date on cancelled invoices and vendor bills

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -522,7 +522,7 @@
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" readonly="state != 'draft'" string="Bill Date" decoration-warning="abnormal_date_warning"/>
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')" readonly="state != 'draft'" string="Invoice Date" decoration-warning="abnormal_date_warning"/>
                     <field name="date" optional="hide" string="Accounting Date" readonly="state in ['cancel', 'posted']"/>
-                    <field name="invoice_date_due" widget="remaining_days" optional="show" invisible="payment_state in ('paid', 'in_payment', 'reversed')"/>
+                    <field name="invoice_date_due" widget="remaining_days" optional="show" invisible="payment_state in ('paid', 'in_payment', 'reversed') or status_in_payment == 'cancel'"/>
                     <field name="invoice_origin" optional="hide" string="Source Document"/>
                     <field name="payment_reference" optional="hide" column_invisible="context.get('default_move_type') in ('out_invoice', 'out_refund', 'out_receipt')"/>
                     <field name="ref" optional="hide"/>


### PR DESCRIPTION
Purpose
-------
This hides the Due Date field on invoices when the document has been cancelled.  
Once an invoice is cancelled, no payment is expected anymore, so the due date becomes irrelevant and potentially misleading.

Changes
-------
- Added condition on the `invoice_date_due` field in the invoice form view.
- The field is now hidden when the invoice state is `cancel`.

How to test
-----------
1. Go to the Accounting app.  
2. Create a Customer Invoice or Vendor Bill with a due date.  
3. Validate it, then cancel the invoice.  
4. Open the cancelled the list view, the due date should be empty for the cancelled lines.
