### PR TITLE
[IMP] sale: add option to hide sections, subsections, and prices on sale orders

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -307,6 +307,28 @@ class SaleOrderLine(models.Model):
     company_price_include = fields.Selection(related="company_id.account_price_include")
     sale_line_warn_msg = fields.Text(related='product_id.sale_line_warn_msg')
 
+    # Section-related fields
+    parent_id = fields.Many2one(
+        string="Parent Line",
+        comodel_name='sale.order.line',
+        compute='_compute_parent_id',
+        store=True,
+    )  # The section or subsection this line belongs to.
+    collapse_prices = fields.Boolean(
+        string="Collapse Prices",
+        compute='_compute_section_visibility_fields',
+        store=True,
+        readonly=False,
+        copy=True,
+    )  # Whether this section's lines' prices will be hidden in reports and in the portal.
+    collapse_composition = fields.Boolean(
+        string="Collapse Composition",
+        compute='_compute_section_visibility_fields',
+        store=True,
+        readonly=False,
+        copy=True,
+    )  # Whether this section's lines will be hidden in reports and in the portal.
+
     #=== COMPUTE METHODS ===#
 
     @api.depends('order_partner_id', 'order_id', 'product_id')
@@ -1130,6 +1152,37 @@ class SaleOrderLine(models.Model):
             # line.ids checks whether it's a new record not yet saved
             line.product_uom_readonly = line.ids and line.state in ['sale', 'cancel']
 
+    @api.depends('sequence', 'display_type', 'order_id')
+    def _compute_parent_id(self):
+        for _orders, lines in self.grouped('order_id').items():
+            current_section = None
+            current_subsection = None
+            for line in lines.sorted('sequence'):
+                if line.display_type == 'line_section':
+                    line.parent_id = None
+                    current_section = line
+                    current_subsection = None  # Reset subsection when entering a new section.
+                elif line.display_type == 'line_subsection':
+                    line.parent_id = current_section
+                    current_subsection = line
+                else:  # Product/Note lines
+                    # Link to the current subsection or fall back to the current section.
+                    line.parent_id = current_subsection or current_section
+
+    @api.depends('parent_id', 'display_type')
+    def _compute_section_visibility_fields(self):
+        for line in self:
+            if line.display_type == 'line_section':
+                continue  # Don't recompute when moving sections around.
+            elif line.display_type == 'line_subsection':
+                line.collapse_prices = line.collapse_prices or line.parent_id.collapse_prices
+                line.collapse_composition = (
+                    line.collapse_composition or line.parent_id.collapse_composition
+                )
+            else:  # Product/Note lines
+                line.collapse_prices = line.parent_id.collapse_prices
+                line.collapse_composition = line.parent_id.collapse_composition
+
     #=== CONSTRAINT METHODS ===#
 
     @api.constrains('combo_item_id')
@@ -1386,6 +1439,41 @@ class SaleOrderLine(models.Model):
             for l in self.invoice_lines
             if l.move_id.state == 'posted' and l.move_id not in invoices  # don't recompute with the final invoice
         )
+
+    def _get_grouped_section_summary(self):
+        """Return a tax-wise summary of sales order lines linked to section.
+
+        Group lines by their tax IDs and computes subtotal and total for each group.
+        """
+        self.ensure_one()
+
+        def is_relevant_line(line_):
+            """Return whether the line is a direct or indirect child of the section."""
+            is_direct_child = line_.parent_id == self and not line_.display_type
+            is_indirect_child = (
+                self.display_type == 'line_section'
+                and line_.parent_id
+                and line_.parent_id.display_type == 'line_subsection'
+                and line_.parent_id.parent_id == self
+            )
+            return is_direct_child or is_indirect_child
+
+        section_lines = self.order_id.order_line.filtered(is_relevant_line)
+        result = []
+        for taxes, lines in groupby(section_lines, key=lambda l: l.tax_ids):
+            tax_labels = [tax.tax_label for tax in taxes if tax.tax_label]
+            subtotal = sum(l.price_subtotal for l in lines)
+            result.append({
+                'name': self.name,
+                'taxes': tax_labels,
+                'price_subtotal': subtotal,
+            })
+
+        return result or [{
+            'name': self.name,
+            'taxes': [],
+            'price_subtotal': 0.0,
+        }]
 
     #=== CORE METHODS OVERRIDES ===#
 

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -98,7 +98,14 @@
                     <t t-foreach="lines_to_report" t-as="line">
 
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
+
+                        <t
+                            t-if="line.display_type not in ('line_section', 'line_subsection')
+                                or line.product_type == 'combo'
+                                or not line.collapse_composition"
+                        >
                         <tr
+                            t-if="not line.collapse_composition"
                             t-att-class="{
                                 'fw-bolder o_line_section': line.display_type == 'line_section' or line.product_type == 'combo',
                                 'fw-bold o_line_subsection': line.display_type == 'line_subsection',
@@ -116,7 +123,12 @@
                                     </span>
                                 </td>
                                 <td name="td_priceunit" class="text-end text-nowrap">
-                                    <span t-field="line.price_unit">3</span>
+                                    <span
+                                        t-if="not line.collapse_prices"
+                                        t-field="line.price_unit"
+                                    >
+                                        3
+                                    </span>
                                 </td>
                                 <td name="td_discount" t-if="display_discount" class="text-end">
                                     <span t-field="line.discount">-</span>
@@ -126,15 +138,25 @@
                                     <span t-out="taxes">Tax 15%</span>
                                 </td>
                                 <td t-if="not line.is_downpayment" name="td_subtotal" class="text-end o_price_total">
-                                    <span t-field="line.price_subtotal">27.00</span>
+                                    <span
+                                        t-if="not line.collapse_prices"
+                                        t-field="line.price_subtotal"
+                                    >
+                                        27.00
+                                    </span>
                                 </td>
                             </t>
-                            <t t-elif="line.display_type in ('line_section', 'line_subsection') or line.product_type == 'combo'">
+                            <t
+                                t-elif="line.display_type in ('line_section', 'line_subsection')
+                                    or line.product_type == 'combo'"
+                            >
                                 <td name="td_section_line" colspan="99">
                                     <span t-field="line.name">A section title</span>
                                 </td>
-                                <t t-set="current_section" t-value="line"/>
-                                <t t-set="current_subtotal" t-value="0"/>
+                                <t t-if="line.display_type == 'line_section'">
+                                    <t t-set="current_section" t-value="line"/>
+                                    <t t-set="current_subtotal" t-value="0"/>
+                                </t>
                             </t>
                             <t t-elif="line.display_type == 'line_note'">
                                 <td name="td_note_line" colspan="99">
@@ -142,6 +164,51 @@
                                 </td>
                             </t>
                         </tr>
+                        </t>
+
+                        <t
+                            t-elif="(
+                                    line.display_type == 'line_subsection'
+                                    and not line.parent_id.collapse_composition
+                                )
+                                or line.display_type == 'line_section'"
+                        >
+                            <tr
+                                t-foreach="line._get_grouped_section_summary()"
+                                t-as="section_line"
+                                class="o_line_section"
+                            >
+                                <td name="td_name">
+                                    <span t-out="section_line['name']">Section Summary</span>
+                                </td>
+                                <td name="td_quantity" class="text-end text-nowrap">
+                                    <span>1.00 Units</span>
+                                </td>
+                                <td name="td_priceunit" class="text-end text-nowrap">
+                                    <span t-out="section_line['price_subtotal']"/>
+                                </td>
+                                <td name="td_discount" t-if="display_discount"/>
+                                <td
+                                    name="td_taxes"
+                                    t-if="display_taxes"
+                                    t-attf-class="text-end {{ 'text-nowrap' if len(section_line['taxes']) &lt; 10 else '' }}"
+                                >
+                                    <span t-out="', '.join(section_line['taxes'])">
+                                        Tax 15%
+                                    </span>
+                                </td>
+                                <td class="text-end o_price_total">
+                                    <span t-out="section_line['price_subtotal']">
+                                        31.05
+                                    </span>
+                                </td>
+                            </tr>
+                            <t t-if="line.display_type == 'line_section'">                                
+                                <t t-set="current_section" t-value="line"/>
+                                <t t-set="current_subtotal" t-value="0"/>
+                            </t>
+                        </t>
+
                         <t
                             t-if="current_section and (
                                 line_last
@@ -151,7 +218,9 @@
                                     line.combo_item_id
                                     and not lines_to_report[line_index+1].combo_item_id
                                 )
-                            ) and not line.is_downpayment"
+                            )
+                            and not line.is_downpayment
+                            and not current_section.collapse_composition"
                         >
                             <t t-set="current_section" t-value="None"/>
                             <tr class="is-subtotal text-end">

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -614,6 +614,9 @@
                                 <field name="selected_combo_items" column_invisible="1"/>
                                 <field name="virtual_id" column_invisible="1"/>
                                 <field name="linked_virtual_id" column_invisible="1"/>
+                                <field name="parent_id" column_invisible="True"/>
+                                <field name="collapse_prices" column_invisible="1"/>
+                                <field name="collapse_composition" column_invisible="1"/>
 
                                 <!-- Currency, needed for monetary widgets to display the currency symbol -->
                                 <field name="currency_id" column_invisible="True"/>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -724,7 +724,14 @@
 
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
                                 <t t-set="is_note" t-value="line.display_type == 'line_note'"/>
+
+                                <!-- TODO VFE NIPL merge t-if -->
+                                <t t-if="line.display_type not in ('line_section', 'line_subsection')
+                                         or line.product_type == 'combo'
+                                         or not line.collapse_composition"
+                                >
                                 <tr
+                                    t-if="not line.collapse_composition"
                                     t-att-class="{
                                         'fw-bolder o_line_section': line.display_type == 'line_section' or line.product_type == 'combo',
                                         'fw-bold o_line_subsection': line.display_type == 'line_subsection',
@@ -746,7 +753,7 @@
                                         </td>
                                         <td t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
                                             <div
-                                                t-if="line.discount &gt;= 0"
+                                                t-if="line.discount &gt;= 0 and not line.collapse_prices"
                                                 t-field="line.price_unit"
                                                 t-att-style="line.discount and 'text-decoration: line-through' or None"
                                                 t-att-class="(line.discount and 'text-danger' or '') + ' text-end'"
@@ -764,15 +771,24 @@
                                             <span t-out="', '.join(map(lambda x: (x.name), line.tax_ids))"/>
                                         </td>
                                         <td t-if="not line.is_downpayment" class="text-end" id="subtotal">
-                                        <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>
+                                            <span
+                                                t-if="not line.collapse_prices"
+                                                class="oe_order_line_price_subtotal"
+                                                t-field="line.price_subtotal"
+                                            />
                                         </td>
                                     </t>
-                                    <t t-if="line.display_type in ('line_section', 'line_subsection') or line.product_type == 'combo'">
+                                    <t
+                                        t-if="line.display_type in ('line_section','line_subsection')
+                                            or line.product_type == 'combo'"
+                                    >
                                         <td colspan="99">
                                             <span t-field="line.name"/>
                                         </td>
-                                        <t t-set="current_section" t-value="line"/>
-                                        <t t-set="current_subtotal" t-value="0"/>
+                                        <t t-if="line.display_type == 'line_section'">
+                                            <t t-set="current_section" t-value="line"/>
+                                            <t t-set="current_subtotal" t-value="0"/>
+                                        </t>
                                     </t>
                                     <t t-if="is_note">
                                         <td colspan="99">
@@ -780,16 +796,62 @@
                                         </td>
                                     </t>
                                 </tr>
+                                </t>
+
+                                <t
+                                    t-elif="(
+                                            line.display_type == 'line_subsection'
+                                            and not line.parent_id.collapse_composition
+                                        )
+                                        or line.display_type == 'line_section'"
+                                >
+                                    <tr
+                                        t-foreach="line._get_grouped_section_summary()"
+                                        t-as="section_line"
+                                        class="o_line_section"
+                                    >
+                                        <td name="td_name">
+                                            <span t-out="section_line['name']">Section Summary</span>
+                                        </td>
+                                        <td name="td_quantity" class="text-end text-nowrap">
+                                            <span>1.00 Units</span>
+                                        </td>
+                                        <td name="td_priceunit" class="text-end text-nowrap">
+                                            <span t-out="section_line['price_subtotal']"/>
+                                        </td>
+                                        <td name="td_discount" t-if="display_discount"/>
+                                        <td
+                                            name="td_taxes"
+                                            t-if="display_taxes"
+                                            t-attf-class="text-end {{ 'text-nowrap' if len(section_line['taxes']) &lt; 10 else '' }}"
+                                        >
+                                            <span t-out="', '.join(section_line['taxes'])">
+                                                Tax 15%
+                                            </span>
+                                        </td>
+                                        <td class="text-end o_price_total">
+                                            <span t-out="section_line['price_subtotal']">
+                                                31.05
+                                            </span>
+                                        </td>
+                                    </tr>
+                                    <t t-if="line.display_type == 'line_section'">
+                                        <t t-set="current_section" t-value="line"/>
+                                        <t t-set="current_subtotal" t-value="0"/>
+                                    </t>
+                                </t>
                                 <tr
                                     t-if="current_section and (
                                         line_last
-                                        or lines_to_report[line_index+1].display_type in ('line_section', 'line_subsection')
+                                        or lines_to_report[line_index+1].display_type == 'line_section'
                                         or lines_to_report[line_index+1].product_type == 'combo'
                                         or (
                                             line.combo_item_id
                                             and not lines_to_report[line_index+1].combo_item_id
                                         )
-                                    ) and not line.is_downpayment"
+                                    )
+                                    and not line.is_downpayment
+                                    and current_section.collapse_composition"
                                     class="is-subtotal text-end"
                                 >
                                     <t t-set="current_section" t-value="None"/>


### PR DESCRIPTION
This commit introduces functionality to toggle the visibility of sections, subsections, and prices in the sale order portal view and PDF quotes.

When a section is hidden, all its nested subsections and their lines are also hidden automatically.
Additionally, if a section or subsection contains lines with different tax rates, the lines are grouped based on similar taxes for better clarity.

task-4669991