### PR TITLE
[IMP][5867754] Modify boolean simplified field for spanish companies

### DIFF
--- a/addons/l10n_es/views/account_move_views.xml
+++ b/addons/l10n_es/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//page[@id='other_tab']//field[@name='delivery_date']" position="after">
-                <field name="l10n_es_is_simplified"/>
+                <field name="l10n_es_is_simplified" invisible="not tax_country_code == 'ES'"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_es/views/account_move_views.xml
+++ b/addons/l10n_es/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//page[@id='other_tab']//field[@name='delivery_date']" position="after">
-                <field name="l10n_es_is_simplified" invisible="not tax_country_code == 'ES'" readonly="state == 'posted'"/>
+                <field name="l10n_es_is_simplified" invisible="not country_code == 'ES'" readonly="state == 'posted'"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_es/views/account_move_views.xml
+++ b/addons/l10n_es/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//page[@id='other_tab']//field[@name='delivery_date']" position="after">
-                <field name="l10n_es_is_simplified" invisible="not tax_country_code == 'ES'"/>
+                <field name="l10n_es_is_simplified" invisible="not tax_country_code == 'ES'" readonly="state == 'posted'"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_es/views/account_move_views.xml
+++ b/addons/l10n_es/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//page[@id='other_tab']//field[@name='delivery_date']" position="after">
-                <field name="l10n_es_is_simplified" invisible="not country_code == 'ES'" readonly="state == 'posted'"/>
+                <field name="l10n_es_is_simplified" invisible="country_code != 'ES'" readonly="state == 'posted'"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Hide simplified field for not spanish companies and make read-only when move is posted. 

Current behavior before PR:
The boolean simplified field always appears

Desired behavior after PR is merged:
The boolean simplified field will only appear if the company is a spanish company and will be read only if the invoice is posted.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr