### PR TITLE
[IMP] account: search of a journal item by amount

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -306,6 +306,7 @@
                     <field name="name" string="Journal Item" filter_domain="[
                         '|', '|', '|',
                         ('name', 'ilike', self), ('ref', 'ilike', self), ('account_id', 'ilike', self), ('partner_id', 'ilike', self)]"/>
+                    <field name="balance" string="Amount" filter_domain="['|', ('debit', '&gt;=', self), ('credit', '&gt;=', self)]" />
                     <field name="name"/>
                     <field name="ref"/>
                     <field name="invoice_date"/>


### PR DESCRIPTION
This change introduces a dedicated search filter for monetary values on account.move.line (Journal Items).
Previously, searching directly by an exact or minimum amount was not possible. This PR allows users to filter using syntax like 'balance >= 1000'.

To ensure comprehensive results, the filter checks the entered value against both the 'credit' and 'debit' fields simultaneously, guaranteeing that transactions matching the amount are returned regardless of whether they are recorded as a debit or a credit.

task-5231308

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr