### PR TITLE
[IMP] account: add invoice sent status column and filter

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -605,7 +605,14 @@ class AccountMove(models.Model):
     )
     is_being_sent = fields.Boolean(
         help="Is the move being sent asynchronously",
-        compute='_compute_is_being_sent'
+        compute='_compute_is_being_sent',
+    )
+    send_status_display = fields.Selection(
+        selection=[
+            ('sent', 'Sent'),
+            ('not_sent', 'Not Sent'),
+        ],
+        compute='_compute_send_status_display'
     )
 
     invoice_user_id = fields.Many2one(
@@ -774,6 +781,11 @@ class AccountMove(models.Model):
     def _compute_is_being_sent(self):
         for move in self:
             move.is_being_sent = bool(move.sending_data)
+    
+    @api.depends('is_move_sent')
+    def _compute_send_status_display(self):
+        for move in self:
+            move.send_status_display = 'sent' if move.is_move_sent else 'not_sent'
 
     def _compute_payment_reference(self):
         for move in self.filtered(lambda m: (

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -548,6 +548,14 @@
                            invisible="payment_state == 'invoicing_legacy' or move_type == 'entry'"
                            optional="show"
                     />
+                    <field name="send_status_display"
+                            string="Send Status"
+                            widget="badge"
+                            decoration-danger="is_move_sent == False"
+                            decoration-success="is_move_sent == True"
+                            invisible="state == 'draft'"
+                            optional="hide"
+                    />
                     <field name="move_type" column_invisible="context.get('default_move_type', True)"/>
                     <field name="abnormal_amount_warning" column_invisible="1"/>
                     <field name="abnormal_date_warning" column_invisible="1"/>
@@ -1581,8 +1589,13 @@
                     <filter name="not_secured" string="Not Secured" domain="[('secured', '=', False), ('state', '=', 'posted')]"
                             groups="account.group_account_secured,base.group_no_one"/>
                     <separator/>
+                    <filter name="sent"
+                            string="Sent Invoices"
+                            domain="[('is_move_sent', '=', True)]"
+                            invisible="context.get('default_move_type') in ('in_invoice', 'in_refund', 'in_receipt')"
+                    />
                     <filter name="not_sent"
-                            string="Not Sent"
+                            string="Not Sent Invoices"
                             domain="[('is_move_sent', '=', False)]"
                             invisible="context.get('default_move_type') in ('in_invoice', 'in_refund', 'in_receipt')"
                     />


### PR DESCRIPTION
Improved the invoice list view by adding a new column indicating whether each invoice has been sent. This gives users better visibility into communication status at a glance.

Also introduced a filter to allow users to easily search for sent or unsent invoices, improving usability during follow-up or audit tasks.