### PR TITLE
[FIX]: hr_holidays: fix time off type error in time off form view

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -280,7 +280,7 @@ class HrLeaveType(models.Model):
         leave_types = self.env['hr.leave.type'].search([])
 
         def is_valid(leave_type):
-            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves)
+            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves, value)
         return [('id', 'in', leave_types.filtered(is_valid).ids)]
 
     @api.depends_context('employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -114,3 +114,27 @@ class TestHrLeaveType(TestHrHolidaysCommon):
             ).search([('has_valid_allocation', '=', True)], limit=1)
 
         self.assertFalse(leave_types, "Got valid leaves outside vaild period")
+
+    def test_search_virtual_remaining_leaves(self):
+        employee_id = self.env['hr.employee'].create({'name': 'Test Employee'})
+        leave_type1, leave_type2 = self.env['hr.leave.type'].create([
+            {
+                'name': 'Leave type 1',
+                'time_type': 'leave',
+                'requires_allocation': True,
+            }, {
+                'name': 'Leave type 2',
+                'time_type': 'leave',
+                'requires_allocation': True,
+            },
+        ])
+        self.env['hr.leave.allocation'].create([{
+            'name': 'Leave type 1 allocation',
+            'holiday_status_id': leave_type1.id,
+            'number_of_days': 1,
+            'employee_id': employee_id.id,
+            'state': 'confirm',
+        }]).action_approve()
+        leave_type_ids = self.env['hr.leave.type'].with_context(employee_id=employee_id.id).search([('virtual_remaining_leaves', '>', 0)])
+        self.assertIn(leave_type1, leave_type_ids)
+        self.assertNotIn(leave_type2, leave_type_ids)


### PR DESCRIPTION
### Steps to Reproduce

1.  Go to **Time Off > Configuration > Time Off Types**.
2.  Open a type and click the "Time Off" smart button.
3.  Click **New**.
4.  An error appears.

[[Reference Video](https://drive.google.com/file/d/1vi_apL24Km5tSomQtwcTArqqWvrBR5ni/view)]

### Reason

In the `_search_virtual_remaining_leaves` method, the code tries to use an operator (like `>`) to compare the `virtual_remaining_leaves`.

This operator requires **two** arguments to work. However, the code was only passing **one** argument, missing the `value` to compare against. This caused the "expects 2 arguments" error.

### Solution

Passed the missing `value` to the operator call so the comparison can be completed correctly.

Task: 5241685