### PR TITLE
[IMP] mail: avoid cron job to send incoming call notification.

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3910,12 +3910,12 @@ class MailThread(models.AbstractModel):
             return devices_su, None, None
         return devices_su.search([("partner_id", "in", partner_ids)]), vapid_private_key, vapid_public_key
 
-    def _web_push_send_notification(self, devices, private_key, public_key, payload_by_lang=None, payload=None):
+    def _web_push_send_notification(self, devices, private_key, public_key, payload_by_lang=None, payload=None, force_direct_send=False):
         """
         :param payload: JSON serializable dict following the notification api specs https://notifications.spec.whatwg.org/#api
         :param payload_by_lang a dict mapping payload by lang, either this or payload must be provided
         """
-        if len(devices) < MAX_DIRECT_PUSH:
+        if len(devices) < MAX_DIRECT_PUSH or force_direct_send is True:
             session = Session()
             devices_to_unlink = set()
             for device in devices:

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -669,7 +669,7 @@ class ResUsers(models.Model):
             return (self.env["res.users"], self.env["mail.guest"]._get_guest_from_context())
         return (self.env.user, self.env["mail.guest"])
 
-    def _webpush_notification(self, body, model, res_id, icon, title='Odoo', author=None, extra_payload=None):
+    def _webpush_notification(self, body, model, res_id, icon, title='Odoo', author=None, extra_payload=None, force_direct_send=False):
         if extra_payload is None:
             extra_payload = {}
         devices, private_key, public_key = self.env['mail.thread']._web_push_get_partners_parameters(self.partner_id.ids)
@@ -688,4 +688,4 @@ class ResUsers(models.Model):
                     },
                 }
             } | extra_payload
-            self.env['mail.thread']._web_push_send_notification(devices, private_key, public_key, payload=payload_webpush)
+            self.env['mail.thread']._web_push_send_notification(devices, private_key, public_key, payload=payload_webpush, force_direct_send=force_direct_send)


### PR DESCRIPTION
When we receive a notification to handle an incoming call we need to avoid to put then inside the job queue because we need to avoid the waiting times due of an urge amont of devices.