### PR TITLE
[FIX] hr_holidays: fix leave type operator

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -283,7 +283,7 @@ class HrLeaveType(models.Model):
         leave_types = self.env['hr.leave.type'].search([])
 
         def is_valid(leave_type):
-            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves)
+            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves, value)
         return [('id', 'in', leave_types.filtered(is_valid).ids)]
 
     @api.depends_context('employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -114,3 +114,37 @@ class TestHrLeaveType(TestHrHolidaysCommon):
             ).search([('has_valid_allocation', '=', True)], limit=1)
 
         self.assertFalse(leave_types, "Got valid leaves outside vaild period")
+
+    def test_search_virtual_remaining_leaves(self):
+        employee = self.env['hr.employee'].create({'name': 'Virtual Remaining Leaves Employee'})
+
+        unlimited_type = self.env['hr.leave.type'].create({
+            'name': 'Unlimited Time Off',
+            'requires_allocation': False,
+        })
+
+        allocated_type = self.env['hr.leave.type'].create({
+            'name': 'Allocated Time Off',
+            'requires_allocation': True,
+        })
+
+        self.env['hr.leave.allocation'].sudo().create({
+            'name': 'Allocation',
+            'holiday_status_id': allocated_type.id,
+            'employee_id': employee.id,
+            'number_of_days': 3,
+            'state': 'confirm',
+        }).action_approve()
+
+        no_allocation_type = self.env['hr.leave.type'].create({
+            'name': 'No Allocation Time Off',
+            'requires_allocation': True,
+        })
+
+        matching_types = self.env['hr.leave.type'].with_context(employee_id=employee.id).search([
+            ('virtual_remaining_leaves', '>=', 1),
+        ])
+
+        self.assertIn(unlimited_type, matching_types)
+        self.assertIn(allocated_type, matching_types)
+        self.assertNotIn(no_allocation_type, matching_types)


### PR DESCRIPTION
The domain helper did not pass the comparison value to the operator, leading to crashes in allocation-based leave types.

Task: 5381490