### PR TITLE
[IMP] account: Quick search on an amount in the journal items

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -323,6 +323,7 @@
                     <field name="tax_ids" />
                     <field name="tax_line_id" string="Originator Tax"/>
                     <field name="reconcile_model_id"/>
+                    <field name="balance" string="Amount" filter_domain="['|', ('balance', '=', self), ('balance', '=', -self)]"/>
                     <separator/>
                     <filter string="Unposted" name="unposted" domain="[('parent_state', '=', 'draft')]" help="Unposted Journal Items"/>
                     <filter string="Posted" name="posted" domain="[('parent_state', '=', 'posted')]" help="Posted Journal Items"/>


### PR DESCRIPTION
New behavior: User can search on journal items based on the amount.

The search is based on the balance field which can be -ve or +ve, so we ignore the sign. 