### PR TITLE
[IMP] sale_stock, web: update return order dialog design

### DIFF
--- a/addons/sale_stock/report/return_slip_report.xml
+++ b/addons/sale_stock/report/return_slip_report.xml
@@ -18,8 +18,8 @@
                                 <h2>RETURN OF <t t-out="picking.name"/></h2>
                                 <p>
                                     Please put this document inside your return parcel.<br/>
-                                    Your parcel must be sent to this address:
                                 </p>
+                                <p class="mt-4 mb-0 fw-bold">Your parcel must be sent to this address:</p>
                                 <div
                                     t-out="wh_address_id"
                                     t-options='{
@@ -30,7 +30,7 @@
                                     }'
                                 />
                             </div>
-                            <div class="col-4 text-center mt-4">
+                            <div class="col-4 text-center mt-1">
                                 <div
                                     t-field="picking.name"
                                     t-options="{
@@ -49,7 +49,7 @@
                                 <strong>Return reason</strong>
                                 <div t-out="return_reason.name"/>
                             </div>
-                            <div class="col-4 text-center mt-4">
+                            <div class="col-4 text-center mt-1">
                                 <t
                                     t-set="return_barcode"
                                     t-value="'OBTRETU:%s' % (return_reason.id)"
@@ -66,7 +66,7 @@
                         </div>
 
                         <!-- Product list -->
-                        <div class="mt-3">
+                        <div class="mt-4">
                             <strong>Returned products</strong>
                             <t t-set="return_products" t-value="return_product_qty_by_delivery[picking.id]"/>
                             <div
@@ -83,7 +83,7 @@
                                     )"
                                     style="width: 64px; height: 64px; object-fit: contain;"
                                 />
-                                <div class="ms-2">
+                                <div class="flex-grow-1 ms-2">
                                     <strong t-out="move.product_id.with_context(display_default_code=False).display_name"/>
                                     <br/>
                                     Quantity:

--- a/addons/sale_stock/static/src/return_order_dialog/return_order_dialog.js
+++ b/addons/sale_stock/static/src/return_order_dialog/return_order_dialog.js
@@ -23,7 +23,7 @@ export class ReturnOrderDialog extends Component {
     setup() {
         this.dialog = useService('dialog');
         this.orm = useService('orm');
-        this.state =  useState({ returnableLines: [] });
+        this.state =  useState({ returnableLines: [], returnReason: null });
         this.title = _t("Request a return");
 
         onWillStart(async () => {
@@ -63,6 +63,7 @@ export class ReturnOrderDialog extends Component {
 
     onReturnReasonChange() {
         const returnReason = document.querySelector('select[name="return_reason"]');
+        this.state.returnReason = returnReason.value;
         returnReason.classList.remove('is-invalid');
     }
 
@@ -84,11 +85,10 @@ export class ReturnOrderDialog extends Component {
         }
         const selectedlines = this.state.returnableLines.filter(line => line.quantity);
         this.dialog.add(ConfirmationDialog, {
-            title: '',
+            title: 'Print the return request label.',
             body: markup(
-                _t("<strong>Print the return request label.</strong><br/>") +
-                _t("Add this label in your package and send it to this address:<br/><br/>") +
-                `<strong>${this.content.company_name}</strong><br/>${this.content.warehouse_address}`
+                _t("Download, print and add this label in your package and send it to this address:<br/><br/>") +
+                `<div class='card border'><div class='card-body'><b class="d-block mb-2">${this.content.company_name}</b><span class='text-muted'>${this.content.warehouse_address.replace('\n\n', ' ').replace('\n', ' ')}</span></div></div>`
             ),
             confirmLabel: _t("Download Label"),
             confirm: async () => {
@@ -107,6 +107,7 @@ export class ReturnOrderDialog extends Component {
                 }
                 this.props.close();
             },
+            size: "md",
         });
     }
 

--- a/addons/sale_stock/static/src/return_order_dialog/return_order_dialog.scss
+++ b/addons/sale_stock/static/src/return_order_dialog/return_order_dialog.scss
@@ -1,0 +1,16 @@
+.o_return_order_dialog{
+    @include media-breakpoint-down(sm) {
+        --ReturnOrderDialog-img-size-sm: 3.5rem;
+
+        .o_return_order_dialog_price {
+            margin-left: calc(var(--ReturnOrderDialog-img-size-sm) + #{map-get($spacers, 2)});
+        }
+    }
+    .o_return_order_dialog_img {
+        width: var(--ReturnOrderDialog-img-size-sm, 6rem);
+    }
+
+    .o_return_order_dialog_return_reason {
+        background: darken($modal-content-bg, 2%);
+    }
+}

--- a/addons/sale_stock/static/src/return_order_dialog/return_order_dialog.xml
+++ b/addons/sale_stock/static/src/return_order_dialog/return_order_dialog.xml
@@ -6,45 +6,37 @@
             size="size"
             title="title"
             contentClass="'o_return_order_dialog'"
+            bodyClass="'d-flex flex-column d-sm-block'"
         >
             <table class="table table-sm table-borderless position-relative mb-0">
                 <tbody class="sale_tbody">
                     <t t-foreach="this.state.returnableLines" t-as="line" t-key="line_index">
                         <tr class="js_product">
-                            <td class="py-3 p-0">
-                                <div class="d-flex align-items-start gap-2">
+                            <td class="d-block d-sm-table-cell pb-1 pb-sm-3 p-0">
+                                <div class="d-flex align-items-start gap-2 gap-md-3">
                                     <img
                                         t-att-alt="line.name"
                                         t-attf-src="/web/image/product.product/{{line.product_id}}/image_128"
-                                        class="border rounded d-block"
+                                        class="o_return_order_dialog_img border rounded d-block"
                                     />
                                     <div>
-                                        <h5 t-out="line.name"/>
-                                        <span
-                                            class="text-muted d-none d-md-inline-block"
-                                            t-if="line.description_sale"
-                                            t-out="line.description_sale"
-                                        />
-                                        <div t-if="line.lot_name">
-                                            Lot/Serial Number: <t t-out="line.lot_name"/>
+                                        <h6 class="o_line_clamp mb-1" t-out="line.name"/>
+                                        <div t-if="line.lot_name" class="small">
+                                            Lot/Serial Number: <strong><t t-out="line.lot_name" /></strong>
                                         </div>
-                                        <div t-if="line.delivery_name">
-                                            Delivery: <t t-out="line.delivery_name"/>
+                                        <div t-if="line.delivery_name" class="small">
+                                            Delivery: <strong><t t-out="line.delivery_name" /></strong>
                                         </div>
                                     </div>
                                 </div>
                             </td>
-                            <td class="w-25 py-3 px-0 text-end">
-                                <div
-                                    class="d-md-flex gap-2 align-items-baseline justify-content-end"
-                                >
-                                    <span
-                                        t-out="formatCurrency(
-                                            line.price, line.currency
-                                        )"
-                                        class="h5 text-nowrap fw-bold text-end h6 mb-2 d-block"
-                                    />
-                                </div>
+                            <td class="d-flex d-sm-table-cell align-items-center justify-content-between w-sm-25 pb-3 p-0 text-sm-end">
+                                <span
+                                    t-out="formatCurrency(
+                                        line.price, line.currency
+                                    )"
+                                    class="o_return_order_dialog_price h6 d-block mb-0 mb-sm-2 text-nowrap fw-bold text-end"
+                                />
                                 <QuantityButtons
                                     quantity="line.quantity or 0"
                                     setQuantity="quantity => this.setQuantity(line, quantity)"
@@ -56,29 +48,35 @@
                     </t>
                 </tbody>
             </table>
-            <t t-set-slot="footer">
-                <div class="w-100 d-flex gap-2">
-                    <select
+            <div class="o_return_order_dialog_return_reason d-sm-flex align-items-center gap-3 mt-auto me-n3 mb-n3 ms-n3 px-3 py-4 border-top">
+                <h6 class="mb-sm-0 text-nowrap">Return reason</h6>
+                <select
                         name="return_reason"
                         class="form-select"
                         required=""
                         t-on-change="onReturnReasonChange"
                     >
-                        <option value="" disabled="disabled" selected="selected">
-                            Select a return reason...
-                        </option>
-                        <t t-foreach="content.reasons" t-as="reason" t-key="reason.id">
-                            <option t-att-value="reason.id" t-out="reason.name"/>
-                        </t>
-                    </select>
-                    <button
-                        name="continue"
-                        class="btn btn-primary"
-                        t-on-click="onContinue"
-                    >
-                        Continue
-                    </button>
-                </div>
+                    <option value="" disabled="disabled" selected="selected">
+                        Select a reason...
+                    </option>
+                    <t t-foreach="content.reasons" t-as="reason" t-key="reason.id">
+                        <option t-att-value="reason.id" t-out="reason.name"/>
+                    </t>
+                </select>
+            </div>
+            <t t-set-slot="footer">
+                <t t-set="noProductAndNoReason" t-value="this.state.returnableLines.every(
+                        line => (line.quantity || 0) === 0
+                    ) || !this.state.returnReason" />
+                <button
+                    name="continue"
+                    class="btn btn-primary"
+                    t-on-click="onContinue"
+                    t-att-disabled="noProductAndNoReason"
+                >
+                    Continue
+                </button>
+                <small t-if="noProductAndNoReason" class="ms-2 text-muted">Select at least one product and a return reason.</small>
             </t>
         </Dialog>
         <WarningDialog

--- a/addons/sale_stock/views/sale_stock_portal_template.xml
+++ b/addons/sale_stock/views/sale_stock_portal_template.xml
@@ -11,7 +11,7 @@
                     class="btn btn-light o_return_button"
                     t-att-data-sale-order-id="sale_order.id"
                 >
-                    Return
+                    <i class="fa fa-reply me-2"/>Return
                 </button>
             </t>
         </div>

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
@@ -31,12 +31,14 @@ export class ConfirmationDialog extends Component {
         cancel: { type: Function, optional: true },
         cancelLabel: { type: String, optional: true },
         dismiss: { type: Function, optional: true },
+        size: { type: String, optional: true },
     };
     static defaultProps = {
         confirmLabel: _t("Ok"),
         cancelLabel: _t("Discard"),
         confirmClass: "btn-primary",
         title: _t("Confirmation"),
+        size: "sm",
     };
 
     setup() {

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="web.ConfirmationDialog">
-    <Dialog size="'sm'" title="props.title" modalRef="modalRef">
+    <Dialog size="props.size" title="props.title" modalRef="modalRef">
       <p t-out="props.body" class="text-prewrap mb-0"/>
       <t t-set-slot="footer">
         <button class="btn" t-att-class="props.confirmClass" t-on-click="_confirm" t-esc="props.confirmLabel" data-hotkey="q"/>

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -3378,3 +3378,11 @@ input[value*="data-oe-translation-source-sha"] {
 img.o_image_popup {
     cursor: pointer;
 }
+
+/*
+The modal title has the fs-3 class, which results
+in a huge font size since it isn’t redefined for the frontend.
+*/
+.modal .modal-content .modal-header .modal-title.fs-3 {
+    font-size: 1.35rem !important;
+}


### PR DESCRIPTION
This PR improves the design of the return order dialog by making
it more consistent with the product configuration dialog.

It also introduces a new prop for the confirmation dialog to change
its size, as the "sm" size may be too small for some use cases.

task-5477354