### PR TITLE
[IMP] mail, im_livechat: manage downgrade of local storage

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/upgrade_19_1.js
+++ b/addons/im_livechat/static/src/core/public_web/upgrade_19_1.js
@@ -1,0 +1,6 @@
+import { upgrade_19_1 } from "@mail/core/common/upgrade/upgrade_19_1";
+
+upgrade_19_1.add("discuss_sidebar_category_folded_im_livechat.category_default", {
+    key: "DiscussAppCategory,im_livechat.category_default:is_open",
+    value: false,
+});

--- a/addons/im_livechat/static/tests/upgrade_19_1.test.js
+++ b/addons/im_livechat/static/tests/upgrade_19_1.test.js
@@ -1,0 +1,45 @@
+import { defineLivechatModels } from "@im_livechat/../tests/livechat_test_helpers";
+
+import { DiscussAppCategory } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
+import { makeRecordFieldLocalId } from "@mail/model/misc";
+import { toRawValue } from "@mail/utils/common/local_storage";
+import { contains, openDiscuss, start, startServer } from "@mail/../tests/mail_test_helpers";
+
+import { beforeEach, describe, expect, test } from "@odoo/hoot";
+
+import { Command, serverState } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+defineLivechatModels();
+
+beforeEach(() => {
+    serverState.serverVersion = [99, 9]; // high version so following upgrades keep good working of feature
+});
+
+test("category 'Livechat' is folded", async () => {
+    const pyEnv = await startServer();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({
+                livechat_member_type: "agent",
+                partner_id: serverState.partnerId,
+            }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+        ],
+        channel_type: "livechat",
+        livechat_operator_id: serverState.partnerId,
+    });
+    localStorage.setItem("discuss_sidebar_category_folded_im_livechat.category_default", "true");
+    await start();
+    await openDiscuss();
+    await contains(".o-mail-DiscussSidebarCategory:contains('Livechat') .oi.oi-chevron-right");
+    const defaultLivechat_is_open = makeRecordFieldLocalId(
+        DiscussAppCategory.localId("im_livechat.category_default"),
+        "is_open"
+    );
+    expect(localStorage.getItem(defaultLivechat_is_open)).toBe(toRawValue(false));
+    expect(
+        localStorage.getItem("discuss_sidebar_category_folded_im_livechat.category_default")
+    ).toBe(null);
+});

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -730,7 +730,7 @@ export class Store extends BaseStore {
 Store.register();
 
 export const storeService = {
-    dependencies: ["bus_service", "im_status", "ui", "popover"],
+    dependencies: ["bus_service", "im_status", "ui", "popover", "discuss.upgrade"],
     /**
      * @param {import("@web/env").OdooEnv} env
      * @param {import("services").ServiceFactories} services

--- a/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
@@ -1,0 +1,30 @@
+import { addUpgrade } from "@mail/core/common/upgrade/upgrade_helpers";
+
+/** @typedef {import("@mail/core/common/upgrade/upgrade_helpers").UpgradeFnParam} UpgradeFnParam */
+/** @typedef {import("@mail/core/common/upgrade/upgrade_helpers").UpgradeFnReturn} UpgradeFnReturn */
+
+export const upgrade_19_1 = {
+    /**
+     * @param {string} key
+     * @param {((param: UpgradeFnParam) => UpgradeFnReturn)|UpgradeFnReturn} upgrade
+     * @returns {UpgradeFnReturn}
+     */
+    add(key, upgrade) {
+        return addUpgrade({ key, version: "19.1", upgrade });
+    },
+};
+
+upgrade_19_1.add("mail.user_setting.message_sound", {
+    key: "Settings,undefined:messageSound",
+    value: false,
+});
+
+upgrade_19_1.add("mail_user_setting_disable_call_auto_focus", {
+    key: "Settings,undefined:useCallAutoFocus",
+    value: false,
+});
+
+upgrade_19_1.add("mail_user_setting_use_blur", {
+    key: "Settings,undefined:useBlur",
+    value: true,
+});

--- a/addons/mail/static/src/core/common/upgrade/upgrade_helpers.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_helpers.js
@@ -1,0 +1,118 @@
+import { getCurrentLocalStorageVersion, LocalStorageEntry } from "@mail/utils/common/local_storage";
+import { parseVersion } from "@mail/utils/common/misc";
+import { registry } from "@web/core/registry";
+
+/**
+ * @typedef {Object} UpgradeData
+ * @property {string} version
+ * @property {string} key
+ * @property {((param: UpgradeFnParam) => UpgradeFnReturn)|UpgradeFnReturn} upgrade
+ */
+/**
+ * @typedef {Object} UpgradeDataWithoutVersion
+ * @property {string} key
+ * @property {((param: UpgradeFnParam) => UpgradeFnReturn)|UpgradeFnReturn} upgrade
+ */
+/**
+ * @typedef {Object} UpgradeFnParam
+ * @property {string} key
+ * @property {any} value
+ */
+/**
+ * @typedef {Object} UpgradeFnReturn
+ * @property {string} key
+ * @property {any} value
+ */
+
+/**
+ * Register a `key` and `upgrade` function for a `version` of local storage.
+ *
+ * When there's request to upgrade a local storage
+ *
+ * Example:
+ * - we have versions 19.1, 19.3, and 20.0.
+ * - define upgrade function with 19.1 is to upgrade to 19.1
+ * - define ugrade function with 20.0 is to upgrade to 20.0
+ *
+ * Upgrades are applied in sequence, i.e.:
+ * - if version is 20.0 and local storage data are in version 0, this will apply upgrade to 19.1, then to 19.3 and finally to 20.0.
+ * - if version is 20.0 and local storage data are in version 19.1, this will apply upgrade to 19.3 and finally to 20.0.
+ * - if version is 20.0 and local storage data are in version 19.2, this will apply upgrade to 19.3 and finally to 20.0.
+ * - if version is 20.0 and local storage data are in version 20.0, this will not upgrade data.
+ *
+ * @param {UpgradeData} param0
+ */
+export function addUpgrade({ version, key, upgrade }) {
+    /** @type {Map<string, Function[]>} */
+    const map = getUpgradeMap();
+    if (!map.has(version)) {
+        map.set(version, new Map());
+    }
+    map.get(version).set(key, { version, key, upgrade });
+}
+
+/** @param {string} version */
+export function upgradeFrom(version) {
+    const orderedUpgradeList = Array.from(getUpgradeMap().entries())
+        .filter(
+            ([v]) =>
+                !parseVersion(v).isLowerThan(version) &&
+                !parseVersion(getCurrentLocalStorageVersion()).isLowerThan(v)
+        )
+        .sort(([v1], [v2]) => (parseVersion(v1).isLowerThan(v2) ? -1 : 1));
+    for (const [, keyMap] of orderedUpgradeList) {
+        for (const upgradeData of keyMap.values()) {
+            applyUpgrade(upgradeData);
+        }
+    }
+}
+
+const upgradeRegistry = registry.category("discuss.upgrade");
+upgradeRegistry.add(null, new Map());
+
+/**
+ * A Map of version numbers to a Map of keys and upgrade functions.
+ * Basically:
+ *
+ * Map: {
+ *     "19.1": {
+ *         key_1: upgradeData_1,
+ *         key_2: upgradeData_2,
+ *     },
+ *     "19.2": {
+ *         key_3: upgradeData_3,
+ *         key_4: upgradeData_4,
+ *         ...
+ *     },
+ *     ...
+ * }
+ *
+ * To upgrade a key in a given version, find the key in version
+ * and applyUpgrade using upgradeData to upgrade with new key, value and version.
+ *
+ * @return {Map<string, Map<string, UpgradeData>>}
+ */
+function getUpgradeMap() {
+    return upgradeRegistry.get(null);
+}
+
+/**
+ * Upgrade local storage using `upgrade` data.
+ * i.e. call `upgradeData.upgrade` to get new key and value.
+ *
+ * @param {UpgradeData} upgradeData
+ */
+function applyUpgrade(upgradeData) {
+    const oldEntry = new LocalStorageEntry(upgradeData.key);
+    const oldValue = oldEntry.rawGet() ?? oldEntry.get();
+    if (oldValue === undefined) {
+        return; // could not upgrade (cannot parse or more recent version)
+    }
+    const { key, value } =
+        typeof upgradeData.upgrade === "function"
+            ? upgradeData.upgrade({ key: upgradeData.key, value: oldValue })
+            : upgradeData.upgrade;
+    oldEntry.remove();
+    const newEntry = new LocalStorageEntry(key);
+    newEntry.set(value);
+}

--- a/addons/mail/static/src/core/common/upgrade/upgrade_helpers.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_helpers.js
@@ -104,8 +104,12 @@ function getUpgradeMap() {
  */
 function applyUpgrade(upgradeData) {
     const oldEntry = new LocalStorageEntry(upgradeData.key);
-    const oldValue = oldEntry.rawGet() ?? oldEntry.get();
-    if (oldValue === undefined) {
+    const parsed = oldEntry.parse();
+    const oldValue = parsed ?? oldEntry.get();
+    if (
+        oldValue === null ||
+        (parsed && parsed.version && parseVersion(upgradeData.version).isLowerThan(parsed.version))
+    ) {
         return; // could not upgrade (cannot parse or more recent version)
     }
     const { key, value } =
@@ -114,5 +118,5 @@ function applyUpgrade(upgradeData) {
             : upgradeData.upgrade;
     oldEntry.remove();
     const newEntry = new LocalStorageEntry(key);
-    newEntry.set(value);
+    newEntry.set(value, upgradeData.version);
 }

--- a/addons/mail/static/src/core/common/upgrade/upgrade_service.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_service.js
@@ -1,0 +1,19 @@
+import { registry } from "@web/core/registry";
+import { upgradeFrom } from "./upgrade_helpers";
+import { getCurrentLocalStorageVersion, LocalStorageEntry } from "@mail/utils/common/local_storage";
+import { parseVersion } from "@mail/utils/common/misc";
+
+export const discussUpgradeService = {
+    dependencies: [],
+    start() {
+        const lse = new LocalStorageEntry("discuss.upgrade.version");
+        const oldVersion = lse.get() ?? "1.0";
+        const currentVersion = getCurrentLocalStorageVersion();
+        lse.set(currentVersion);
+        if (parseVersion(oldVersion).isLowerThan(currentVersion)) {
+            upgradeFrom(oldVersion);
+        }
+    },
+};
+
+registry.category("services").add("discuss.upgrade", discussUpgradeService);

--- a/addons/mail/static/src/core/common/upgrade/upgrade_service.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_service.js
@@ -7,9 +7,10 @@ export const discussUpgradeService = {
     dependencies: [],
     start() {
         const lse = new LocalStorageEntry("discuss.upgrade.version");
-        const oldVersion = lse.get() ?? "1.0";
+        const parsed = lse.parse();
+        const oldVersion = parsed?.version ?? "1.0";
         const currentVersion = getCurrentLocalStorageVersion();
-        lse.set(currentVersion);
+        lse.set(true, currentVersion);
         if (parseVersion(oldVersion).isLowerThan(currentVersion)) {
             upgradeFrom(oldVersion);
         }

--- a/addons/mail/static/src/core/public_web/discuss_app/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/discuss_app_model.js
@@ -1,9 +1,4 @@
 import { fields, Record } from "@mail/model/export";
-import { browser } from "@web/core/browser/browser";
-
-const NO_MEMBERS_DEFAULT_OPEN_LS = "mail.user_setting.no_members_default_open";
-export const DISCUSS_SIDEBAR_COMPACT_LS = "mail.user_setting.discuss_sidebar_compact";
-export const LAST_DISCUSS_ACTIVE_ID_LS = "mail.user_setting.discuss_last_active_id";
 
 export class DiscussApp extends Record {
     INSPECTOR_WIDTH = 300;
@@ -12,49 +7,9 @@ export class DiscussApp extends Record {
     activeTab = "notification";
     searchTerm = "";
     isActive = false;
-    isMemberPanelOpenByDefault = fields.Attr(true, {
-        compute() {
-            return browser.localStorage.getItem(NO_MEMBERS_DEFAULT_OPEN_LS) !== "true";
-        },
-        /** @this {import("models").DiscussApp} */
-        onUpdate() {
-            if (this.isMemberPanelOpenByDefault) {
-                browser.localStorage.removeItem(NO_MEMBERS_DEFAULT_OPEN_LS);
-            } else {
-                browser.localStorage.setItem(NO_MEMBERS_DEFAULT_OPEN_LS, "true");
-            }
-        },
-    });
-    isSidebarCompact = fields.Attr(false, {
-        compute() {
-            return browser.localStorage.getItem(DISCUSS_SIDEBAR_COMPACT_LS) === "true";
-        },
-        /** @this {import("models").DiscussApp} */
-        onUpdate() {
-            if (this.isSidebarCompact) {
-                browser.localStorage.setItem(
-                    DISCUSS_SIDEBAR_COMPACT_LS,
-                    this.isSidebarCompact.toString()
-                );
-            } else {
-                browser.localStorage.removeItem(DISCUSS_SIDEBAR_COMPACT_LS);
-            }
-        },
-    });
-    lastActiveId = fields.Attr(undefined, {
-        /** @this {import("models").DiscussApp} */
-        compute() {
-            return browser.localStorage.getItem(LAST_DISCUSS_ACTIVE_ID_LS) ?? undefined;
-        },
-        /** @this {import("models").DiscussApp} */
-        onUpdate() {
-            if (this.lastActiveId) {
-                browser.localStorage.setItem(LAST_DISCUSS_ACTIVE_ID_LS, this.lastActiveId);
-            } else {
-                browser.localStorage.removeItem(LAST_DISCUSS_ACTIVE_ID_LS);
-            }
-        },
-    });
+    isMemberPanelOpenByDefault = fields.Attr(true, { localStorage: true });
+    isSidebarCompact = fields.Attr(false, { localStorage: true });
+    lastActiveId = fields.Attr(undefined, { localStorage: true });
     thread = fields.One("mail.thread", {
         /** @this {import("models").DiscussApp} */
         onUpdate() {
@@ -62,27 +17,6 @@ export class DiscussApp extends Record {
         },
     });
     hasRestoredThread = false;
-
-    static new() {
-        const record = super.new(...arguments);
-        record.onStorage = record.onStorage.bind(record);
-        browser.addEventListener("storage", record.onStorage);
-        return record;
-    }
-
-    delete() {
-        browser.removeEventListener("storage", this.onStorage);
-        super.delete(...arguments);
-    }
-
-    onStorage(ev) {
-        if (ev.key === DISCUSS_SIDEBAR_COMPACT_LS) {
-            this.isSidebarCompact = ev.newValue === "true";
-        }
-        if (ev.key === NO_MEMBERS_DEFAULT_OPEN_LS) {
-            this.isMemberPanelOpenByDefault = ev.newValue !== "true";
-        }
-    }
 }
 
 DiscussApp.register();

--- a/addons/mail/static/src/core/public_web/discuss_app/upgrade_19_1.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/upgrade_19_1.js
@@ -1,0 +1,26 @@
+import { upgrade_19_1 } from "@mail/core/common/upgrade/upgrade_19_1";
+
+upgrade_19_1.add("mail.user_setting.no_members_default_open", {
+    key: "DiscussApp,undefined:isMemberPanelOpenByDefault",
+    value: false,
+});
+
+upgrade_19_1.add("mail.user_setting.discuss_sidebar_compact", {
+    key: "DiscussApp,undefined:isSidebarCompact",
+    value: true,
+});
+
+upgrade_19_1.add("mail.user_setting.discuss_last_active_id", ({ value }) => ({
+    key: "DiscussApp,undefined:lastActiveId",
+    value,
+}));
+
+upgrade_19_1.add("discuss_sidebar_category_folded_channels", {
+    key: "DiscussAppCategory,channels:is_open",
+    value: false,
+});
+
+upgrade_19_1.add("discuss_sidebar_category_folded_chats", {
+    key: "DiscussAppCategory,chats:is_open",
+    value: false,
+});

--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -99,7 +99,7 @@
                     <t t-set="onchange" t-value="onChangeShowOnlyVideo"/>
                 </t>
             </div>
-            <div t-if="store.settings.hasCanvasFilterSupport" class="d-flex flex-column my-1">
+            <div t-if="store.settings.hasCanvasFilterSupport" class="d-flex flex-column my-1 o-discuss-CallSettings-item">
                 <t t-call="discuss.CallSettings.textToggler">
                     <t t-set="text">Blur video background</t>
                     <t t-set="value" t-value="store.settings.useBlur"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_category_model.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_category_model.js
@@ -1,29 +1,8 @@
 import { compareDatetime } from "@mail/utils/common/misc";
 import { fields, Record } from "@mail/model/export";
-import { browser } from "@web/core/browser/browser";
-
-export const DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS = "discuss_sidebar_category_folded_";
 
 export class DiscussAppCategory extends Record {
     static id = "id";
-
-    static new() {
-        const record = super.new(...arguments);
-        record.onStorage = record.onStorage.bind(record);
-        browser.addEventListener("storage", record.onStorage);
-        return record;
-    }
-
-    delete() {
-        browser.removeEventListener("storage", this.onStorage);
-        super.delete(...arguments);
-    }
-
-    onStorage(ev) {
-        if (ev.key === `${DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS}${this.id}`) {
-            this.is_open = ev.newValue !== "true";
-        }
-    }
 
     /**
      * @param {import("models").Thread} t1
@@ -70,26 +49,7 @@ export class DiscussAppCategory extends Record {
     /** @type {number} */
     sequence;
 
-    is_open = fields.Attr(false, {
-        /** @this {import("models").DiscussApp} */
-        compute() {
-            return !(
-                browser.localStorage.getItem(`${DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS}${this.id}`) ??
-                false
-            );
-        },
-        /** @this {import("models").DiscussApp} */
-        onUpdate() {
-            if (!this.is_open) {
-                browser.localStorage.setItem(
-                    `${DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS}${this.id}`,
-                    true
-                );
-            } else {
-                browser.localStorage.removeItem(`${DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS}${this.id}`);
-            }
-        },
-    });
+    is_open = fields.Attr(true, { localStorage: true });
 
     threads = fields.Many("mail.thread", {
         sort(t1, t2) {

--- a/addons/mail/static/src/model/make_store.js
+++ b/addons/mail/static/src/model/make_store.js
@@ -166,9 +166,6 @@ export function makeStore(env, { localRegistry } = {}) {
                         store = record;
                         Record.store = store;
                     }
-                    for (const name of Model._.fields.keys()) {
-                        record._.prepareField(record, name, recordProxy);
-                    }
                     return recordProxy;
                 }
             },

--- a/addons/mail/static/src/model/misc.js
+++ b/addons/mail/static/src/model/misc.js
@@ -203,4 +203,8 @@ export const fields = {
     },
 };
 
+export function makeRecordFieldLocalId(recordLocalId, fieldName) {
+    return `${recordLocalId}:${fieldName}`;
+}
+
 export const technicalKeysOnRecords = ["_", "_proxy", "_proxyInternal", "_raw", "env", "Model"];

--- a/addons/mail/static/src/model/model_internal.js
+++ b/addons/mail/static/src/model/model_internal.js
@@ -1,5 +1,7 @@
 import { toRaw } from "@odoo/owl";
 import { ATTR_SYM, MANY_SYM, ONE_SYM } from "./misc";
+import { parseVersion } from "@mail/utils/common/misc";
+import { getCurrentLocalStorageVersion } from "@mail/utils/common/local_storage";
 
 export class ModelInternal {
     /** @type {Map<string, boolean>} */
@@ -75,12 +77,13 @@ export class ModelInternal {
                 function fieldLocalStorageCompute() {
                     const record = toRaw(this)._raw;
                     const lse = record._.fieldsLocalStorage.get(fieldName);
-                    const value = lse.get();
-                    if (value === undefined) {
+                    const parsed = lse.parse();
+                    const currentOdooVersion = getCurrentLocalStorageVersion();
+                    if (!parsed || parseVersion(currentOdooVersion).isLowerThan(parsed.version)) {
                         lse.remove();
                         return this[fieldName];
                     }
-                    return value;
+                    return parsed.value;
                 }
             );
 

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -192,6 +192,9 @@ export class Record {
             const recordProxy = new Model.Class();
             const record = toRaw(recordProxy)._raw;
             Object.assign(record._, { localId: Model.localId(ids) });
+            for (const name of Model._.fields.keys()) {
+                record._.prepareField(record, name, recordProxy);
+            }
             Object.assign(recordProxy, { ...ids });
             Model.records[record.localId] = recordProxy;
             if (record.Model.getName() === "Store") {

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -161,6 +161,15 @@ export class Store extends Record {
                             }
                         }
                     }
+                    for (const lsFieldName of record.Model._.fieldsLocalStorage) {
+                        const { localStorageKeyToRecordFields } = record.store._;
+                        const key = record._.fieldsLocalStorage.get(lsFieldName).key;
+                        const lsKeyMap = localStorageKeyToRecordFields.get(key);
+                        lsKeyMap.delete(record);
+                        if (lsKeyMap.size === 0) {
+                            localStorageKeyToRecordFields.delete(key);
+                        }
+                    }
                     deletingRecordsByLocalId.set(record.localId, record);
                     this.recordByLocalId.delete(record.localId);
                     this._.ADD_QUEUE("hard_delete", toRaw(record));

--- a/addons/mail/static/src/model/store_internal.js
+++ b/addons/mail/static/src/model/store_internal.js
@@ -6,7 +6,7 @@ import { RecordInternal } from "./record_internal";
 import { deserializeDate, deserializeDateTime } from "@web/core/l10n/dates";
 import { IS_DELETED_SYM, isCommand, isMany } from "./misc";
 import { browser } from "@web/core/browser/browser";
-import { parseRawValue } from "@mail/utils/common/local_storage";
+import { getCurrentLocalStorageVersion, parseRawValue } from "@mail/utils/common/local_storage";
 
 const Markup = markup().constructor;
 
@@ -55,7 +55,7 @@ export class StoreInternal extends RecordInternal {
                 record._proxy[fieldName] = record._.fieldsDefault.get(fieldName);
             } else {
                 const parsed = parseRawValue(ev.newValue);
-                if (!parsed) {
+                if (!parsed || parsed.version !== getCurrentLocalStorageVersion()) {
                     record._proxy[fieldName] = record._.fieldsDefault.get(fieldName);
                 } else {
                     record._proxy[fieldName] = parsed.value;

--- a/addons/mail/static/src/utils/common/local_storage.js
+++ b/addons/mail/static/src/utils/common/local_storage.js
@@ -1,0 +1,67 @@
+import { browser } from "@web/core/browser/browser";
+import { session } from "@web/session";
+
+const LOCAL_STORAGE_SUBVERSION = 0;
+
+/**
+ * @typedef {Object} VersionedValue
+ * @property {any} value
+ * @property {string} version
+ */
+
+export function getCurrentLocalStorageVersion() {
+    const [major, minor] = session.server_version_info ?? "1.0";
+    return [major, minor, LOCAL_STORAGE_SUBVERSION].join(".");
+}
+
+/**
+ * Utility class to simplify interaction on local storage with constant local storage key and with versioning.
+ * When a value is set, this is done as `{ value, version }`.
+ * Note: The object syntax is necessary to properly handle types, like "false" vs false.
+ */
+export class LocalStorageEntry {
+    /** @type {string} */
+    key;
+    constructor(key) {
+        this.key = key;
+    }
+    get() {
+        const rawValue = this.rawGet();
+        if (rawValue === null) {
+            return undefined;
+        }
+        return parseRawValue(rawValue)?.value;
+    }
+    set(value) {
+        const oldValue = this.get();
+        if (oldValue !== undefined && oldValue === value) {
+            return;
+        }
+        browser.localStorage.setItem(this.key, toRawValue(value));
+    }
+    rawGet() {
+        return browser.localStorage.getItem(this.key);
+    }
+    remove() {
+        if (this.rawGet() === null) {
+            return;
+        }
+        browser.localStorage.removeItem(this.key);
+    }
+}
+
+export function toRawValue(value) {
+    return JSON.stringify({ value });
+}
+
+/**
+ * @param {string} rawValue
+ * @returns {VersionedValue}
+ */
+export function parseRawValue(rawValue) {
+    try {
+        return JSON.parse(rawValue);
+    } catch {
+        // noop
+    }
+}

--- a/addons/mail/static/src/utils/common/local_storage.js
+++ b/addons/mail/static/src/utils/common/local_storage.js
@@ -26,32 +26,28 @@ export class LocalStorageEntry {
         this.key = key;
     }
     get() {
-        const rawValue = this.rawGet();
-        if (rawValue === null) {
-            return undefined;
-        }
-        return parseRawValue(rawValue)?.value;
-    }
-    set(value) {
-        const oldValue = this.get();
-        if (oldValue !== undefined && oldValue === value) {
-            return;
-        }
-        browser.localStorage.setItem(this.key, toRawValue(value));
-    }
-    rawGet() {
         return browser.localStorage.getItem(this.key);
     }
+    parse() {
+        return parseRawValue(this.get());
+    }
+    set(value, version = getCurrentLocalStorageVersion()) {
+        const parsed = this.parse();
+        if (parsed && parsed.value === value && parsed.version === version) {
+            return;
+        }
+        browser.localStorage.setItem(this.key, toRawValue(value, version));
+    }
     remove() {
-        if (this.rawGet() === null) {
+        if (this.get() === null) {
             return;
         }
         browser.localStorage.removeItem(this.key);
     }
 }
 
-export function toRawValue(value) {
-    return JSON.stringify({ value });
+export function toRawValue(value, version = getCurrentLocalStorageVersion()) {
+    return JSON.stringify({ value, version });
 }
 
 /**

--- a/addons/mail/static/tests/core/common/upgrade_19_1.test.js
+++ b/addons/mail/static/tests/core/common/upgrade_19_1.test.js
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, test } from "@odoo/hoot";
+import {
+    click,
+    contains,
+    defineMailModels,
+    mockGetMedia,
+    openDiscuss,
+    patchUiSize,
+    SIZES,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+import { makeRecordFieldLocalId } from "@mail/model/misc";
+import { toRawValue } from "@mail/utils/common/local_storage";
+import { Settings } from "@mail/core/common/settings_model";
+import { DiscussApp } from "@mail/core/public_web/discuss_app/discuss_app_model";
+import { DiscussAppCategory } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
+import { getService, serverState } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+defineMailModels();
+
+beforeEach(() => {
+    serverState.serverVersion = [99, 9]; // high version so following upgrades keep good working of feature
+});
+
+test("message sound is 'off'", async () => {
+    localStorage.setItem("mail.user_setting.message_sound", "false");
+    await start();
+    getService("action").doAction({
+        tag: "mail.discuss_notification_settings_action",
+        type: "ir.actions.client",
+    });
+    await contains("label:has(h5:contains('Message sound')) input:not(:checked)");
+    const messageSoundKey = makeRecordFieldLocalId(Settings.localId(), "messageSound");
+    expect(localStorage.getItem(messageSoundKey)).toBe(toRawValue(false));
+    expect(localStorage.getItem("mail.user_setting.message_sound")).toBe(null);
+});
+
+test("use blur is 'on'", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    localStorage.setItem("mail_user_setting_use_blur", "true");
+    patchUiSize({ size: SIZES.SM });
+    await start();
+    await openDiscuss(channelId);
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
+    await click("[title='Open Actions Menu']");
+    await click(".o-dropdown-item", { text: "Call Settings" });
+    await contains(".o-discuss-CallSettings");
+    await contains(
+        ".o-discuss-CallSettings-item:has(label:contains('Blur video background')) input:checked"
+    );
+    const useBlurKey = makeRecordFieldLocalId(Settings.localId(), "useBlur");
+    expect(localStorage.getItem(useBlurKey)).toBe(toRawValue(true));
+    expect(localStorage.getItem("mail_user_setting_use_blur")).toBe(null);
+});
+
+test("member default open is 'off'", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    localStorage.setItem("mail.user_setting.no_members_default_open", "true");
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Thread:contains('Welcome to #test')");
+    await contains(".o-mail-ActionList-button[title='Members']");
+    await contains(".o-mail-ActionList-button[title='Members']:not(.active)");
+    const isMemberPanelOpenByDefaultKey = makeRecordFieldLocalId(
+        DiscussApp.localId(),
+        "isMemberPanelOpenByDefault"
+    );
+    expect(localStorage.getItem(isMemberPanelOpenByDefaultKey)).toBe(toRawValue(false));
+    expect(localStorage.getItem("mail.user_setting.no_members_default_open")).toBe(null);
+    await click(".o-mail-ActionList-button[title='Members']");
+    await contains(".o-mail-ActionList-button[title='Members'].active"); // just to validate .active is correct selector
+    expect(localStorage.getItem(isMemberPanelOpenByDefaultKey)).toBe(null);
+});
+
+test("sidebar compact is 'on'", async () => {
+    localStorage.setItem("mail.user_setting.discuss_sidebar_compact", "true");
+    await start();
+    await openDiscuss();
+    await contains(".o-mail-DiscussSidebar.o-compact");
+    const isSidebarCompact = makeRecordFieldLocalId(DiscussApp.localId(), "isSidebarCompact");
+    expect(localStorage.getItem(isSidebarCompact)).toBe(toRawValue(true));
+    expect(localStorage.getItem("mail.user_setting.discuss_sidebar_compact")).toBe(null);
+});
+
+test("category 'Channels' is folded", async () => {
+    localStorage.setItem("discuss_sidebar_category_folded_channels", "true");
+    await start();
+    await openDiscuss();
+    await contains(".o-mail-DiscussSidebarCategory:contains('Channels') .oi.oi-chevron-right");
+    const channels_is_open = makeRecordFieldLocalId(
+        DiscussAppCategory.localId("channels"),
+        "is_open"
+    );
+    expect(localStorage.getItem(channels_is_open)).toBe(toRawValue(false));
+    expect(localStorage.getItem("discuss_sidebar_category_folded_channels")).toBe(null);
+});
+
+test("category 'Direct messages' is folded", async () => {
+    localStorage.setItem("discuss_sidebar_category_folded_chats", "true");
+    await start();
+    await openDiscuss();
+    await contains(
+        ".o-mail-DiscussSidebarCategory:contains('Direct messages') .oi.oi-chevron-right"
+    );
+    const chats_is_open = makeRecordFieldLocalId(DiscussAppCategory.localId("chats"), "is_open");
+    expect(localStorage.getItem(chats_is_open)).toBe(toRawValue(false));
+    expect(localStorage.getItem("discuss_sidebar_category_folded_chats")).toBe(null);
+});
+
+test("last active id of discuss app", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    localStorage.setItem(
+        "mail.user_setting.discuss_last_active_id",
+        `discuss.channel_${channelId}`
+    );
+    await start();
+    await openDiscuss();
+    await contains(".o-mail-Thread:contains('Welcome to #test')");
+    const lastActiveId = makeRecordFieldLocalId(DiscussApp.localId(), "lastActiveId");
+    expect(localStorage.getItem(lastActiveId)).toBe(toRawValue(`discuss.channel_${channelId}`));
+    expect(localStorage.getItem("mail.user_setting.discuss_last_active_id")).toBe(null);
+});
+
+test("call auto focus is 'off", async () => {
+    mockGetMedia();
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    localStorage.setItem("mail_user_setting_disable_call_auto_focus", "true");
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await click(".o-discuss-CallActionList [title='More']");
+    await contains(".o-dropdown-item:contains('Autofocus speaker')");
+    // correct local storage values
+    const useCallAutoFocusKey = makeRecordFieldLocalId(Settings.localId(), "useCallAutoFocus");
+    expect(localStorage.getItem(useCallAutoFocusKey)).toBe(toRawValue(false));
+    expect(localStorage.getItem("mail_user_setting_disable_call_auto_focus")).toBe(null);
+});

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -9,6 +9,9 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
+import { toRawValue } from "@mail/utils/common/local_storage";
+import { Settings } from "@mail/core/common/settings_model";
+import { makeRecordFieldLocalId } from "@mail/model/misc";
 import { describe, test, expect } from "@odoo/hoot";
 import { advanceTime } from "@odoo/hoot-mock";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
@@ -94,7 +97,8 @@ test("local storage for call settings", async () => {
     localStorage.setItem("mail_user_setting_background_blur_amount", "3");
     localStorage.setItem("mail_user_setting_edge_blur_amount", "5");
     localStorage.setItem("mail_user_setting_show_only_video", "true");
-    localStorage.setItem("mail_user_setting_use_blur", "true");
+    const useBlurLocalStorageKey = makeRecordFieldLocalId(Settings.localId(), "useBlur");
+    localStorage.setItem(useBlurLocalStorageKey, toRawValue(true));
     patchWithCleanup(localStorage, {
         setItem(key, value) {
             if (key.startsWith("mail_user_setting")) {
@@ -118,12 +122,9 @@ test("local storage for call settings", async () => {
 
     // testing save to local storage
     await click("input[title='Show video participants only']");
-    await expect.waitForSteps([
-        "mail_user_setting_use_blur: true",
-        "mail_user_setting_show_only_video: false",
-    ]);
+    await expect.waitForSteps(["mail_user_setting_show_only_video: false"]);
     await click("input[title='Blur video background']");
-    expect(localStorage.getItem("mail_user_setting_use_blur")).toBe(null);
+    expect(localStorage.getItem(useBlurLocalStorageKey)).toBe(null);
     await editInput(document.body, ".o-Discuss-CallSettings-thresholdInput", 0.3);
     await advanceTime(2000); // threshold setting debounce timer
     await expect.waitForSteps(["mail_user_setting_voice_threshold: 0.3"]);

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -14,7 +14,9 @@ import {
     triggerHotkey,
     waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
-import { DISCUSS_SIDEBAR_COMPACT_LS } from "@mail/core/public_web/discuss_app/discuss_app_model";
+import { toRawValue } from "@mail/utils/common/local_storage";
+import { DiscussApp } from "@mail/core/public_web/discuss_app/discuss_app_model";
+import { makeRecordFieldLocalId } from "@mail/model/misc";
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, drag, press, queryFirst } from "@odoo/hoot-dom";
 import { Deferred, mockDate } from "@odoo/hoot-mock";
@@ -1021,7 +1023,11 @@ test("Can make sidebar smaller", async () => {
 });
 
 test("Sidebar compact is locally persistent (saved in local storage)", async () => {
-    browser.localStorage.setItem(DISCUSS_SIDEBAR_COMPACT_LS, true);
+    const DISCUSS_SIDEBAR_COMPACT_LS = makeRecordFieldLocalId(
+        DiscussApp.localId(),
+        "isSidebarCompact"
+    );
+    browser.localStorage.setItem(DISCUSS_SIDEBAR_COMPACT_LS, toRawValue(true));
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebar.o-compact");
@@ -1038,7 +1044,7 @@ test("Sidebar compact is locally persistent (saved in local storage)", async () 
         position: { x: 0 },
     });
     await contains(".o-mail-DiscussSidebar.o-compact");
-    expect(browser.localStorage.getItem(DISCUSS_SIDEBAR_COMPACT_LS)).toBe("true");
+    expect(browser.localStorage.getItem(DISCUSS_SIDEBAR_COMPACT_LS)).toBe(toRawValue(true));
 });
 
 test("Sidebar compact is crosstab synced", async () => {

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -78,7 +78,9 @@ import { ResUsersSettingsVolumes } from "./mock_server/mock_models/res_users_set
 import { Network } from "@mail/discuss/call/common/rtc_service";
 import { UPDATE_EVENT } from "@mail/discuss/call/common/peer_to_peer";
 import { SoundEffects } from "@mail/core/common/sound_effects_service";
-import { DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
+import { DiscussAppCategory } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
+import { makeRecordFieldLocalId } from "@mail/model/misc";
+import { LocalStorageEntry } from "@mail/utils/common/local_storage";
 
 export * from "./mail_test_helpers_contains";
 
@@ -771,15 +773,19 @@ export function setupChatHub({ opened = [], folded = [] } = {}) {
 }
 
 export function setDiscussSidebarCategoryFoldState(categoryId, val) {
+    const localId = DiscussAppCategory.localId(categoryId);
+    const lse = new LocalStorageEntry(makeRecordFieldLocalId(localId, "is_open"));
     if (val) {
-        localStorage.setItem(`${DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS}${categoryId}`, val);
+        lse.set(!val);
     } else {
-        localStorage.removeItem(`${DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS}${categoryId}`);
+        lse.remove();
     }
 }
 
 export function isDiscussSidebarCategoryFolded(categoryId) {
-    return localStorage.getItem(`${DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS}${categoryId}`) === "true";
+    const localId = DiscussAppCategory.localId(categoryId);
+    const lse = new LocalStorageEntry(makeRecordFieldLocalId(localId, "is_open"));
+    return !(lse.get() ?? true);
 }
 
 export function assertChatHub({ opened = [], folded = [] }) {

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -785,7 +785,7 @@ export function setDiscussSidebarCategoryFoldState(categoryId, val) {
 export function isDiscussSidebarCategoryFolded(categoryId) {
     const localId = DiscussAppCategory.localId(categoryId);
     const lse = new LocalStorageEntry(makeRecordFieldLocalId(localId, "is_open"));
-    return !(lse.get() ?? true);
+    return !(lse.parse()?.value ?? true);
 }
 
 export function assertChatHub({ opened = [], folded = [] }) {


### PR DESCRIPTION
This commit adds versioning to local storage entries, so that when version is more recent than current version, business code can have a strategy to drop the values.

This strategy is the one used by local storage field: older versions are most updated and upgraded fields so 19.1 is implicitly valid for 19.2 and 19.3. 20.0 is invalid as it can potentially be affected by unknown upgrade scripts of current version (19.3), thus it's dropped.

Part of Task-5003012