### PR TITLE
[IMP] account: improved send status of invoices visibility

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -618,7 +618,16 @@ class AccountMove(models.Model):
         help="Is the move being sent asynchronously",
         compute='_compute_is_being_sent'
     )
-
+    send_status = fields.Selection(
+        selection=[
+            ('sent', "Sent"),
+            ('not_sent', "Not sent")
+        ],
+        string="Send Status",
+        compute='_compute_send_status',
+        readonly=True,
+        copy=False,
+    )
     invoice_user_id = fields.Many2one(
         string='Salesperson',
         comodel_name='res.users',
@@ -785,6 +794,11 @@ class AccountMove(models.Model):
     def _compute_is_being_sent(self):
         for move in self:
             move.is_being_sent = bool(move.sending_data)
+
+    @api.depends('is_being_sent')
+    def _compute_send_status(self):
+        for move in self:
+            move.send_status = 'sent' if move.is_move_sent else 'not_sent'
 
     def _compute_payment_reference(self):
         for move in self.filtered(lambda m: (

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -549,6 +549,12 @@
                            invisible="payment_state == 'invoicing_legacy' or move_type == 'entry'"
                            optional="show"
                     />
+                    <field name="send_status"
+                           widget="badge"
+                           decoration-success="send_status == 'sent'"
+                           decoration-muted="send_status == 'not_sent'"
+                           optional="hide"
+                    />
                     <field name="move_type" column_invisible="context.get('default_move_type', True)"/>
                     <field name="abnormal_amount_warning" column_invisible="1"/>
                     <field name="abnormal_date_warning" column_invisible="1"/>
@@ -1597,6 +1603,11 @@
                     <filter name="not_sent"
                             string="Not Sent"
                             domain="[('is_move_sent', '=', False)]"
+                            invisible="context.get('default_move_type') in ('in_invoice', 'in_refund', 'in_receipt')"
+                    />
+                    <filter name="sent"
+                            string="Sent"
+                            domain="[('is_move_sent', '=', True)]"
                             invisible="context.get('default_move_type') in ('in_invoice', 'in_refund', 'in_receipt')"
                     />
                     <separator/>


### PR DESCRIPTION
When an invoice is sent there is no other way to ee it than in the form view by the button send & print thus I added an optional hide field in the list view that shows the send status and made 2 filters sent and not sent to easily differentiate those invoices