### PR TITLE
[FIX] hr_holidays: fix crash when filtering or searching on Time Off Types

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -282,7 +282,7 @@ class HrLeaveType(models.Model):
         leave_types = self.env['hr.leave.type'].search([])
 
         def is_valid(leave_type):
-            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves)
+            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves, value)
         return [('id', 'in', leave_types.filtered(is_valid).ids)]
 
     @api.depends_context('uid', 'employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -114,3 +114,21 @@ class TestHrLeaveType(TestHrHolidaysCommon):
             ).search([('has_valid_allocation', '=', True)], limit=1)
 
         self.assertFalse(leave_types, "Got valid leaves outside vaild period")
+
+    def test_search_virtual_remaining_leaves_operator(self):
+        leave_type_allow = self.env['hr.leave.type'].create({
+            'name': 'custom leave',
+            'requires_allocation': True,
+        })
+        allocation = self.env['hr.leave.allocation'].create({
+            'state': 'confirm',
+            'holiday_status_id': leave_type_allow.id,
+            'employee_id': self.employee_emp.id,
+            'number_of_days': 10
+        })
+        allocation.action_approve()
+        self.assertEqual(allocation.state, 'validate')
+        result = self.env['hr.leave.type'].with_user(self.user_employee).search([
+            ('virtual_remaining_leaves', '=', 10)
+        ])
+        self.assertIn(leave_type_allow, result, "Search results not found")


### PR DESCRIPTION
**Steps to reproduce**:
1. Go to _Time Off_ -> _Configuration_ -> _Time Off Types_.
2. Open any record.
3. Attempt to search or trigger a recomputation involving the "_Virtual Remaining Leaves_" field.
4. The system raises a TypeError.

Bug Cause:
The search method `__search_virtual_remaining_leaves_` contains an internal `is_valid` helper function. This function attempts to call a comparison operator (e.g., `operator.gt`, `operator.lt`) by passing only a single argument. Since these operator methods require two arguments to perform a comparison, the process fails.

Solution:
Update the `is_valid` method to correctly pass the comparison value (the right-hand operand) to the operator, ensuring the search domain is evaluated correctly without crashing.

task - 5449122