### PR TITLE
[FIX] hr_holidays: Fixed Traceback on Time Off Type Issue

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -282,7 +282,7 @@ class HrLeaveType(models.Model):
         leave_types = self.env['hr.leave.type'].search([])
 
         def is_valid(leave_type):
-            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves)
+            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves, value)
         return [('id', 'in', leave_types.filtered(is_valid).ids)]
 
     @api.depends_context('uid', 'employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -114,3 +114,32 @@ class TestHrLeaveType(TestHrHolidaysCommon):
             ).search([('has_valid_allocation', '=', True)], limit=1)
 
         self.assertFalse(leave_types, "Got valid leaves outside vaild period")
+
+    def test_search_virtual_remaining_leaves_with_allocation(self):
+        leave_type_with_alloc = self.env['hr.leave.type'].create({
+            'name': 'Paid Time Off (Allocated)',
+            'requires_allocation': True
+        })
+
+        alloc = self.env['hr.leave.allocation'].create({
+            'name': 'Ten Days Allocation',
+            'holiday_status_id': leave_type_with_alloc.id,
+            'number_of_days': 10,
+            'employee_id': self.employee_emp.id,
+            'state': 'confirm',
+        })
+        alloc.action_approve()
+
+        search_results = self.env['hr.leave.type'].with_user(self.user_employee).search([('virtual_remaining_leaves', '>', 5)])
+
+        self.assertIn(leave_type_with_alloc, search_results, "The leave type should be found as it has 7 virtual days left.")
+
+    def test_search_virtual_remaining_leaves_without_allocation(self):
+        leave_type_no_alloc = self.env['hr.leave.type'].create({
+            'name': 'Sick Leave (Non-Allocated)',
+            'requires_allocation': False
+        })
+
+        search_results = self.env['hr.leave.type'].with_user(self.user_employee).search([('virtual_remaining_leaves', '>', 5)])
+
+        self.assertIn(leave_type_no_alloc, search_results, "The leave type should be found as it has infinite virtual days left.")


### PR DESCRIPTION
Steps to reproduce:
1. Time Off >> Configuration >> Time Off Types >> Open any type, navigate to the Smart button Time Off >> Click on New >> Time Off Type
Leads to a traceback error.

Bug cause:
The op function called in _search_virtual_remaining_leaves method expects two values [ie. op(value1, value2)], but only one was passed. This led to the traceback error.

Solution:
Passed a second parameter "value" in the op function call.

task-5449083