### PR TITLE
[FIX] hr_holidays: fix traceback bug when selecting leave type

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -283,7 +283,7 @@ class HrLeaveType(models.Model):
         leave_types = self.env['hr.leave.type'].search([])
 
         def is_valid(leave_type):
-            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves)
+            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves, value)
         return [('id', 'in', leave_types.filtered(is_valid).ids)]
 
     @api.depends_context('employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -114,3 +114,21 @@ class TestHrLeaveType(TestHrHolidaysCommon):
             ).search([('has_valid_allocation', '=', True)], limit=1)
 
         self.assertFalse(leave_types, "Got valid leaves outside vaild period")
+
+    def test_search_virtual_remaining_leaves(self):
+        self.env['hr.leave.type'].create({
+            'name': 'leave_with_allocation',
+            'time_type': 'leave',
+            'requires_allocation': True,
+            'virtual_remaining_leaves': 100,
+        })
+
+        self.env['hr.leave.type'].create({
+            'name': 'leave_without_allocation',
+            'time_type': 'leave',
+            'requires_allocation': False,
+            'virtual_remaining_leaves': 100,
+        })
+
+        self.assertNotIn('leave_with_allocation', self.env['hr.leave.type'].search(domain=[('virtual_remaining_leaves', '>', 0)]).mapped('name'))
+        self.assertIn('leave_without_allocation', self.env['hr.leave.type'].search(domain=[('virtual_remaining_leaves', '>', 0)]).mapped('name'))


### PR DESCRIPTION
[FIX] hr_holidays: fix traceback bug when selecting leave type

Steps to reproduce:

- On the Time Off app go to Configuration -> Time Off Types
- Select any time off type the click the Time Off smart button
- Click new and on the creation form try changing the Time Off type for an employee

Cause of the bug:

- The function that compares the leave type days and the employee's remaining leave days
only gets the leave type days as an input, the other argument is missing

Fix done:

- Passing the input value as the second argument for the op(v1, v2) function

task-5380284