### PR TITLE
[IMP] account: enabling searching journal item by inexact balance

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -312,6 +312,8 @@
                     <field name="date"/>
                     <field name="date_maturity" string="Due Date"/>
                     <field name="discount_date" string="Discount Date"/>
+                    <field name="credit" string="Amount" filter_domain="[
+                        '|', ('credit', 'ilike', self), ('debit', 'ilike', self)]"/>
                     <field name="account_id"/>
                     <field name="account_type"/>
                     <field name="partner_id"/>


### PR DESCRIPTION
When searching a journal item by the amount it has to be exact to find it so to resolve this problem I added a new field for quicksearch so that you do not have to search perfect amount

task-5231322