### PR TITLE
[IMP] l10n_fr_account: Delivery Date in Invoice Header

### DIFF
--- a/addons/l10n_fr_account/models/account_move.py
+++ b/addons/l10n_fr_account/models/account_move.py
@@ -19,3 +19,17 @@ class AccountMove(models.Model):
     def _compute_l10n_fr_is_company_french(self):
         for record in self:
             record.l10n_fr_is_company_french = record.country_code in record.company_id._get_france_country_codes()
+
+    @api.depends('l10n_fr_is_company_french')
+    def _compute_show_delivery_date(self):
+        for move in self:
+            if move.l10n_fr_is_company_french:
+                move.show_delivery_date = True
+
+    @api.depends('invoice_date', 'show_delivery_date')
+    def _compute_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_delivery_date()
+        for move in self:
+            if not move.delivery_date and move.show_delivery_date:
+                move.delivery_date = move.invoice_date


### PR DESCRIPTION
### [IMP] l10n_fr_account: Delivery Date in Invoice Header

There is a New legislation in France to add delivery date on invoice

 `delivery_date` appears in the header of customer invoice and in the invoice layout.

task-4908888