### PR TITLE
[IMP] account, sale, purchase: Section and note logic improvements

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2766,12 +2766,10 @@ class AccountMove(models.Model):
                  sale order and the quantity selected.
         :rtype: float
         """
-        move_line = self.line_ids.filtered_domain([
-            ('product_id', '=', product_id),
-            '|',
-            ('id', 'child_of', selected_section_id),
-            ('parent_id', '=', False),
-        ])
+        move_line = self.line_ids.filtered(
+            lambda line: line.product_id.id == product_id
+            and line.get_parent_section_line().id == selected_section_id,
+        )
         if move_line:
             if quantity != 0:
                 move_line.quantity = quantity
@@ -4278,9 +4276,6 @@ class AccountMove(models.Model):
 
     @api.onchange('invoice_line_ids')
     def _onchange_quick_edit_line_ids(self):
-        self.invoice_line_ids._conditional_add_to_compute('parent_id', lambda line: (
-            line.display_type in ('line_section', 'line_subsection', 'line_note', 'product')
-        ))
         quick_encode_suggestion = self.env.context.get('quick_encoding_vals')
         if (
             not self.quick_edit_total_amount

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -339,12 +339,10 @@ class AccountMoveLine(models.Model):
     collapse_composition = fields.Boolean(
         string="Hide Composition",
         help="If checked, the lines below this section will not be displayed in reports and portal.",
-        compute="_compute_section_visibility_fields", store=True, copy=True,
     )
     collapse_prices = fields.Boolean(
         string="Hide Prices",
         help="If checked, the prices of the lines below this section will not be displayed in reports and portal.",
-        compute="_compute_section_visibility_fields", store=True, copy=True,
     )
     parent_id = fields.Many2one(
         'account.move.line',
@@ -1203,20 +1201,6 @@ class AccountMoveLine(models.Model):
                     last_sub = line
                 elif line in amls:
                     line.parent_id = last_sub or last_section
-
-    @api.depends('parent_id')
-    def _compute_section_visibility_fields(self):
-        for move in self.filtered(lambda l: l.move_id.move_type != 'entry').grouped('move_id'):
-            for line in move.invoice_line_ids.sorted('sequence'):
-                if line.display_type == 'line_section':
-                    continue
-
-                if line.display_type == 'line_subsection':
-                    line.collapse_prices = line.collapse_prices or line.parent_id.collapse_prices
-                    line.collapse_composition = line.collapse_composition or line.parent_id.collapse_composition
-                else:
-                    line.collapse_prices = line.parent_id.collapse_prices
-                    line.collapse_composition = line.parent_id.collapse_composition
 
     @api.depends('move_id.move_type')
     def _compute_no_followup(self):

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
@@ -24,21 +24,21 @@
                                 <DropdownItem onSelected="() => this.addRowAfterSection(record, false)">
                                     <i class="me-1 fa fa-fw fa-level-down"/><span>Add a section</span>
                                 </DropdownItem>
-                                <t t-if="this.canAddSubSection">
+                                <t t-if="props.subsections">
                                     <DropdownItem onSelected="() => this.addRowInSection(record, true)">
                                         <i class="me-1 fa fa-fw fa-level-down"/><span>Add a subsection</span>
                                     </DropdownItem>
                                 </t>
                             </t>
-                            <t t-elif="this.canAddSubSection">
+                            <t t-elif="props.subsections">
                                 <DropdownItem onSelected="() => this.addRowAfterSection(record, true)">
                                     <i class="me-1 fa fa-fw fa-level-down"/><span>Add a subsection</span>
                                 </DropdownItem>
                             </t>
-                            <DropdownItem t-if="showPricesButton" onSelected="() => this.toggleHidePrices(record)">
+                            <DropdownItem t-if="props.hidePrices and showPricesButton" onSelected="() => this.toggleCollapse(record, 'collapse_prices')">
                                 <i class="me-1 fa fa-fw" t-att-class="hidePrices ? 'fa-eye' : 'fa-eye-slash'"/><span t-out="hidePrices ? 'Show Prices' : 'Hide Prices'"/>
                             </DropdownItem>
-                            <DropdownItem t-if="showCompositionButton" onSelected="() => this.toggleHideComposition(record)">
+                            <DropdownItem t-if="props.hideComposition and showCompositionButton" onSelected="() => this.toggleCollapse(record, 'collapse_composition')">
                                 <i class="me-1 fa fa-fw" t-att-class="hideCompositions ? 'fa-eye' : 'fa-eye-slash'"/><span t-out="hideCompositions ? 'Show Composition' : 'Hide Composition'"/>
                             </DropdownItem>
                             <DropdownItem onSelected="() => this.addNoteInSection(record)">

--- a/addons/account/static/tests/section_and_note.test.js
+++ b/addons/account/static/tests/section_and_note.test.js
@@ -81,7 +81,7 @@ test("can add a line in a section", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -144,7 +144,7 @@ test("can add a line in a subsection", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -207,7 +207,7 @@ test("can add a subsection in a section", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -261,7 +261,7 @@ test("can add a subsection in a section", async () => {
     expect(".o_is_line_subsection:contains(Aa)").toHaveCount(1);
 });
 
-test("can't add a subsection if value not in selection", async () => {
+test("can't add a subsection if value not in options", async () => {
     InvoiceLine._records[10].display_type = "line_section";
     InvoiceLine._fields.display_type = fields.Selection({
         default: false,
@@ -280,7 +280,6 @@ test("can't add a subsection if value not in selection", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
                 >
                     <list editable="bottom">
                         <control>
@@ -310,7 +309,7 @@ test("can add a section after another", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -374,7 +373,7 @@ test("can add a subsection after another", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -438,7 +437,7 @@ test("can delete sections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -484,7 +483,7 @@ test("can delete subsections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -541,7 +540,7 @@ test("can duplicate sections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -607,7 +606,7 @@ test("can duplicate subsections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -690,7 +689,7 @@ test("can resequence records inside sections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -784,7 +783,7 @@ test("resequence can be discarded", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -860,7 +859,7 @@ test("can resequence sections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -901,7 +900,7 @@ test("add a section", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -965,7 +964,7 @@ test("add note", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -1029,7 +1028,7 @@ test("section_and_note_text widget", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -1093,7 +1092,7 @@ test("sections with required content field", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -1163,7 +1162,7 @@ test("sections duplicate with many2many", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -1266,7 +1265,7 @@ test("swap sections and subsections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1130,7 +1130,8 @@
                                            'default_display_type': 'product',
                                            'quick_encoding_vals': quick_encoding_vals,
                                        }" readonly="state != 'draft'"
-                                       aggregated_fields="price_subtotal,price_total">
+                                       aggregated_fields="price_subtotal,price_total"
+                                       options="{'hide_composition': True, 'hide_prices': True, 'subsections': True}">
                                     <list name="journal_items" editable="bottom" string="Journal Items" default_order="sequence, id">
                                         <control>
                                             <create name="add_line_control" string="Add a line"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1208,9 +1208,8 @@
                                         <field name="company_id" column_invisible="True"/>
                                         <field name="company_currency_id" column_invisible="True"/>
                                         <field name="display_type" force_save="1" column_invisible="True"/>
-                                        <field name="collapse_prices" column_invisible="True" force_save="1"/>
-                                        <field name="collapse_composition" column_invisible="True" force_save="1"/>
-                                        <field name="parent_id" column_invisible="True" force_save="1"/>
+                                        <field name="collapse_prices" column_invisible="True"/>
+                                        <field name="collapse_composition" column_invisible="True"/>
                                     </list>
                                     <kanban class="o_kanban_mobile">
                                         <!-- Displayed fields -->

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -172,8 +172,6 @@
                                 <t t-set="treated_lines" t-value="[]"/>
 
                                 <t t-foreach="lines" t-as="line">
-                                    <t t-set="hide_details" t-value="line.collapse_composition"/>
-                                    <t t-set="hide_prices" t-value="line.collapse_prices"/>
 
                                     <t t-if="line.id not in treated_lines and (hide_details or hide_prices)">
                                         <t t-if="hide_details" t-set="grouped_lines" t-value="line.get_lines_grouped_by_section()"/>
@@ -181,9 +179,13 @@
                                         <t t-set="current_subsection" t-value="0"/>
                                         <t t-if="line.display_type == 'line_section'">
                                             <t t-set="current_section" t-value="0"/>
+                                            <t t-set="hide_details" t-value="line.collapse_composition"/>
+                                            <t t-set="hide_prices" t-value="line.collapse_prices"/>
                                         </t>
                                         <t t-elif="line.display_type == 'line_subsection'">
                                             <t t-set="current_section" t-value="line"/>
+                                            <t t-set="hide_details" t-value="hide_details or line.collapse_composition"/>
+                                            <t t-set="hide_prices" t-value="hide_prices or line.collapse_prices"/>
                                         </t>
                                         <t t-foreach="grouped_lines" t-as="grouped_line">
                                             <t t-if="grouped_line['display_type'] == 'line_section'">
@@ -263,7 +265,7 @@
                                                 </span>
                                             </td>
                                             <td name="td_price_unit" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                                <span t-if="not line.collapse_prices" class="text-nowrap" t-field="line.price_unit">9.00</span>
+                                                <span t-if="not line.parent_id.collapse_prices" class="text-nowrap" t-field="line.price_unit">9.00</span>
                                             </td>
                                             <td name="td_discount" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                                 <span class="text-nowrap" t-field="line.discount">0</span>
@@ -273,8 +275,8 @@
                                                 <span t-if="not line.collapse_prices" t-out="taxes" id="line_tax_ids">Tax 15%</span>
                                             </td>
                                             <td name="td_subtotal" class="text-end o_price_total">
-                                                <span t-if="not line.collapse_prices and o.company_price_include == 'tax_excluded'" class="text-nowrap" t-field="line.price_subtotal">27.00</span>
-                                                <span t-if="not line.collapse_prices and o.company_price_include == 'tax_included'" class="text-nowrap" t-field="line.price_total">31.05</span>
+                                                <span t-if="not line.parent_id.collapse_prices and o.company_price_include == 'tax_excluded'" class="text-nowrap" t-field="line.price_subtotal">27.00</span>
+                                                <span t-if="not line.parent_id.collapse_prices and o.company_price_include == 'tax_included'" class="text-nowrap" t-field="line.price_total">31.05</span>
                                             </td>
                                         </t>
                                         <t t-elif="line.display_type in ('line_section', 'line_subsection')">

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -290,21 +290,15 @@ class ProductCatalogMixin(models.AbstractModel):
         lines = self[child_field].sorted('sequence')
         move_section, target_section = sections
 
-        move_block = lines.filtered_domain([
-            '|',
-            ('id', '=', move_section['id']),
-            '|',
-            ('id', 'child_of', move_section['id']),
-            ('parent_id', '=', False),
-        ])
+        move_block = lines.filtered(
+            lambda line: line.id == move_section['id']
+            or line.parent_id.id == move_section['id'],
+        )
 
-        target_block = lines.filtered_domain([
-            '|',
-            ('id', '=', target_section['id']),
-            '|',
-            ('id', 'child_of', target_section['id']),
-            ('parent_id', '=', False),
-        ])
+        target_block = lines.filtered(
+            lambda line: line.id == target_section['id']
+            or line.parent_id.id == target_section['id'],
+        )
 
         remaining_lines = lines - move_block
         insert_after = move_section['sequence'] < target_section['sequence']

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -363,11 +363,9 @@ class ProductProduct(models.Model):
         if not (order_id and order_model and line_field):
             return []
 
-        product_ids = self.env[order_model].browse(order_id)[line_field].filtered_domain([
-            '|',
-            ('id', 'child_of', ctx.get('selected_section_id')),
-            ('parent_id', '=', False),
-        ]).mapped('product_id').ids
+        product_ids = self.env[order_model].browse(order_id)[line_field].filtered(
+            lambda line: line.get_parent_section_line().id == ctx.get('selected_section_id'),
+        ).mapped('product_id').ids
 
         return [('id', 'in', product_ids)]
 

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -453,11 +453,6 @@ class PurchaseOrder(models.Model):
         """
         self.order_line._compute_tax_id()
 
-    @api.onchange('order_line')
-    def _onchange_order_line(self):
-        self.order_line.invalidate_recordset(['parent_id'])
-        self.env.add_to_compute(self.order_line._fields['parent_id'], self.order_line)
-
     # ------------------------------------------------------------
     # MAIL.THREAD
     # ------------------------------------------------------------
@@ -1276,12 +1271,10 @@ class PurchaseOrder(models.Model):
         :rtype: float
         """
         self.ensure_one()
-        pol = self.order_line.filtered_domain([
-            ('product_id', '=', product_id),
-            '|',
-            ('id', 'child_of', selected_section_id),
-            ('parent_id', '=', False),
-        ])
+        pol = self.order_line.filtered(
+            lambda l: l.product_id.id == product_id
+            and l.get_parent_section_line().id == selected_section_id,
+        )
         if pol:
             if quantity != 0:
                 pol.product_qty = quantity

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -86,24 +86,11 @@ class PurchaseOrderLine(models.Model):
     product_template_attribute_value_ids = fields.Many2many(related='product_id.product_template_attribute_value_ids', readonly=True)
     product_no_variant_attribute_value_ids = fields.Many2many('product.template.attribute.value', string='Product attribute values that do not create variants', ondelete='restrict')
     purchase_line_warn_msg = fields.Text(related='product_id.purchase_line_warn_msg')
-    collapse_composition = fields.Boolean(
-        string="Hide Composition",
-        help="If checked, the lines below this section will not be displayed in reports and portal.",
-        compute="_compute_section_visibility_fields", store=True, copy=True,
-    )
-    collapse_prices = fields.Boolean(
-        string="Hide Prices",
-        help="If checked, the prices of the lines below this section will not be displayed in reports and portal.",
-        compute="_compute_section_visibility_fields", store=True, copy=True,
-    )
     parent_id = fields.Many2one(
         'purchase.order.line',
         string="Parent Section Line",
         compute='_compute_parent_id',
-        index='btree_not_null',
-        store=True
     )
-    child_ids = fields.One2many(comodel_name='purchase.order.line', inverse_name='parent_id')
     technical_price_unit = fields.Float(help="Technical field for price computation")
 
     @api.depends('product_qty', 'price_unit', 'tax_ids', 'discount')
@@ -413,10 +400,12 @@ class PurchaseOrderLine(models.Model):
             price_unit *= self.product_id.uom_id.factor / self.product_uom_id.factor
         return price_unit
 
-    @api.depends('order_id.order_line.order_id')
     def _compute_parent_id(self):
         purchase_order_lines = set(self)
-        for order in self.grouped('order_id'):
+        for order, lines in self.grouped('order_id').items():
+            if not order:
+                lines.parent_id = False
+                continue
             last_section = False
             last_sub = False
             for line in order.order_line.sorted('sequence'):
@@ -431,20 +420,6 @@ class PurchaseOrderLine(models.Model):
                     last_sub = line
                 elif line in purchase_order_lines:
                     line.parent_id = last_sub or last_section
-
-    @api.depends('parent_id')
-    def _compute_section_visibility_fields(self):
-        for order in self.grouped('order_id'):
-            for line in order.order_line.sorted('sequence'):
-                if line.display_type == 'line_section':
-                    continue
-
-                if line.display_type == 'line_subsection':
-                    line.collapse_prices = line.collapse_prices or line.parent_id.collapse_prices
-                    line.collapse_composition = line.collapse_composition or line.parent_id.collapse_composition
-                else:
-                    line.collapse_prices = line.parent_id.collapse_prices
-                    line.collapse_composition = line.parent_id.collapse_composition
 
     def action_add_from_catalog(self):
         order = self.env['purchase.order'].browse(self.env.context.get('order_id'))
@@ -668,3 +643,15 @@ class PurchaseOrderLine(models.Model):
             return self.parent_id.parent_id
 
         return self.parent_id
+
+    def _is_line_in_section(self, line):
+        """Return whether the line is a direct or indirect child of the section."""
+        self.ensure_one()
+        is_direct_child = line.parent_id == self and not line.display_type
+        is_indirect_child = (
+            self.display_type == 'line_section'
+            and line.parent_id
+            and line.parent_id.display_type == 'line_subsection'
+            and line.parent_id.parent_id == self
+        )
+        return is_direct_child or is_indirect_child

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -242,7 +242,8 @@
                                 widget="product_label_section_and_note_field_o2m"
                                 mode="list,kanban"
                                 context="{'default_state': 'draft'}"
-                                readonly="state == 'cancel' or locked">
+                                readonly="state == 'cancel' or locked"
+                                options="{ 'subsections': True }">
                                 <list string="Purchase Order Lines" editable="bottom" limit="200"
                                       decoration-warning="purchase_line_warn_msg">
                                     <control>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -259,9 +259,6 @@
                                     <field name="state" column_invisible="True"/>
                                     <field name="product_type" column_invisible="True"/>
                                     <field name="invoice_lines" column_invisible="True"/>
-                                    <field name="parent_id" column_invisible="True" force_save="1"/>
-                                    <field name="collapse_prices" column_invisible="True" force_save="1"/>
-                                    <field name="collapse_composition" column_invisible="True" force_save="1"/>
                                     <field name="technical_price_unit" column_invisible="True"/>
                                     <field name="sequence" widget="handle"/>
                                     <!-- optional="show" allows name (description) to be editable -->

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1764,8 +1764,7 @@ class SaleOrder(models.Model):
                 )
             return (
                 line.display_type == 'line_section'
-                or (line.display_type == 'line_subsection' and not line.parent_id.collapse_composition)
-                or not line.collapse_composition
+                or not line.parent_id.collapse_composition
             )
 
         return self.order_line.filtered(show_line)

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -893,9 +893,6 @@ class SaleOrder(models.Model):
 
     @api.onchange('order_line')
     def _onchange_order_line(self):
-        self.order_line.invalidate_recordset(['parent_id'])
-        self.env.add_to_compute(self.order_line._fields['parent_id'], self.order_line)
-
         for index, line in enumerate(self.order_line):
             if line.product_type != 'combo':
                 continue
@@ -1764,7 +1761,10 @@ class SaleOrder(models.Model):
                 )
             return (
                 line.display_type == 'line_section'
-                or not line.parent_id.collapse_composition
+                or not (
+                    line.parent_id.collapse_composition
+                    or line.parent_id.parent_id.collapse_composition
+                )
             )
 
         return self.order_line.filtered(show_line)
@@ -2128,12 +2128,10 @@ class SaleOrder(models.Model):
         :rtype: float
         """
         request.update_context(catalog_skip_tracking=True)
-        sol = self.order_line.filtered_domain([
-            ('product_id', '=', product_id),
-            '|',
-            ('id', 'child_of', selected_section_id),
-            ('parent_id', '=', False),
-        ])
+        sol = self.order_line.filtered(
+            lambda l: l.product_id.id == product_id
+            and l.get_parent_section_line().id == selected_section_id,
+        )
         if sol:
             if quantity != 0:
                 sol.product_uom_qty = quantity

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -119,10 +119,12 @@
                             <t t-set="current_section" t-value="line"/>
                             <t t-set="current_subsection" t-value="None"/>
                             <t t-set="line_padding" t-value="0"/>
+                            <t t-set="collapse_prices" t-value="line.collapse_prices"/>
                         </t>
                         <t t-elif="is_subsection">
                             <t t-set="current_subsection" t-value="line"/>
                             <t t-set="line_padding" t-value="2"/>
+                            <t t-set="collapse_prices" t-value="collapse_prices or line.collapse_prices"/>
                         </t>
                         <t t-else="">
                             <t
@@ -143,14 +145,22 @@
                                 name="tr_section"
                                 t-att-class="'fw-bolder o_line_section' if is_section else 'fw-bold o_line_subsection'"
                             >
+                                <t t-set="show_section_total" t-value="is_section or not line.parent_id.collapse_prices"/>
+                                <t
+                                    t-set="section_name_colspan"
+                                    t-value="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                />
+                                <t t-if="not show_section_total">
+                                    <t t-set="section_name_colspan" t-value="99"/>
+                                </t>
                                 <td
                                     name="td_section_name"
-                                    t-att-colspan="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                    t-att-colspan="section_name_colspan"
                                     t-att-class="padding_class"
                                 >
                                     <span t-field="line.name">A section title</span>
                                 </td>
-                                <td name="td_section_price" class="text-end o_price_total">
+                                <td t-if="show_section_total" name="td_section_price" class="text-end o_price_total">
                                     <span
                                         name="price_subtotal_section"
                                         t-out="line._get_section_totals(price_field)"
@@ -196,7 +206,7 @@
                                 </td>
                                 <td name="td_product_priceunit" class="text-end text-nowrap">
                                     <span
-                                        t-if="not line.collapse_prices"
+                                        t-if="not collapse_prices"
                                         t-field="line.price_unit"
                                         t-options="{'widget': 'monetary', 'display_currency': line.currency_id}"
                                     >
@@ -204,7 +214,7 @@
                                     </span>
                                 </td>
                                 <td t-if="display_discount" name="td_product_discount" class="text-end">
-                                    <t t-if="not line.collapse_prices">
+                                    <t t-if="not collapse_prices">
                                         <!-- ! Always check collapse_prices separately; keep discount condition below for XPath -->
                                         <span t-field="line.discount">-</span>
                                     </t>
@@ -214,7 +224,7 @@
                                     <span t-out="taxes">Tax 15%</span>
                                 </td>
                                 <td t-if="not line.is_downpayment" name="td_product_subtotal" class="text-end o_price_total">
-                                    <t t-if="not line.collapse_prices">
+                                    <t t-if="not collapse_prices">
                                         <span
                                             t-if="price_field == 'price_subtotal'"
                                             t-field="line.price_subtotal"

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -16,6 +16,11 @@ import { CharField } from '@web/views/fields/char/char_field';
 export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRender {
     static recordRowTemplate = 'sale.ListRenderer.RecordRow';
 
+    setup(){
+        super.setup();
+        this.priceColumns.push('discount');
+    }
+
     /**
      * Product description widget logic
      */
@@ -88,6 +93,10 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
 
     shouldDuplicateSectionItem(record) {
         return !this.isCombo(record) && !this.isComboItem(record);
+    }
+
+    displayDeleteIcon(record){
+        return super.displayDeleteIcon(record) && !this.isComboItem(record);
     }
 }
 

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
@@ -5,11 +5,51 @@
         t-inherit="account.SectionAndNoteListRenderer.RecordRow"
         t-inherit-mode="primary"
     >
-        <!-- Remove the drag-and-drop handle for combo lines and combo item lines. -->
-        <Field position="attributes">
-            <attribute name="t-if">
-                !((isCombo(record) || isComboItem(record)) &amp;&amp; column.widget === 'handle')
-            </attribute>
-        </Field>
+        <t t-set="isInvisible" position="attributes">
+            <attribute
+                name="t-value"
+                separator=" or "
+                add="isCombo(record) and !this.comboColumns.includes(column.name)"
+            />
+        </t>
+
+        <xpath expr="//td[hasclass('o_list_record_remove')]" position="attributes">
+            <attribute name="t-if" separator=" and " add="!isCombo(record)"/>
+        </xpath>
+
+        <xpath expr="//td[hasclass('o_list_section_options')]" position="before">
+            <td t-elif="isCombo(record)" class="o_list_section_options w-print-0 p-print-0 text-center">
+                <Dropdown position="'bottom-end'" t-if="!props.readonly">
+                    <button class="btn px-1cursor-pointer">
+                        <i class="fa fa-ellipsis-v"/>
+                    </button>
+                    <t t-set-slot="content">
+                        <DropdownItem
+                            t-if="!record.isNew and this.getPreviousRecords(record)"
+                            onSelected="() => this.moveCombo(record, 'up')"
+                        >
+                            <i class="me-1 fa fa-fw fa-arrow-up"/>
+                            <span>Move Up</span>
+                        </DropdownItem>
+                        <DropdownItem
+                            t-if="!record.isNew and this.getNextRecords(record)"
+                            onSelected="() => this.moveCombo(record, 'down')"
+                        >
+                            <i class="me-1 fa fa-fw fa-arrow-down"/>
+                            <span>Move Down</span>
+                        </DropdownItem>
+                        <t t-if="hasDeleteButton">
+                            <DropdownItem
+                                onSelected="() => this.onDeleteRecord(record)"
+                                class="'text-danger'"
+                            >
+                                <i class="me-1 fa fa-fw fa-trash"/>
+                                <span>Delete</span>
+                            </DropdownItem>
+                        </t>
+                    </t>
+                </Dropdown>
+            </td>
+        </xpath>
     </t>
 </templates>

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
@@ -11,9 +11,5 @@
                 !((isCombo(record) || isComboItem(record)) &amp;&amp; column.widget === 'handle')
             </attribute>
         </Field>
-         <!-- Remove the "delete" button for combo item lines. -->
-        <xpath expr="//td[hasclass('o_list_record_remove')]" position="attributes">
-            <attribute name="t-att-class">{'d-none': isComboItem(record)}</attribute>
-        </xpath>
     </t>
 </templates>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -500,6 +500,7 @@
                             mode="list,kanban"
                             readonly="state == 'cancel' or locked"
                             aggregated_fields="price_subtotal,price_total"
+                            options="{'hide_composition': True, 'hide_prices': True, 'subsections': True}"
                         >
                             <form>
                                 <field name="technical_price_unit" invisible="1"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -615,9 +615,8 @@
                                 <field name="selected_combo_items" column_invisible="1"/>
                                 <field name="virtual_id" column_invisible="1"/>
                                 <field name="linked_virtual_id" column_invisible="1"/>
-                                <field name="parent_id" column_invisible="1" force_save="1"/>
-                                <field name="collapse_prices" column_invisible="1" force_save="1"/>
-                                <field name="collapse_composition" column_invisible="1" force_save="1"/>
+                                <field name="collapse_prices" column_invisible="1"/>
+                                <field name="collapse_composition" column_invisible="1"/>
 
                                 <!-- Currency, needed for monetary widgets to display the currency symbol -->
                                 <field name="currency_id" column_invisible="True"/>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -751,7 +751,7 @@
                                 <t t-elif="is_subsection">
                                     <t t-set="current_subsection" t-value="line"/>
                                     <t t-set="line_padding" t-value="2"/>
-                                    <t t-set="collapse_prices" t-value="collapse_prices or line.collapse_prices"/>
+                                    <t t-set="collapse_prices" t-value="current_section.collapse_prices or line.collapse_prices"/>
                                 </t>
                                 <t t-else="">
                                     <t

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -746,10 +746,12 @@
                                     <t t-set="current_section" t-value="line"/>
                                     <t t-set="current_subsection" t-value="None"/>
                                     <t t-set="line_padding" t-value="0"/>
+                                    <t t-set="collapse_prices" t-value="line.collapse_prices"/>
                                 </t>
                                 <t t-elif="is_subsection">
                                     <t t-set="current_subsection" t-value="line"/>
                                     <t t-set="line_padding" t-value="2"/>
+                                    <t t-set="collapse_prices" t-value="collapse_prices or line.collapse_prices"/>
                                 </t>
                                 <t t-else="">
                                     <t
@@ -770,14 +772,26 @@
                                         name="tr_section"
                                         t-att-class="'fw-bolder o_line_section' if is_section else 'fw-bold o_line_subsection'"
                                     >
+                                        <t t-set="show_section_total" t-value="is_section or not line.parent_id.collapse_prices"/>
+                                        <t
+                                            t-set="section_name_colspan"
+                                            t-value="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                        />
+                                        <t t-if="not show_section_total">
+                                            <t t-set="section_name_colspan" t-value="99"/>
+                                        </t>
                                         <td
                                             name="td_section_name"
-                                            t-att-colspan="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                            t-att-colspan="section_name_colspan"
                                             t-att-class="padding_class"
                                         >
                                             <span t-field="line.name"/>
                                         </td>
-                                        <td name="td_section_price" class="text-end o_price_total">
+                                        <td
+                                            t-if="show_section_total"
+                                            name="td_section_price"
+                                            class="text-end o_price_total"
+                                        >
                                             <span
                                                 name="price_subtotal_section"
                                                 t-out="line._get_section_totals(price_field)"
@@ -821,7 +835,7 @@
                                             name="td_product_priceunit"
                                             t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}"
                                         >
-                                            <t t-if="not line.collapse_prices">
+                                            <t t-if="not collapse_prices">
                                                 <div
                                                     t-if="line.discount &gt;= 0"
                                                     t-field="line.price_unit"
@@ -838,7 +852,7 @@
                                             </t>
                                         </td>
                                         <td t-if="display_discount" name="td_product_discount" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
-                                            <t t-if="not line.collapse_prices">
+                                            <t t-if="not collapse_prices">
                                                 <!-- ! Always check collapse_prices separately; keep discount condition below for XPath -->
                                                 <strong t-if="line.discount &gt; 0" class="text-info">
                                                     <t t-out="((line.discount % 1) and '%s' or '%d') % line.discount"/>%
@@ -849,14 +863,12 @@
                                             <span t-out="', '.join(map(lambda x: (x.name), line.tax_ids))"/>
                                         </td>
                                         <td t-if="not line.is_downpayment" name="td_product_subtotal" class="text-end">
-                                            <t t-if="not line.collapse_prices">
+                                            <t t-if="not collapse_prices">
                                                 <span
                                                     t-if="price_field == 'price_subtotal'"
                                                     t-field="line.price_subtotal"
                                                 />
-                                                <span
-                                                    t-else="" t-field="line.price_total"
-                                                />
+                                                <span t-else="" t-field="line.price_total"/>
                                             </t>
                                         </td>
                                     </tr>


### PR DESCRIPTION
This PR introduces several improvements to section, note, and combo line handling in **Sales** and **Accounting**, along with performance optimizations around the `parent_id` field. It also fixes a pending issue with Sales Orders invoicing.

### Key Changes

* **Section & Note Logic**

  * Added new options `{ subsections, hide_prices, hide_composition }` to the JS widget, to better control collapse/visibility logic.
  * Simplified collapse behavior by letting child lines dynamically inherit parent section properties (no redundant recomputations).
  * Improved bulk toggle: updating only the parent section, with child states resolved on the fly.
  * Fixed issue where subsection prices were still shown when the parent section was hidden.
  * Applied overrides for **Sale Order Templates** and **Purchase Orders** to disable collapse logic where not needed.

* **Combo Product Enhancements**

  * Enabled resequencing of combo product blocks (moving entire blocks up/down).
  * Swapping logic: moving stops at other combo blocks and swaps them as a whole.
  * Centralized visibility conditions for combo-specific fields → less cluttered XML.
  * Used renderer hook to hide the delete icon, replacing XPath-based hacks.
  * Fixed dark mode issue for combo product lines.

* **Parent ID Performance Optimization**

  * Changed `parent_id` compute field from **stored** → **non-stored**, removing recomputations.
  * Added a custom search method so catalog domains continue to work correctly.
  * Temporary fallback: treat `line_section` as a parent in catalogs until subsection support is available.

* **Fixed a Sales Order → Invoice issue**

  * if a section has all subsections as a child. Then, when making an invoice, the section line is not getting invoiced. Applied fix to invoice section if there is an invoicable line directly beneath it, or atleast have one subsection that is invoicable


* task-5009037

See Also:
- https://github.com/odoo-dev/enterprise/pull/1132