### PR TITLE
[FIX] hr_holidays: fix the error when selecting Time Off Type

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -283,7 +283,7 @@ class HrLeaveType(models.Model):
         leave_types = self.env['hr.leave.type'].search([])
 
         def is_valid(leave_type):
-            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves)
+            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves, value)
         return [('id', 'in', leave_types.filtered(is_valid).ids)]
 
     @api.depends_context('employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -35,3 +35,4 @@ from . import test_multi_contract
 from . import test_time_off_allocation_tour
 from . import test_flexible_resource_calendar
 from . import test_calendar_leaves_count
+from . import test_leave_type

--- a/addons/hr_holidays/tests/test_leave_type.py
+++ b/addons/hr_holidays/tests/test_leave_type.py
@@ -1,0 +1,31 @@
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestSearchVirtualRemainingLeaves(TransactionCase):
+
+    def test_search_virtual_remaining_leaves(self):
+        test_employee = self.env['hr.employee'].create({
+            'name': 'Test Employee',
+        })
+
+        test_leave_type = self.env['hr.leave.type'].create({
+                'name': 'Test Leave Type',
+                'requires_allocation': True,
+            })
+
+        test_allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Test Leave Type Allocation',
+            'holiday_status_id': test_leave_type.id,
+            'number_of_days': 1,
+            'employee_id': test_employee.id,
+            'state': 'confirm',
+        })
+        test_allocation.action_approve()
+
+        result_types = self.env['hr.leave.type'].with_context(employee_id=test_employee.id).search([
+                            ('virtual_remaining_leaves', '>', 0)
+                        ])
+
+        self.assertIn(test_leave_type, result_types)


### PR DESCRIPTION
This fixed an error which appeared by choosing a Time Off Type in new Time Off

task-5380599

_Edit (new commit description):_ 

Problem
---------
Selecting a Time Off Type during the Time Off creation flow triggers a traceback:
Time Off → Configuration → Time Off Types → open any type → Time Off smart button → New → select Time Off Type.
The same error occurs when selecting the Time Off Type in the Management flow.

The issue happens because the method `is_valid` is called by a domain operator expecting
a two-argument signature, but the method only provided one argument,
causing a `TypeError`.

Objective
----------
Ensure that selecting a Time Off Type no longer crashes and that the domain on
`virtual_remaining_leaves` evaluates correctly.

Solution
----------
Add the second argument('value') to the operator in the method `is_valid`:

Before:
    op(leave_type.virtual_remaining_leaves)

After:
    op(leave_type.virtual_remaining_leaves, value)

A unit test has been added.

task-5380599