### PR TITLE
[IMP] l10n_fr_account: delivery date added on french invoices

### DIFF
--- a/addons/l10n_fr_account/models/account_move.py
+++ b/addons/l10n_fr_account/models/account_move.py
@@ -20,3 +20,17 @@ class AccountMove(models.Model):
     def _compute_l10n_fr_is_company_french(self):
         for record in self:
             record.l10n_fr_is_company_french = record.country_code in record.company_id._get_france_country_codes()
+
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self): #EXTEND 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.l10n_fr_is_company_french:
+                move.show_delivery_date = move.is_sale_document()
+                
+    def _post(self, soft=True):
+        post = super()._post(soft)
+        for move in self:
+            if move.show_delivery_date and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
+        return post


### PR DESCRIPTION
[IMP] l10n_fr_account: delivery date added on french invoices 

as a new legislation in french required the addition of delivery date on invoices we have to modify the localisation for french companies to always have the delivery date included in the invoices to comply with the legislation. 

task : [l10n_fr] Add delivery date on invoice