### PR TITLE
[FIX][5867618] l10n_es: Fix visibility and readonly behavior of l10n_es_is_simplified.

### DIFF
--- a/addons/l10n_es/views/account_move_views.xml
+++ b/addons/l10n_es/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//page[@id='other_tab']//field[@name='delivery_date']" position="after">
-                <field name="l10n_es_is_simplified"/>
+                <field name="l10n_es_is_simplified" invisible="not(country_code in ('ES'))" readonly="state == 'posted'"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Makes the field visible only if the company is spanish. The field will be readonly if the state of the account.move is 'posted'