### PR TITLE
[FIX] hr: New Contract button Invisible on no contract

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -374,7 +374,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <label for="wage"/>
                                         <div class="o_row" name="wage">


### PR DESCRIPTION
Steps to reproduce:
1. Open "Employees" App
2. Click on any employee
3. Click on the "Payroll" Tab
4. Make sure "contract" date is empty

Bug cause:
The "button_new_contract" widget in the employee_form view is always displayed because it does not define an invisible condition.

Solution:
Added an invisible condition to the button_new_contract widget so it is shown only when the contract start date is set.

task-447352