### PR TITLE
[FIX] hr_holidays: day selection fix in accrual ux

### DIFF
--- a/addons/hr_holidays/static/src/components/day_selector/day_selector.js
+++ b/addons/hr_holidays/static/src/components/day_selector/day_selector.js
@@ -1,0 +1,41 @@
+import { registry } from "@web/core/registry";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { Component } from "@odoo/owl";
+import { SelectionField } from "@web/views/fields/selection/selection_field";
+
+function getDaysInMonth(year, month) {
+    return new Date(year, month, 0).getDate();
+}
+export class DaySelector extends SelectionField {
+    static template = "web.SelectionField";
+    static props = { ...standardFieldProps, month: { type: String } };
+
+    get options() {
+        let all_days = [];
+        let current_month = this.props.record.data[this.props.month];
+        let leap_year_example = 2024
+        let max_day = getDaysInMonth(leap_year_example, current_month);
+        for (let i = 1; i <= max_day; i++) {
+            all_days.push([i.toString(), i.toString()]);
+        }
+        return all_days;
+    }
+
+    async onDayChange(ev) {
+        const newValue = ev.target.value;
+        await this.props.update(newValue);
+    }
+}
+
+export const daySelector = {
+    ...SelectionField,
+    component: DaySelector,
+    supportedTypes: ["selection"],
+    extractProps: ({ attrs }) => {
+        return {
+            month: attrs.month
+        };
+    },
+};
+
+registry.category("fields").add("day_selector", daySelector);

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,17 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'" widget="day_selector" month="first_month"/>
                                     of
                                     <field name="first_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'" widget="day_selector" month="second_month"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a day" widget="day_selector" month="yearly_month"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -192,8 +192,8 @@
                                                options="{'links': {'other': 'carryover_custom_date'}, 'observe': 'carryover'}"/>
                                         <span id="carryover_custom_date">
                                             : the
-                                            <field name="carryover_day" placeholder="select a day"
-                                                   required="carryover_date == 'other'"/>
+                                            <field name="carryover_day" placeholder="select a day" style="width: auto"
+                                                   required="carryover_date == 'other'" widget="day_selector" month="carryover_month"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"
                                                    required="carryover_date == 'other'"/>


### PR DESCRIPTION
Bug reproduction steps: Timeoff->Configuration->Accrual Reports, when adding milestones you can select all days from 1 to 31 independently from the month when you selected yearly or twice a year options.
Bug cause: The days are kept with selection field and this selection field takes all the values in between 1-31.
Solution: Creating a new widget that extends selection field and arranges the shown days according to the received month props

task - 5463057