### PR TITLE
[IMP] account: analytic menu removed if not checked

### DIFF
--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -26,13 +26,13 @@
         <menuitem id="menu_finance_entries" name="Accounting" sequence="4" groups="account.group_account_readonly">
             <menuitem id="menu_action_move_journal_line_form" action="action_move_journal_line" groups="account.group_account_readonly" sequence="1"/>
             <menuitem id="menu_action_account_moves_all" action="action_account_moves_all" groups="account.group_account_readonly" sequence="10"/>
-            <menuitem id="menu_action_analytic_lines_tree" name="Analytic Items" action="analytic.account_analytic_line_action_entries" groups="account.group_account_invoice,account.group_account_readonly,analytic.group_analytic_accounting" sequence="31"/>
+            <menuitem id="menu_action_analytic_lines_tree" name="Analytic Items" action="analytic.account_analytic_line_action_entries" groups="analytic.group_analytic_accounting" sequence="31"/>
         </menuitem>
         <menuitem id="menu_finance_reports" name="Reporting" sequence="20" groups="account.group_account_readonly,account.group_account_invoice">
             <menuitem id="account_reports_partners_reports_menu" name="Partner Reports" sequence="3"/>
             <menuitem id="account_reports_management_menu" name="Management" sequence="4">
                 <menuitem id="menu_action_account_invoice_report_all" name="Invoice Analysis" action="action_account_invoice_report_all" sequence="1"/>
-                <menuitem id="menu_action_analytic_reporting" name="Analytic Report" action="action_analytic_reporting" groups="account.group_account_readonly"/>
+                <menuitem id="menu_action_analytic_reporting" name="Analytic Report" action="action_analytic_reporting" groups="analytic.group_analytic_accounting"/>
             </menuitem>
             <menuitem id="account_reports_legal_statements_menu" name="Statement Reports" sequence="1" groups="account.group_account_readonly"/>
         </menuitem>


### PR DESCRIPTION
Analytic menu is an option to be enabled in the settings which allows the users to access analytic menu, report analytics and analytic menu configuration. However, even when not checked those menus still appear to the user, thus this change which removes ( hides ) these menus from the ui if the user does not check the analytics in the settings

task: 5231336