### PR TITLE
[FIX] account: show sent status on invoices and added filter

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -597,6 +597,16 @@ class AccountMove(models.Model):
         string='Terms and Conditions',
         compute='_compute_narration', store=True, readonly=False,
     )
+    status_move_sent = fields.Selection(
+        selection=[
+            ('not_sent', "Not Sent"),
+            ('sent', "Sent"),
+        ],
+        readonly=True,
+        string="Sent Status",
+        default='not_sent',
+        compute='_compute_status_move_sent',
+    )
     is_move_sent = fields.Boolean(
         readonly=True,
         copy=False,
@@ -753,6 +763,11 @@ class AccountMove(models.Model):
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
+
+    @api.depends('is_move_sent')
+    def _compute_status_move_sent(self):
+        for move in self:
+            move.status_move_sent = 'sent' if move.is_move_sent else 'not_sent'
 
     @api.depends('move_type', 'partner_id')
     def _compute_invoice_default_sale_person(self):

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -548,6 +548,12 @@
                            invisible="payment_state == 'invoicing_legacy' or move_type == 'entry'"
                            optional="show"
                     />
+                    <field name="status_move_sent" 
+                           string="Sent"
+                           widget="badge"
+                           decoration-success="status_move_sent == 'sent'"
+                           decoration-danger="status_move_sent == 'not_sent'"
+                           optional="hide" />
                     <field name="move_type" column_invisible="context.get('default_move_type', True)"/>
                     <field name="abnormal_amount_warning" column_invisible="1"/>
                     <field name="abnormal_date_warning" column_invisible="1"/>
@@ -1581,6 +1587,11 @@
                     <filter name="not_secured" string="Not Secured" domain="[('secured', '=', False), ('state', '=', 'posted')]"
                             groups="account.group_account_secured,base.group_no_one"/>
                     <separator/>
+                    <filter name="sent"
+                            string="Sent"
+                            domain="[('is_move_sent', '=', True)]"
+                            invisible="context.get('default_move_type') in ('in_invoice', 'in_refund', 'in_receipt')"
+                    />
                     <filter name="not_sent"
                             string="Not Sent"
                             domain="[('is_move_sent', '=', False)]"


### PR DESCRIPTION
Purpose
-------
Improve visibility of whether a customer invoice has been sent or not using the "Send & Print" feature. With the rise of electronic invoicing and general accounting needs, it's helpful to clearly distinguish sent from unsent invoices in the list view.

Changes
-------
- Added a "Sent" column (optional, hidden by default) next to the invoice status in the customer invoices list view.
- Added the filter "Sent": shows invoices that have been sent via the "Send & Print" feature.

How to test
-----------
1. Go to Accounting > Customers > Invoices.
2. Click the optional columns icon on the list view to show the "Sent" column.
3. Send one invoice via the "Send" button in the form view.
4. Or Select multiple invoices from the list view and use "Action > Send & Print" to send them.
5. The "Sent" column should update accordingly.
6. Use the "Sent invoices" and "Not sent invoices" filters to check the expected results.