### PR TITLE
[IMP] account: hide analytic menu items if analytic accounting setting is disabled

### DIFF
--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -26,7 +26,7 @@
         <menuitem id="menu_finance_entries" name="Accounting" sequence="4" groups="account.group_account_readonly">
             <menuitem id="menu_action_move_journal_line_form" action="action_move_journal_line" groups="account.group_account_readonly" sequence="1"/>
             <menuitem id="menu_action_account_moves_all" action="action_account_moves_all" groups="account.group_account_readonly" sequence="10"/>
-            <menuitem id="menu_action_analytic_lines_tree" name="Analytic Items" action="analytic.account_analytic_line_action_entries" groups="account.group_account_invoice,account.group_account_readonly,analytic.group_analytic_accounting" sequence="31"/>
+            <menuitem id="menu_action_analytic_lines_tree" name="Analytic Items" action="analytic.account_analytic_line_action_entries" groups="analytic.group_analytic_accounting" sequence="31"/>
         </menuitem>
         <menuitem id="menu_finance_reports" name="Reporting" sequence="20" groups="account.group_account_readonly,account.group_account_invoice">
             <menuitem id="account_reports_partners_reports_menu" name="Partner Reports" sequence="3"/>


### PR DESCRIPTION
When the 'Analytic Accounting' feature is not enabled in the Accounting settings, several related menu items are still displayed to the user.
This causes clutter and presents irrelevant options, confusing users.

This PR ensures that all menu items related to analytic accounting are conditionally hidden.

This affects menus under:
* Accounting -> Analytic Items
* Reporting -> Analytic Report
* Configuration -> Analytic Accounting and its submenus

task-5231311

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
