### PR TITLE
[FIX] hr_payroll: restrict New Contract button visibility

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -374,7 +374,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <label for="wage"/>
                                         <div class="o_row" name="wage">


### PR DESCRIPTION

**Steps to reproduce**: Open an Employee form (via Payroll or Employees module). Navigate to the "_Payroll_" tab and locate the "_Contract Overview_" section. Observe that the "_New Contract_" button is visible even when no contract start date is present.

**Bug Cause**: The button lacked a visibility attribute, causing it to render by default regardless of the state of the contract date fields.

**Solution**: Added a conditional visibility attribute to the button so it remains hidden until a contract start date is defined.

task - 5447340