### PR TITLE
[FIX] hr_holidays: fix time-off traceback

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -282,7 +282,7 @@ class HrLeaveType(models.Model):
         leave_types = self.env['hr.leave.type'].search([])
 
         def is_valid(leave_type):
-            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves)
+            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves, value)
         return [('id', 'in', leave_types.filtered(is_valid).ids)]
 
     @api.depends_context('uid', 'employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -114,3 +114,24 @@ class TestHrLeaveType(TestHrHolidaysCommon):
             ).search([('has_valid_allocation', '=', True)], limit=1)
 
         self.assertFalse(leave_types, "Got valid leaves outside vaild period")
+
+    def test_virtual_leave_search(self):
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Paid Time Off',
+            'time_type': 'leave',
+            'requires_allocation': False,
+        })
+        employee = self.env['hr.employee'].create({'name': 'Test Employee'})
+        employee_allocation = self.env['hr.leave.allocation'].create({
+            'employee_id': employee.id,
+            'holiday_status_id': leave_type.id,
+            'allocation_type': 'regular',
+            'number_of_days': 3
+        })
+        employee_allocation.action_approve()
+
+        matching_types = self.env['hr.leave.type'].with_context(employee_id=employee.id).search([
+            ('virtual_remaining_leaves', '>=', 1),
+        ])
+
+        self.assertIn( leave_type, matching_types)


### PR DESCRIPTION
This fixes a traceback raised by trying to create a timeoff using the
smart buttons on time-off types

Steps to reproduce: Time Off >> Configuration >> Time Off Types >> Open
any type, navigate to the Smart button Time Off >> Click on New >> Time
Off Type (Leads to an error.)

Bug cause: Missing second argument of the comparison operation in the
search function

Solution: Add the value entered by the user to the comparison with
remaining virtual leaves operator function

task-5447241
