### PR TITLE
[FIX] account: show delivery date on invoices for French companies

### DIFF
--- a/addons/l10n_fr_account/models/account_move.py
+++ b/addons/l10n_fr_account/models/account_move.py
@@ -19,3 +19,17 @@ class AccountMove(models.Model):
     def _compute_l10n_fr_is_company_french(self):
         for record in self:
             record.l10n_fr_is_company_french = record.country_code in record.company_id._get_france_country_codes()
+
+    @api.depends('l10n_fr_is_company_french')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.l10n_fr_is_company_french:
+                move.show_delivery_date = move.is_sale_document()
+
+    def _post(self, soft=True):
+        for move in self:
+            if move.show_delivery_date and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
+        return super()._post(soft)


### PR DESCRIPTION
Fixed an issue where the delivery date was not displayed on invoices for companies operating in France when the interface language was set to French.

The delivery date is now properly fixed.

shzi

task-4908851