### PR TITLE
[IMP] l10n_es: Display delivery_date in form view and report.

### DIFF
--- a/addons/l10n_es/models/account_move.py
+++ b/addons/l10n_es/models/account_move.py
@@ -26,6 +26,21 @@ class AccountMove(models.Model):
                 )
             )
 
+    @api.depends('country_code')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.country_code == 'ES':
+                move.show_delivery_date = True
+
     def _l10n_es_is_dua(self):
         self.ensure_one()
         return any(t.l10n_es_type == 'dua' for t in self.invoice_line_ids.tax_ids.flatten_taxes_hierarchy())
+
+    def action_post(self):
+        post = super().action_post()
+        for move in self:
+            if move.country_code == 'ES' and not move.delivery_date:
+                move.delivery_date = move.invoice_date
+        return post


### PR DESCRIPTION
New legislation in Spain requires to display the delivery date in the pdf report aswell as in the header of the invoice form layout

task-5867624