### PR TITLE
[IMP] account: more visibility about the sent status of invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -603,6 +603,12 @@ class AccountMove(models.Model):
         tracking=True,
         help="It indicates that the invoice/payment has been sent or the PDF has been generated.",
     )
+
+    move_sent_state = fields.Selection(
+        selection=[('not_sent', "Not Sent"), ('sent', "Sent")],
+        compute='_compute_move_sent_state',
+    )
+
     is_being_sent = fields.Boolean(
         help="Is the move being sent asynchronously",
         compute='_compute_is_being_sent'
@@ -1723,6 +1729,11 @@ class AccountMove(models.Model):
                 narration = _('Terms & Conditions: %s', baseurl)
                 del context
             move.narration = narration or False
+
+    @api.depends('is_move_sent')
+    def _compute_move_sent_state(self):
+        for move in self:
+            move.move_sent_state = 'sent' if move.is_move_sent else 'not_sent'
 
     def _get_partner_credit_warning_exclude_amount(self):
         # to extend in module 'sale'; see there for details

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -548,6 +548,12 @@
                            invisible="payment_state == 'invoicing_legacy' or move_type == 'entry'"
                            optional="show"
                     />
+                    <field name="move_sent_state"
+                           widget="badge"
+                           string="Move Sent?"
+                           decoration-info="move_sent_state == 'not_sent'"
+                           decoration-success="move_sent_state == 'sent'"
+                           optional="hide"/>
                     <field name="move_type" column_invisible="context.get('default_move_type', True)"/>
                     <field name="abnormal_amount_warning" column_invisible="1"/>
                     <field name="abnormal_date_warning" column_invisible="1"/>


### PR DESCRIPTION
### [IMP] account: more visibility about the sent status of invoice

With the evolution of the electronic invoicing, but also in general, it's a good idea to show more easily when an invoice is sent or not by the send & print.

User can easily see the difference between invoices which are Sent or not.

task-4908889