### PR TITLE
[IMP] l10n_fr_account: display delivery date on customer invoices

### DIFF
--- a/addons/l10n_fr_account/models/account_move.py
+++ b/addons/l10n_fr_account/models/account_move.py
@@ -16,6 +16,22 @@ class AccountMove(models.Model):
                 shipping_fields[0].attrib.pop("groups", None)
         return arch, view
 
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.l10n_fr_is_company_french:
+                move.show_delivery_date = move.is_sale_document()
+
+    def _post(self, soft=True):
+        # EXTENDS 'account'
+        posted = super()._post(soft)
+        for move in self:
+            if move.show_delivery_date and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
+        return posted
+
     @api.depends('company_id.country_code')
     def _compute_l10n_fr_is_company_french(self):
         for record in self:


### PR DESCRIPTION
New legislation in France requires the delivery date to be clearly displayed on customer invoices.
Previously, this date was not exposed on the invoice form view or in the printed invoice layout for French localization.

This PR updates the invoice form view to display the 'delivery_date' field and integrates the date into the printable invoice report for French localization, ensuring compliance with the new legal requirement.

task-5231313

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
