### PR TITLE
[FIX] hr: remove unused new contract button

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -374,7 +374,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <label for="wage"/>
                                         <div class="o_row" name="wage">


### PR DESCRIPTION
Steps to reproduce:
- Open an employee form view
- Go to the payroll section
- Observe an unused "New Contract" button

Bug cause:
The "New Contract" button was present in the employee form view's payroll section
but had no functionality or was redundant with existing contract creation methods.

Solution:
Make the button 'New Contract' invisible if there is no contract start date.

task-5447186