### PR TITLE
[IMP] account: Group Payment: Change memo to PAY/XXXX

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -164,7 +164,7 @@ class ResCompany(models.Model):
             'padding': 5,
             'use_date_range': True,
             'company_id': self.id,
-            'prefix': 'BATCH/%(year)s/',
+            'prefix': 'PAY/%(year)s/',
         }),
     )
 
@@ -272,8 +272,8 @@ class ResCompany(models.Model):
 
     def get_next_batch_payment_communication(self):
         '''
-        When in need of a batch payment communication reference (several invoices paid at the same time)
-        use batch_payment_sequence_id to get it (eventually create it first): e.g BATCH/2024/00001
+        When in need of a group payment communication reference (several invoices paid at the same time)
+        use batch_payment_sequence_id to get it (eventually create it first): e.g PAY/2024/00001
         '''
         self.ensure_one()
         return self.sudo().batch_payment_sequence_id.next_by_id()

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -202,7 +202,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': Like(f'PAY/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -235,7 +235,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': Like(f'PAY/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -270,7 +270,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': Like(f'PAY/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -313,7 +313,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': Like(f'PAY/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -356,7 +356,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': Like(f'PAY/{self.current_year}/...'),
             'payment_method_line_id': self.outbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -399,7 +399,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': Like(f'PAY/{self.current_year}/...'),
             'payment_method_line_id': self.outbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -555,7 +555,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
         self.assertRecordValues(payments, [
             {
-                'memo': Like(f'BATCH/{self.current_year}/...'),
+                'memo': Like(f'PAY/{self.current_year}/...'),
                 'payment_method_line_id': self.outbound_payment_method_line.id,
             },
         ])
@@ -676,7 +676,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
         self.assertRecordValues(payments, [
             {
-                'memo': Like(f'BATCH/{self.current_year}/...'),
+                'memo': Like(f'PAY/{self.current_year}/...'),
                 'payment_method_line_id': self.outbound_payment_method_line.id,
             },
             {
@@ -1747,7 +1747,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'installments_mode': 'next',
             'installments_switch_amount': 1333.33,
             'currency_id': self.company.currency_id.id,  # Different currencies, so we get the company's one
-            'communication': Like(f'BATCH/{self.current_year}/...'),
+            'communication': Like(f'PAY/{self.current_year}/...'),
         }])
 
         wizard = self.env['account.payment.register'].with_context(
@@ -1784,7 +1784,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'payment_difference': 0.5,
             'installments_mode': 'next',
             'installments_switch_amount': 357.83,  # 24.5 for in_invoice_epd_applied + 1000 / 3 (rate) for the second
-            'communication': Like(f'BATCH/{self.current_year}/...'),
+            'communication': Like(f'PAY/{self.current_year}/...'),
         }])
 
         # Clicking on the button to full gets the amount from js, so we need to put it by hand here
@@ -1798,7 +1798,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'payment_difference': 0.5,
             'installments_mode': 'full',
             'installments_switch_amount': 57.83,  # The previous 'next' amount
-            'communication': Like(f'BATCH/{self.current_year}/...'),
+            'communication': Like(f'PAY/{self.current_year}/...'),
         }])
 
     def test_payment_register_with_next_payment_date(self):


### PR DESCRIPTION
### [IMP] account: Group Payment: Change memo to `PAY/XXXX`

When creating a payment group, it generates a new payment memo using a `BATCH/XXX` prefix. 
It can be confusing as there is a Batch Payment feature, but it has nothing to do with it.

We use `PAY/XXX` syntax for payment group.
task-4908883