### PR TITLE
[FIX] account: allow journal item search by amount

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -306,6 +306,7 @@
                         '|', '|', '|',
                         ('name', 'ilike', self), ('ref', 'ilike', self), ('account_id', 'ilike', self), ('partner_id', 'ilike', self)]"/>
                     <field name="name"/>
+                    <field name="balance" string="Amount" filter_domain="['|', ('credit', '=', self), ('debit', '=', self)]"/>
                     <field name="ref"/>
                     <field name="invoice_date"/>
                     <field name="date"/>


### PR DESCRIPTION
Purpose
-------
Allow searching journal items by their amount directly from the search bar.  
This improves usability when accountants want to find entries with a specific amount.

Changes
-------
- Added a custom search on `amount` field of `account.move.line`.
- Enables syntax like `amount:123.45` in the search bar on the Journal Items list.

How to test
-----------
1. Go to Accounting > Journal Items.
2. In the search bar, type `amount:42.0` (replace 42.0 with a known amount).
3. Only journal items with exactly that amount should appear.