### PR TITLE
[IMP] account: hide analytics if analytics not checked

### DIFF
--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -26,13 +26,13 @@
         <menuitem id="menu_finance_entries" name="Accounting" sequence="4" groups="account.group_account_readonly">
             <menuitem id="menu_action_move_journal_line_form" action="action_move_journal_line" groups="account.group_account_readonly" sequence="1"/>
             <menuitem id="menu_action_account_moves_all" action="action_account_moves_all" groups="account.group_account_readonly" sequence="10"/>
-            <menuitem id="menu_action_analytic_lines_tree" name="Analytic Items" action="analytic.account_analytic_line_action_entries" groups="account.group_account_invoice,account.group_account_readonly,analytic.group_analytic_accounting" sequence="31"/>
+            <menuitem id="menu_action_analytic_lines_tree" name="Analytic Items" action="analytic.account_analytic_line_action_entries" groups="analytic.group_analytic_accounting" sequence="31"/>
         </menuitem>
         <menuitem id="menu_finance_reports" name="Reporting" sequence="20" groups="account.group_account_readonly,account.group_account_invoice">
             <menuitem id="account_reports_partners_reports_menu" name="Partner Reports" sequence="3"/>
             <menuitem id="account_reports_management_menu" name="Management" sequence="4">
                 <menuitem id="menu_action_account_invoice_report_all" name="Invoice Analysis" action="action_account_invoice_report_all" sequence="1"/>
-                <menuitem id="menu_action_analytic_reporting" name="Analytic Report" action="action_analytic_reporting" groups="account.group_account_readonly"/>
+                <menuitem id="menu_action_analytic_reporting" name="Analytic Report" action="action_analytic_reporting" groups="analytic.group_analytic_accounting"/>
             </menuitem>
             <menuitem id="account_reports_legal_statements_menu" name="Statement Reports" sequence="1" groups="account.group_account_readonly"/>
         </menuitem>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -336,10 +336,10 @@
                                 <field name="group_analytic_accounting"/>
                             </setting>
                             <setting id="account_budget" title="This allows accountants to manage analytic and crossovered budgets. Once the master budgets and the budgets are defined, the project managers can set the planned amount on each analytic account." groups="account.group_account_user" help="Use budgets to compare actual with expected revenues and costs"
-                                documentation="/applications/finance/accounting/others/adviser/budget.html">
+                                documentation="/applications/finance/accounting/others/adviser/budget.html" invisible="not group_analytic_accounting">
                                 <field name="module_account_budget" widget="upgrade_boolean"/>
                             </setting>
-                            <setting id="monitor_product_margins" string="Margin Analysis" help="Monitor your product margins from invoices" groups="account.group_account_user">
+                            <setting id="monitor_product_margins" string="Margin Analysis" help="Monitor your product margins from invoices" groups="account.group_account_user" invisible="not group_analytic_accounting">
                                 <field name="module_product_margin"/>
                             </setting>
                         </block>


### PR DESCRIPTION
In the account modules, when the analytic accounting is not checked in the settings,
hidding the sub-menus linked to the analytic accounting.

task-5231285