### PR TITLE
[FIX] hr: new contract button invisible

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -374,7 +374,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <label for="wage"/>
                                         <div class="o_row" name="wage">


### PR DESCRIPTION
Description of the issue/feature this PR addresses: In the employee's payroll page, the "New Contract" button is visible even if an employee doesn't have the contract start date set. This PR ensures the button for creating a contract is only visible when the contract start date field is populated.

Current behavior before PR: "New Contract" button visible regardless of start date 

Desired behavior after PR is merged: "New Contract" button is only visible when the contract start date for an employee is set


task: 5446065


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
