### PR TITLE
[FIX] l10n_fr_account: show delivery date on customer invoice

### DIFF
--- a/addons/l10n_fr_account/models/account_move.py
+++ b/addons/l10n_fr_account/models/account_move.py
@@ -19,3 +19,18 @@ class AccountMove(models.Model):
     def _compute_l10n_fr_is_company_french(self):
         for record in self:
             record.l10n_fr_is_company_french = record.country_code in record.company_id._get_france_country_codes()
+
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if self.l10n_fr_is_company_french:
+                move.show_delivery_date = move.is_sale_document()
+
+    def _post(self, soft=True):
+        res = super()._post(soft)
+        for move in self:
+            if move.show_delivery_date and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
+        return res


### PR DESCRIPTION
Purpose
-------
Comply with new French legislation requiring the delivery date to appear on customer invoices. This aims to increase transparency for buyers and meet legal obligations.

Changes
-------
- Added a `delivery_date` field in the invoice form for companies based in France.
- Field is editable by the user and shown in the invoice header.
- If no delivery date is provided, the invoice date is used as default.
- Delivery date is also printed on the invoice layout (PDF report).
- Aligned implementation with similar use cases in other localisations.

How to test
-----------
1. Set the company country to France.
2. Go to Accounting > Customers > Invoices.
3. Open or create a customer invoice.
4. A new "Delivery Date" field should appear in the form header.
5. Leave it empty or set a specific date.
6. Save and print the invoice.
7. The delivery date should appear in the invoice header, defaulting to the invoice date if not manually set.

task-4908872