### PR TITLE
[IMP] account: add sent status column and filters on invoice list

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -340,6 +340,15 @@ class AccountMove(models.Model):
         copy=False,
         domain=[('display_type', 'in', ('product', 'line_section', 'line_note'))],
     )
+    invoice_sent_status = fields.Selection(
+        selection=[
+            ('sent', "Sent"),
+            ('not_sent', "Not sent")
+        ],
+        compute='_compute_is_sent_status',
+        copy=False,
+        store=True
+    )
 
     # === Date fields === #
     invoice_date = fields.Date(
@@ -780,6 +789,11 @@ class AccountMove(models.Model):
                     )
             else:
                 move.invoice_user_id = False
+
+    @api.depends('is_move_sent')
+    def _compute_is_sent_status(self):
+        for move in self:
+            move.invoice_sent_status = 'sent' if move.is_move_sent else 'not_sent'
 
     @api.depends('sending_data')
     def _compute_is_being_sent(self):

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -306,6 +306,7 @@
                     <field name="name" string="Journal Item" filter_domain="[
                         '|', '|', '|',
                         ('name', 'ilike', self), ('ref', 'ilike', self), ('account_id', 'ilike', self), ('partner_id', 'ilike', self)]"/>
+                    <field name="amount_currency" filter_domain="[('amount_currency', '&gt;=', self)]" />
                     <field name="name"/>
                     <field name="ref"/>
                     <field name="invoice_date"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -550,6 +550,7 @@
                            invisible="payment_state == 'invoicing_legacy' or move_type == 'entry'"
                            optional="show"
                     />
+                    <field name="invoice_sent_status" string="Sent" optional="hide" widget="badge" decoration-success="is_move_sent" decoration-warning="not is_move_sent"/>
                     <field name="move_type" column_invisible="context.get('default_move_type', True)"/>
                     <field name="abnormal_amount_warning" column_invisible="1"/>
                     <field name="abnormal_date_warning" column_invisible="1"/>
@@ -1594,6 +1595,15 @@
                     <separator groups="account.group_account_secured,base.group_no_one"/>
                     <filter name="not_secured" string="Not Secured" domain="[('secured', '=', False), ('state', '=', 'posted')]"
                             groups="account.group_account_secured,base.group_no_one"/>
+                    <separator/>
+                    <filter name="invoice_sent_status"
+                            string="Sent invoices"
+                            domain="[('invoice_sent_status', '=', 'sent')]"
+                    />
+                    <filter name="invoice_sent_status"
+                            string="Not sent invoices"
+                            domain="[('invoice_sent_status', '=', 'not_sent')]"
+                    />
                     <separator/>
                     <filter name="not_sent"
                             string="Not Sent"


### PR DESCRIPTION
To improve traceability for users, it is now necessary to easily see which invoices have been sent, especially with the rise of electronic invoicing.

This PR adds the 'sent' status as an optional column in the invoice list view. It also introduces two new search filters: 'Sent Invoices' and 'Not Sent Invoices' to quickly track documents that need to be dispatched.

task-5231314

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr