### PR TITLE
[IMP] account: change group payments memo to 'PAY'

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -164,7 +164,7 @@ class ResCompany(models.Model):
             'padding': 5,
             'use_date_range': True,
             'company_id': self.id,
-            'prefix': 'BATCH/%(year)s/',
+            'prefix': 'PAY/%(year)s/',
         }),
     )
 

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -204,7 +204,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': Like(f'PAY/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -237,7 +237,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': Like(f'PAY/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -272,7 +272,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': Like(f'PAY/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -315,7 +315,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': Like(f'PAY/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [


### PR DESCRIPTION
For the customer invoices, when we want to do a group payment, changing the memo
of this group payment to 'PAY' instead of 'BATCH' to avoid the confusion with batch payments.

task-5231284