### PR TITLE
[IMP] account: add quick search on an amount in the journal items

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -312,6 +312,8 @@
                     <field name="date"/>
                     <field name="date_maturity" string="Due Date"/>
                     <field name="discount_date" string="Discount Date"/>
+                    <field name="debit" string="Amount" filter_domain="['|', ('debit', 'ilike', self), 
+                    ('credit', 'ilike', self)]"/>
                     <field name="account_id"/>
                     <field name="account_type"/>
                     <field name="partner_id"/>


### PR DESCRIPTION
In the list view of the journal items in the account module, adding a quick search on the amount of the journal item to help customers to find more easily a journal item based on the amount.

task-5231282