### PR TITLE
[FIX] hr_holidays: dynamic day selection for accrual plan milestones

### DIFF
--- a/addons/hr_holidays/static/src/components/accrual_level/day_selector/day_selector.js
+++ b/addons/hr_holidays/static/src/components/accrual_level/day_selector/day_selector.js
@@ -1,0 +1,47 @@
+import { registry } from "@web/core/registry";
+import { SelectionField } from "@web/views/fields/selection/selection_field";
+import { useEffect } from "@odoo/owl";
+
+
+export class DaySelector extends SelectionField {
+    setup() {
+        super.setup();
+        
+        useEffect(
+            (monthValue) => {
+                if (monthValue) {
+                    const maxDay = this.getMaxDay(monthValue);
+                    const currentDay = parseInt(this.props.record.data[this.props.name]);
+
+                    if (currentDay > maxDay) {
+                        this.props.record.update({ [this.props.name]: maxDay.toString() });
+                    }
+                }
+            },
+            () => [this.props.record.data[this.props.month]]
+        );
+    }
+
+    getMaxDay(monthValue) {
+        const year = new Date().getFullYear();
+        return new Date(year, parseInt(monthValue), 0).getDate();
+    }
+
+    get options() {
+        const monthValue = this.props.record.data[this.props.month];
+        if (!monthValue) return [];
+
+        const maxDay = this.getMaxDay(monthValue);
+        return Array.from({ length: maxDay }, (_, i) => [(i + 1).toString(), (i + 1).toString()]);
+    }
+}
+
+export const daySelector = {
+    component: DaySelector,
+    supportedTypes: ["selection"],
+    extractProps: ({ attrs }) => ({
+        month: attrs.month, 
+    }),
+};
+
+registry.category("fields").add("day_selector", daySelector);

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,17 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'" widget="day_selector" month="first_month"/>
                                     of
                                     <field name="first_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'" widget="day_selector" month="second_month"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a day" widget="day_selector" month="yearly_month"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -193,7 +193,7 @@
                                         <span id="carryover_custom_date">
                                             : the
                                             <field name="carryover_day" placeholder="select a day"
-                                                   required="carryover_date == 'other'"/>
+                                                   required="carryover_date == 'other'" widget="day_selector" month="carryover_month"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"
                                                    required="carryover_date == 'other'"/>


### PR DESCRIPTION
Bug reproduction steps:
1. Go to Time Off -> Configuration -> Accrual Plans.
2. Create or edit a plan and add/edit a Milestone.
3. Set the frequency to 'Yearly' or 'Twice a year'.
4. Observe that the 'Day of month' selection allows choosing '31' even if the selected month is February or April.

Bug cause:
The 'day' and 'month' fields were treated as independent selection fields. The day field used a static selection list (1-31) defined in the Python model, which did not account for the varying lengths of months. This allowed for invalid dates like February 31st to be saved in the database.

Solution:
Created a new OWL field widget 'day_selector' that extends the standard SelectionField.
- The widget accepts a 'month' attribute via the view to track the sibling month field.
- It dynamically computes the 'options' list based on the selected month using a JavaScript Date logic.
- It utilizes a 'useEffect' hook to monitor changes in the month field; if the month changes to one with fewer days than the currently selected day, the widget automatically updates the record to the maximum valid day for that month (e.g., shifting 31 to 30 or 28).
- Updated the accrual plan form view to apply this widget to the milestone day fields.

task - 5468807
