### PR TITLE
[IMP] account: add a search field to search for journal items by debit/credit

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -309,6 +309,7 @@
                     <field name="name"/>
                     <field name="ref"/>
                     <field name="invoice_date"/>
+                    <field name="debit" string="Debit/Credit" filter_domain="['|',('debit', '=', self), ('credit', '=', self)]"/>
                     <field name="date"/>
                     <field name="date_maturity" string="Due Date"/>
                     <field name="discount_date" string="Discount Date"/>


### PR DESCRIPTION
when typing a number in the search, a new field depending on either the debit or credit can now be used
to filter journal items, this is better than using just the balance field because the balance can be negative
while debit or credit are always positive values
task id: 5231294