### PR TITLE
[FIX] web_editor: fix image upload error handling

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.js
@@ -140,10 +140,23 @@ export class ImageSelector extends FileSelector {
     }
 
     async uploadFiles(files) {
-        const uploadResult = await this.uploadService.uploadFilesWithAbort(files, { resModel: this.props.resModel, resId: this.props.resId, isImage: true }, (attachment) => this.onUploaded(attachment));
-        this.props.abortUploads(() => uploadResult.abort());
-        await uploadResult.promise;
-    }
+        let abortFn;
+
+        const uploadPromise = this.uploadService.uploadFiles(
+            files,
+            {
+                resModel: this.props.resModel,
+                resId: this.props.resId,
+                isImage: true,
+            },
+            (attachment) => this.onUploaded(attachment),
+            (abort) => {
+                abortFn = abort;
+            }
+        );
+        this.props.setAbortUploadsCallback(() => abortFn?.());
+        await uploadPromise;
+}
 
     async uploadUrl(url) {
         await fetch(url).then(async result => {

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -100,7 +100,7 @@ export class MediaDialog extends Component {
                 selectedMedia: this.selectedMedia,
                 selectMedia: (...args) => this.selectMedia(...args, tab.id, additionalProps.multiSelect),
                 save: this.save.bind(this),
-                abortUploads: (abortFunc) => this.abortUploads = abortFunc,
+                setAbortUploadsCallback: (abortFunc) => this.abortUploads = abortFunc,
                 onAttachmentChange: this.props.onAttachmentChange,
                 errorMessages: (errorMessage) => this.errorMessages[tab.id] = errorMessage,
                 modalRef: this.modalRef,

--- a/addons/web_editor/static/src/components/upload_progress_toast/upload_service.js
+++ b/addons/web_editor/static/src/components/upload_progress_toast/upload_service.js
@@ -97,11 +97,34 @@ export const uploadService = {
              * @param {Array<File>} files
              * @param {Object} options
              * @param {Function} onUploaded
+             * @param {Function} setAbortCallback // Optional - To abort uploads
              */
-            uploadFiles: async (files, {resModel, resId, isImage}, onUploaded) => {
+            uploadFiles: async (
+                files,
+                { resModel, resId, isImage },
+                onUploaded,
+                setAbortCallback
+            ) => {
                 // Upload the smallest file first to block the user the least possible.
                 const sortedFiles = Array.from(files).sort((a, b) => a.size - b.size);
+
+                const controller = new AbortController();
+                const { signal } = controller;
+
+                let currentXHR = null;
+                let addAttachmentRpc = null;
+
+                setAbortCallback?.(() => {
+                    controller.abort();
+                    addAttachmentRpc?.abort?.();
+                    currentXHR?.abort?.();
+                });
+
                 for (const file of sortedFiles) {
+                    if (signal.aborted) {
+                        return;
+                    }
+
                     let fileSize = file.size;
                     if (!checkFileSize(fileSize, notification)) {
                         return null;
@@ -126,10 +149,17 @@ export const uploadService = {
                 // Upload one file at a time: no need to parallel as upload is
                 // limited by bandwidth.
                 for (const sortedFile of sortedFiles) {
+                    if (signal.aborted) {
+                        break;
+                    }
+
                     const file = progressToast.files[sortedFile.progressToastId];
                     let dataURL;
                     try {
                         dataURL = await getDataURLFromFile(sortedFile);
+                        if (signal.aborted) {
+                            break;
+                        }
                     } catch {
                         deleteFile(file.id);
                         env.services.notification.add(
@@ -139,232 +169,84 @@ export const uploadService = {
                             ),
                             { type: 'danger' }
                         );
-                        continue
+                        continue;
                     }
+
+                    currentXHR = new XMLHttpRequest();
+                    addAttachmentRpc = null;
+
+                    const onProgress = (ev) => {
+                        if (ev.lengthComputable) {
+                            file.progress = (ev.loaded / ev.total) * 100;
+                        }
+                    };
+                    const onLoad = () => (file.progress = 100);
+
+                    currentXHR.upload.addEventListener("progress", onProgress);
+                    currentXHR.upload.addEventListener("load", onLoad);
+
                     try {
-                        const xhr = new XMLHttpRequest();
-                        xhr.upload.addEventListener('progress', ev => {
-                            const rpcComplete = ev.loaded / ev.total * 100;
-                            file.progress = rpcComplete;
-                        });
-                        xhr.upload.addEventListener('load', function () {
-                            // Don't show yet success as backend code only starts now
-                            file.progress = 100;
-                        });
-                        const attachment = await rpc('/web_editor/attachment/add_data', {
-                            'name': file.name,
-                            'data': dataURL.split(',')[1],
-                            'res_id': resId,
-                            'res_model': resModel,
-                            'is_image': !!isImage,
-                            'width': 0,
-                            'quality': 0,
-                        }, {xhr});
+                        addAttachmentRpc = rpc(
+                            "/web_editor/attachment/add_data",
+                            {
+                                name: file.name,
+                                data: dataURL.split(",")[1],
+                                res_id: resId,
+                                res_model: resModel,
+                                is_image: !!isImage,
+                                width: 0,
+                                quality: 0,
+                            },
+                            { xhr: currentXHR }
+                        );
+
+                        const attachment = await addAttachmentRpc;
+                        if (signal.aborted) {
+                            break;
+                        }
+
                         if (attachment.error) {
                             file.hasError = true;
                             file.errorMessage = attachment.error;
                         } else {
-                            if (attachment.mimetype === 'image/webp') {
-                                // Generate alternate format for reports.
-                                await convertWebpToJpeg(
-                                    dataURL,
-                                    file.name,
-                                    attachment.id
-                                );
+                            if (attachment.mimetype === "image/webp") {
+                                try {
+                                    // Generate alternate format for reports.
+                                    await convertWebpToJpeg(
+                                        dataURL,
+                                        file.name,
+                                        attachment.id
+                                    );
+                                } catch (convErr) {
+                                    console.warn(
+                                        "[uploadService] webp conversion failed:",
+                                        convErr
+                                    );
+                                }
                             }
                             file.uploaded = true;
                             await onUploaded(attachment);
                         }
-                        setTimeout(() => deleteFile(file.id), AUTOCLOSE_DELAY);
-                    } catch (error) {
+                    } catch (err) {
+                        if (signal.aborted) {
+                            break;
+                        }
                         file.hasError = true;
+                        console.error("Upload error:", err);
+                        throw err;
+                    } finally {
+                        currentXHR.upload.removeEventListener(
+                            "progress",
+                            onProgress
+                        );
+                        currentXHR.upload.removeEventListener("load", onLoad);
                         setTimeout(() => deleteFile(file.id), AUTOCLOSE_DELAY);
-                        throw error;
+                        dataURL = null;
                     }
                 }
-            },
-            /**
-             * TODO: merge with uploadFiles in master
-             *
-             * Uploads files with the ability to abort the entire upload process.
-             * @param {Array<File>} files
-             * @param {Object} options
-             * @param {Function} onUploaded
-             * @return {Object} { promise, abort }
-             * Technical Diff from uploadFiles:
-             *  - Wraps upload logic inside a returned promise instead of implicit async flow.
-             *  - Keeps local state (currentXHR, addAttachmentRpc) instead of service-level globals.
-             *  - Returns "invalid_size" instead of null for oversized files.
-             *  - Uses AbortController and checks signal.aborted before/after each upload and inside error handling.
-             *  - Checks ev.lengthComputable before computing progress.
-             *  - Explicitly calls currentXHR.abort() and addAttachmentRpc.abort?.() on cancellation.
-             *  - Explicitly nullifies large variables (dataURL = null) for memory release.
-             *  - Removes XHR event listeners (progress, load) in finally.
-             *  - Returns a control object { promise, abort } instead of nothing.
-             *  - Uses structured try/catch/finally around each upload to handle abortion cleanly.
-             */
-            uploadFilesWithAbort(
-                files,
-                { resModel, resId, isImage },
-                onUploaded
-            ) {
-                const sortedFiles = Array.from(files).sort(
-                    (a, b) => a.size - b.size
-                );
-                const controller = new AbortController();
-                const { signal } = controller;
-                let addAttachmentRpc = null;
-                let currentXHR = null;
 
-                const promise = (async () => {
-                    try {
-                        // Step 1: prepare UI entries
-                        for (const file of sortedFiles) {
-                            if (!checkFileSize(file.size, notification)) {
-                                return "invalid_size";
-                            }
-                            const id = ++fileId;
-                            file.progressToastId = id;
-                            addFile({
-                                id,
-                                name: file.name,
-                                size: file.size
-                                    ? humanNumber(file.size) + "B"
-                                    : "",
-                            });
-                        }
-
-                        // Step 2: upload sequentially
-                        for (const sortedFile of sortedFiles) {
-                            if (signal.aborted) {
-                                throw new Error("Upload Aborted Manually");
-                            }
-
-                            const file =
-                                progressToast.files[sortedFile.progressToastId];
-                            let dataURL;
-                            try {
-                                dataURL = await getDataURLFromFile(sortedFile);
-                            } catch {
-                                deleteFile(file.id);
-                                env.services.notification.add(
-                                    sprintf(
-                                        _t('Could not load the file "%s".'),
-                                        sortedFile.name
-                                    ),
-                                    { type: "danger" }
-                                );
-                                continue;
-                            }
-
-                            currentXHR = new XMLHttpRequest();
-                            addAttachmentRpc = null;
-
-                            const onProgress = (ev) => {
-                                if (ev.lengthComputable) {
-                                    file.progress =
-                                        (ev.loaded / ev.total) * 100;
-                                }
-                            };
-                            const onLoad = () => (file.progress = 100);
-                            currentXHR.upload.addEventListener(
-                                "progress",
-                                onProgress
-                            );
-                            currentXHR.upload.addEventListener("load", onLoad);
-
-                            try {
-                                addAttachmentRpc = rpc(
-                                    "/web_editor/attachment/add_data",
-                                    {
-                                        name: file.name,
-                                        data: dataURL.split(",")[1],
-                                        res_id: resId,
-                                        res_model: resModel,
-                                        is_image: !!isImage,
-                                        width: 0,
-                                        quality: 0,
-                                    },
-                                    { xhr: currentXHR }
-                                );
-
-                                const attachment = await addAttachmentRpc;
-                                if (signal.aborted) {
-                                    throw new Error("Upload Aborted Manually");
-                                }
-
-                                if (attachment.error) {
-                                    file.hasError = true;
-                                    file.errorMessage = attachment.error;
-                                } else {
-                                    if (attachment.mimetype === "image/webp") {
-                                        try {
-                                            // Generate alternate format for reports.
-                                            await convertWebpToJpeg(
-                                                dataURL,
-                                                file.name,
-                                                attachment.id
-                                            );
-                                        } catch (convErr) {
-                                            console.warn(
-                                                "[uploadService] webp conversion failed:",
-                                                convErr
-                                            );
-                                        }
-                                    }
-                                    file.uploaded = true;
-                                    await onUploaded(attachment);
-                                }
-                            } catch (error) {
-                                if (signal.aborted) {
-                                    throw new Error("Upload Aborted Manually");
-                                }
-                                file.hasError = true;
-                                console.error("Upload error:", error);
-                            } finally {
-                                currentXHR?.upload.removeEventListener(
-                                    "progress",
-                                    onProgress
-                                );
-                                currentXHR?.upload.removeEventListener(
-                                    "load",
-                                    onLoad
-                                );
-                                setTimeout(
-                                    () => deleteFile(file.id),
-                                    AUTOCLOSE_DELAY
-                                );
-                                dataURL = null; // explicitly free memory
-                            }
-                        }
-                        return "done";
-                    } catch (err) {
-                        console.error("[uploadService] unexpected error:", err);
-                        return "error";
-                    } finally {
-                        currentXHR = null;
-                        addAttachmentRpc = null;
-                    }
-                })();
-
-                const abort = () => {
-                    controller.abort();
-                    try {
-                        addAttachmentRpc?.abort?.();
-                        // Abort the current XMLHttpRequest if it’s running
-                        // In general, rpc abort should be enough, but just in case.
-                        currentXHR?.abort?.();
-                    } catch (err) {
-                        console.warn("[uploadService] abort failed:", err);
-                    }
-                    Object.keys(progressToast.files).forEach((fid) =>
-                        deleteFile(fid)
-                    );
-                    addAttachmentRpc = null; // release last reference
-                    currentXHR = null;
-                };
-
-                return { promise, abort };
+                currentXHR = null;
+                addAttachmentRpc = null;
             },
         };
     },


### PR DESCRIPTION
Steps to Reproduce:
1. Open the website module.
2. Open the media upload dialog to upload an image by either double-clicking the logo or replacing the existing image.
3. Upload a large file.
4. Abort the upload before it finishes by clicking the 'Discard' button in the media dialog box.
After performing these steps, a traceback is observed.

Before this commit:
- Image upload failures would throw uncaught exceptions.
- These exceptions would interrupt the flow and result in a poor user experience with no clear feedback.
- Even after clicking the discard button, the image was still getting uploaded.

After this commit:
- Each upload is wrapped in a try-catch-finally block.
- If an error occurs, it no longer breaks the flow.
- The error is logged to the console for debugging purposes.
- Discard button stops the upload of the image.

task-4752497