### PR TITLE
[IMP] l10n_cl: add a button to print an invoice with extra info box

### DIFF
--- a/addons/l10n_cl/views/account_move_view.xml
+++ b/addons/l10n_cl/views/account_move_view.xml
@@ -73,6 +73,19 @@
         <field name="view_mode">list,form</field>
     </record>
 
+    <record id="account_invoices_cl" model="ir.actions.report">
+        <field name="name">Invoices with copy</field>
+        <field name="model">account.move</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">l10n_cl.report_invoice_document_with_box</field>
+        <field name="report_file">l10n_cl.report_invoice_document_with_box</field>
+        <field name="print_report_name">(object._get_report_base_filename())</field>
+        <field name="attachment"/>
+        <field name="binding_model_id" ref="model_account_move"/>
+        <field name="binding_type">report</field>
+        <field name="domain" eval="[('move_type', '!=', 'entry')]"/>
+    </record>
+
     <menuitem id="menu_sale_invoices_credit_notes" parent="account.menu_finance_receivables" sequence="3" action="sale_invoices_credit_notes" name="Sale Invoices and Credit Notes (CL)"/>
     <menuitem id="menu_vendor_bills_and_refunds" parent="account.menu_finance_payables" sequence="3" action="vendor_bills_and_refunds" name="Vendor Bills and Refunds (CL)"/>
 

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -216,6 +216,22 @@
             <span t-out="line_amounts['line_description']" t-options="{'widget': 'text'}"/>
         </xpath>
 
+        <xpath expr="//div[contains(@class, 'invoice_main')]" position="inside">
+            <t t-if="show_details_box">
+                <div style="position: fixed; width: 45%; right: 3%;">
+                    <div style="border: 3px solid black; padding: 1rem;" >
+                        <div style="font-size: 1.5rem"> Nombre : ___________________________________ </div>
+                        <div style="font-size: 1.5rem"> RUT : ______________ FECHA : _______________ </div>
+                        <div style="font-size: 1.5rem"> Recinto : __________  FIRMA : _______________ </div>
+                        <div style="font-size: 1rem"> El acuse de recibo que se declara en este acto, de acuredo a lo dispuesto en la letra b) del art.
+                                                    4 y la letra c) del Art. 5 de la ley 19.983, acredita que la entrega de mercaderia(s) o servicios
+                        </div>
+                    </div>
+                    <div style="font-size: 1.2rem; text-align: right; margin-right: 2rem; margin-top: 1rem; font-weight: bold;"> CEDIBLE </div>
+                </div>
+            </t>
+        </xpath>
+
         <t t-call="account.document_tax_totals" position="attributes">
             <attribute name="t-call">l10n_cl.tax_totals_widget</attribute>
         </t>
@@ -228,8 +244,29 @@
             <t t-if="o._get_name_invoice_report() == 'l10n_cl.report_invoice_document'"
                 t-call="l10n_cl.report_invoice_document" t-lang="lang"/>
         </xpath>
-
     </template>
+
+    <template id="report_invoice_document_with_box">
+        <t t-call="account.report_invoice_document">
+            <t t-set="show_details_box" t-value="True"/>
+        </t>
+    </template>
+
+<!--    <template id="report_invoice_details_box" inherit_id="l10n_cl.report_invoice_document" primary="True">-->
+<!--        <xpath expr="//div[contains(@class, 'invoice_main')]" position="inside">-->
+<!--            <div style="position: fixed; width: 45%; right: 3%;">-->
+<!--                <div style="border: 3px solid black; padding: 1rem;" >-->
+<!--                    <div style="font-size: 1.5rem"> Nombre : ___________________________________ </div>-->
+<!--                    <div style="font-size: 1.5rem"> RUT : ______________ FECHA : _______________ </div>-->
+<!--                    <div style="font-size: 1.5rem"> Recinto : __________  FIRMA : _______________ </div>-->
+<!--                    <div style="font-size: 1rem"> El acuse de recibo que se declara en este acto, de acuredo a lo dispuesto en la letra b) del art. -->
+<!--                                                4 y la letra c) del Art. 5 de la ley 19.983, acredita que la entrega de mercaderia(s) o servicios -->
+<!--                    </div>-->
+<!--                </div>-->
+<!--                <div style="font-size: 1.2rem; text-align: right; margin-right: 2rem; margin-top: 1rem; font-weight: bold;"> CEDIBLE </div>-->
+<!--            </div>-->
+<!--        </xpath>-->
+<!--    </template>-->
 
     <template id="tax_totals_widget" inherit_id="account.document_tax_totals" primary="True">
         <t t-foreach="tax_totals['subtotals']" t-as="subtotal" position="replace">


### PR DESCRIPTION
In chile, if the invoice is yielded physically, a copy with the informational box is required, to be filled if needed by the user, this is for the customers that rely on physical documents, a separate button was created to give the option to either print a normal pdf with no box, or the new pdf with the box 
task-5231303