### PR TITLE
[IMP] l10n_fr: automatic display delivery date on fr invoices header

### DIFF
--- a/addons/l10n_fr_account/models/account_move.py
+++ b/addons/l10n_fr_account/models/account_move.py
@@ -20,3 +20,19 @@ class AccountMove(models.Model):
     def _compute_l10n_fr_is_company_french(self):
         for record in self:
             record.l10n_fr_is_company_french = record.country_code in record.company_id._get_france_country_codes()
+
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account.move'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.l10n_fr_is_company_french:
+                move.show_delivery_date = move.is_sale_document()
+
+    def _post(self, soft=True):
+        # EXTENDS 'account.move'
+        posted = super()._post(soft)
+        for move in self:
+            if move.show_delivery_date and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
+        return posted


### PR DESCRIPTION
there was a new legislation in France and the delivery date has to appear on the invoices so now it appears automatically in the customer invoice header and write a date on the invoice layout even if none is specified when creating the invoice

task-5231327