### PR TITLE
[FIX] hr_holidays: Fix _search_virtual_remaining_leaves missing value parameter

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -282,7 +282,7 @@ class HrLeaveType(models.Model):
         leave_types = self.env['hr.leave.type'].search([])
 
         def is_valid(leave_type):
-            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves)
+            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves, value)
         return [('id', 'in', leave_types.filtered(is_valid).ids)]
 
     @api.depends_context('uid', 'employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -35,3 +35,4 @@ from . import test_multi_contract
 from . import test_time_off_allocation_tour
 from . import test_flexible_resource_calendar
 from . import test_calendar_leaves_count
+from . import test_search_virtual_remaining_leaves

--- a/addons/hr_holidays/tests/test_search_virtual_remaining_leaves.py
+++ b/addons/hr_holidays/tests/test_search_virtual_remaining_leaves.py
@@ -1,0 +1,268 @@
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+
+
+class TestSearchVirtualRemainingLeaves(TestHrHolidaysCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        
+        cls.test_employee = cls.env['hr.employee'].create({
+            'name': 'Test Employee for Search',
+            'company_id': cls.company.id,
+        })
+        cls.leave_type_with_allocation = cls.env['hr.leave.type'].create({
+            'name': 'Leave Type With Allocation',
+            'requires_allocation': True,
+            'request_unit': 'day',
+            'company_id': cls.company.id,
+        })
+        
+        cls.leave_type_no_allocation = cls.env['hr.leave.type'].create({
+            'name': 'Leave Type No Allocation',
+            'requires_allocation': False,
+            'request_unit': 'day',
+            'company_id': cls.company.id,
+        })
+        
+        cls.leave_type_with_hours = cls.env['hr.leave.type'].create({
+            'name': 'Leave Type Hours',
+            'requires_allocation': True,
+            'request_unit': 'hour',
+            'company_id': cls.company.id,
+        })
+
+    def test_search_virtual_remaining_leaves_greater_than(self):
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Test Allocation',
+            'holiday_status_id': self.leave_type_with_allocation.id,
+            'employee_id': self.test_employee.id,
+            'number_of_days': 10,
+            'date_from': '2025-01-01',
+            'date_to': '2025-12-31',
+        })
+        allocation.action_approve()
+        
+        leave_types = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '>', 5)
+        ])
+        self.assertIn(self.leave_type_with_allocation, leave_types)
+        self.assertIn(self.leave_type_no_allocation, leave_types)
+
+    def test_search_virtual_remaining_leaves_less_than(self):
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Small Allocation',
+            'holiday_status_id': self.leave_type_with_allocation.id,
+            'employee_id': self.test_employee.id,
+            'number_of_days': 3,
+            'date_from': '2025-01-01',
+            'date_to': '2025-12-31',
+        })
+        allocation.action_approve()
+        
+        leave_types = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '<', 5)
+        ])
+        self.assertIn(self.leave_type_with_allocation, leave_types)
+
+    def test_search_virtual_remaining_leaves_equal(self):
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Exact Allocation',
+            'holiday_status_id': self.leave_type_with_allocation.id,
+            'employee_id': self.test_employee.id,
+            'number_of_days': 15,
+            'date_from': '2025-01-01',
+            'date_to': '2025-12-31',
+        })
+        allocation.action_approve()
+        
+        leave_types = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '=', 15)
+        ])
+        self.assertIn(self.leave_type_with_allocation, leave_types)
+
+    def test_search_virtual_remaining_leaves_greater_equal(self):
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Large Allocation',
+            'holiday_status_id': self.leave_type_with_allocation.id,
+            'employee_id': self.test_employee.id,
+            'number_of_days': 20,
+            'date_from': '2025-01-01',
+            'date_to': '2025-12-31',
+        })
+        allocation.action_approve()
+        
+        leave_types = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '>=', 20)
+        ])
+        self.assertIn(self.leave_type_with_allocation, leave_types)
+        leave_types_exact = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '>=', 20)
+        ])
+        
+        self.assertIn(self.leave_type_with_allocation, leave_types_exact)
+
+    def test_search_virtual_remaining_leaves_less_equal(self):
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Medium Allocation',
+            'holiday_status_id': self.leave_type_with_allocation.id,
+            'employee_id': self.test_employee.id,
+            'number_of_days': 8,
+            'date_from': '2025-01-01',
+            'date_to': '2025-12-31',
+        })
+        allocation.action_approve()
+        
+        leave_types = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '<=', 10)
+        ])
+        self.assertIn(self.leave_type_with_allocation, leave_types)
+
+    def test_search_virtual_remaining_leaves_not_equal(self):
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Allocation',
+            'holiday_status_id': self.leave_type_with_allocation.id,
+            'employee_id': self.test_employee.id,
+            'number_of_days': 12,
+            'date_from': '2025-01-01',
+            'date_to': '2025-12-31',
+        })
+        allocation.action_approve()
+        
+        leave_types = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '!=', 5)
+        ])
+        self.assertIn(self.leave_type_with_allocation, leave_types)
+
+    def test_search_with_taken_leaves(self):
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Initial Allocation',
+            'holiday_status_id': self.leave_type_with_allocation.id,
+            'employee_id': self.test_employee.id,
+            'number_of_days': 15,
+            'date_from': '2025-01-01',
+            'date_to': '2025-12-31',
+        })
+        allocation.action_approve()
+        leave = self.env['hr.leave'].create({
+            'name': 'Test Leave',
+            'holiday_status_id': self.leave_type_with_allocation.id,
+            'employee_id': self.test_employee.id,
+            'request_date_from': '2025-06-01',
+            'request_date_to': '2025-06-05',
+            'number_of_days': 5,
+        })
+        leave.action_approve()
+        leave_types = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '>', 0)
+        ])
+        self.assertIn(self.leave_type_with_allocation, leave_types)
+        remaining = self.leave_type_with_allocation.with_context(
+            employee_id=self.test_employee.id
+        ).virtual_remaining_leaves
+        self.assertGreater(remaining, 0)
+        self.assertLess(remaining, 15)
+
+    def test_search_without_employee_context(self):
+        leave_types = self.env['hr.leave.type'].search([
+            ('virtual_remaining_leaves', '>', 0)
+        ])
+        self.assertTrue(isinstance(leave_types, type(self.env['hr.leave.type'])))
+
+    def test_search_no_allocation_leave_type(self):
+        leave_types = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '>=', 0)
+        ])
+        self.assertIn(self.leave_type_no_allocation, leave_types)
+
+    def test_search_with_multiple_allocations(self):
+        allocation1 = self.env['hr.leave.allocation'].create({
+            'name': 'First Allocation',
+            'holiday_status_id': self.leave_type_with_allocation.id,
+            'employee_id': self.test_employee.id,
+            'number_of_days': 10,
+            'date_from': '2025-01-01',
+            'date_to': '2025-06-30',
+        })
+        allocation1.action_approve()
+        
+        allocation2 = self.env['hr.leave.allocation'].create({
+            'name': 'Second Allocation',
+            'holiday_status_id': self.leave_type_with_allocation.id,
+            'employee_id': self.test_employee.id,
+            'number_of_days': 5,
+            'date_from': '2025-07-01',
+            'date_to': '2025-12-31',
+        })
+        allocation2.action_approve()
+        leave_types = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '>=', 1)
+        ])
+        self.assertIn(self.leave_type_with_allocation, leave_types)
+
+    def test_search_with_draft_allocation(self):
+        self.env['hr.leave.allocation'].create({
+            'name': 'Draft Allocation',
+            'holiday_status_id': self.leave_type_with_allocation.id,
+            'employee_id': self.test_employee.id,
+            'number_of_days': 100,
+            'date_from': '2025-01-01',
+            'date_to': '2025-12-31',
+        })
+        leave_types = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '>', 50)
+        ])
+        if self.leave_type_with_allocation in leave_types:
+            self.assertLess(
+                self.leave_type_with_allocation.with_context(
+                    employee_id=self.test_employee.id
+                ).virtual_remaining_leaves,
+                50
+            )
+
+    def test_search_with_hours_unit(self):
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Hours Allocation',
+            'holiday_status_id': self.leave_type_with_hours.id,
+            'employee_id': self.test_employee.id,
+            'number_of_hours_display': 40,
+            'date_from': '2025-01-01',
+            'date_to': '2025-12-31',
+        })
+        allocation.action_approve()
+        leave_types = self.env['hr.leave.type'].with_context(
+            employee_id=self.test_employee.id
+        ).search([
+            ('virtual_remaining_leaves', '>', 20)
+        ])
+        if self.leave_type_with_hours in leave_types:
+            remaining = self.leave_type_with_hours.with_context(
+                employee_id=self.test_employee.id
+            ).virtual_remaining_leaves
+            self.assertGreater(remaining, 20)
+
+    def test_search_invalid_operator(self):
+        result = self.leave_type_with_allocation._search_virtual_remaining_leaves('invalid_op', 10)
+        self.assertEqual(result, NotImplemented)


### PR DESCRIPTION
**Steps to reproduce:**
1. Navigate to Time Off >> Configuration >> Time Off Types
2. Open any leave type
3. Click on Smart button "Time Off"
4. Click on "New" to create a new allocation
5. Try to search leave types by virtual_remaining_leaves with comparison operators
6. Run test suite: test_search_virtual_remaining_leaves.py

**Bug cause:**
The `_search_virtual_remaining_leaves` method was missing the `value` parameter
when calling the comparison operator function `op()`. The method was:
  - Retrieving the correct operator from PY_OPERATORS dict
  - Converting the search value to float
  But then failed to pass this `value` to the operator when executing the comparison:
  `op(leave_type.virtual_remaining_leaves)` instead of
  `op(leave_type.virtual_remaining_leaves, value)`

This caused the search to fail silently or return incorrect results when
filtering leave types by virtual remaining leaves.

**Solution:**
Added the missing `value` parameter to the operator call:
  `return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves, value)`

This ensures the comparison operator has both operands (the leave type's
virtual_remaining_leaves and the search value) needed to perform the comparison.

**Tests status:** All 13 tests in test_search_virtual_remaining_leaves.py now passing ✓

Task Id: 5447343