### PR TITLE
[IMP] l10n_es_edi_facturae: added FileReference to facturae template.

### DIFF
--- a/addons/l10n_es_edi_facturae/data/facturae_templates.xml
+++ b/addons/l10n_es_edi_facturae/data/facturae_templates.xml
@@ -128,6 +128,7 @@
             <InvoiceLine>
                 <ReceiverContractReference t-out="line.get('ReceiverContractReference')"/>
                 <ReceiverTransactionReference t-out="line.get('ReceiverTransactionReference')"/>
+                <FileReference t-out="line.get('FileReference')"/>
                 <FileDate t-out="line.get('FileDate')"/>
                 <SequenceNumber t-out="line.get('SequenceNumber')"/>
                 <ItemDescription t-out="line['ItemDescription']"/>
@@ -206,6 +207,7 @@
                     <TaxCurrencyCode t-out="invoice['invoice_currency'].name"/>
                     <LanguageName t-out="invoice['InvoiceIssueData']['LanguageName']"/>
                     <ReceiverTransactionReference t-out="invoice['InvoiceIssueData']['ReceiverTransactionReference']"/>
+                    <FileReference t-out="invoice['InvoiceIssueData'].get('FileReference')"/>
                     <ReceiverContractReference t-out="invoice['InvoiceIssueData']['ReceiverContractReference']"/>
                 </InvoiceIssueData>
                 <TaxesOutputs>

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -316,6 +316,7 @@ class AccountMove(models.Model):
         xml_values = {
             'ReceiverTransactionReference': receiver_transaction_reference,
             'ReceiverContractReference': invoice_ref,
+            'FileReference': invoice_ref,
             'FileDate': fields.Date.context_today(self),
             'ItemDescription': line.name,
             'Quantity': line.quantity,
@@ -419,6 +420,7 @@ class AccountMove(models.Model):
                 'ExchangeRate': f"{round(self.invoice_currency_rate, 4):.4f}",
                 'LanguageName': self.env.context.get('lang', 'en_US').split('_')[0],
                 'InvoicingPeriod': None,
+                'FileReference': invoice_ref,
                 'ReceiverTransactionReference': invoice_ref,
                 'ReceiverContractReference': invoice_ref,
             },

--- a/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
@@ -80,6 +80,7 @@
         <TaxCurrencyCode>EUR</TaxCurrencyCode>
         <LanguageName>en</LanguageName>
         <ReceiverTransactionReference>ABCD-2023-001</ReceiverTransactionReference>
+        <FileReference>ABCD-2023-001</FileReference>
         <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
       </InvoiceIssueData>
       <TaxesOutputs>
@@ -117,6 +118,7 @@
         <InvoiceLine>
           <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
           <ReceiverTransactionReference>ABCD-2023-001</ReceiverTransactionReference>
+          <FileReference>ABCD-2023-001</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -140,6 +142,7 @@
         <InvoiceLine>
           <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
           <ReceiverTransactionReference>ABCD-2023-001</ReceiverTransactionReference>
+          <FileReference>ABCD-2023-001</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>


### PR DESCRIPTION
Modified _l10n_es_edi_facturae_prepare_inv_line and _l10n_es_edi_facturae_export_facturae methods in account_move.py to pass the invoice_ref value to FileReference and then used it in the facturae template. Also fixed the tests.

Task-ID: 5867669