### PR TITLE
[IMP] account: added quick search on amount in journal items

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -324,6 +324,7 @@
                     <field name="tax_ids" />
                     <field name="tax_line_id" string="Originator Tax"/>
                     <field name="reconcile_model_id"/>
+                    <field name="balance" string="Amount" filter_domain="[('balance', '=', self)]"/>
                     <separator/>
                     <filter string="Unposted" name="unposted" domain="[('parent_state', '=', 'draft')]" help="Unposted Journal Items"/>
                     <filter string="Posted" name="posted" domain="[('parent_state', '=', 'posted')]" help="Posted Journal Items"/>


### PR DESCRIPTION
[IMP] account: added the seach filter for the journal amount 

Previously users can not search the journal items based on the amount thus motivated this changed to enable the user to search for the journal items by amount of balance. 

task: Quick search on an amount in the journal items