### PR TITLE
[FIX] hr_holiday: prevent accrual day selection of invalid days (e.g Feb 31st) via new widget

### DIFF
--- a/addons/hr_holidays/static/src/components/accrual_day_field/accrual_day_field.js
+++ b/addons/hr_holidays/static/src/components/accrual_day_field/accrual_day_field.js
@@ -1,0 +1,28 @@
+import { registry } from "@web/core/registry";
+import { SelectionField } from "@web/views/fields/selection/selection_field";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+
+export class AccrualDayField extends SelectionField {
+
+    static props = {
+        ...standardFieldProps,
+        monthField: {
+            type: String,
+        }
+    }
+
+    get options() {
+        let options = super.options;
+        const carryover_month = this.props.record.data[this.props.monthField];
+        const lastDay = new Date(2020, carryover_month, 0).getDate();
+        options = options.filter((option) => option[0] <= lastDay);
+        return options;
+    }
+}
+
+registry.category("fields").add("accrual_day", {
+    component: AccrualDayField,
+    extractProps: ({ attrs }) => ({
+        monthField: attrs.monthField
+    })
+});

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,17 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" widget="accrual_day" monthField="first_month" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field name="first_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" widget="accrual_day" monthField="second_month" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" widget="accrual_day" monthField="yearly_month" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a day"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -192,7 +192,7 @@
                                                options="{'links': {'other': 'carryover_custom_date'}, 'observe': 'carryover'}"/>
                                         <span id="carryover_custom_date">
                                             : the
-                                            <field name="carryover_day" placeholder="select a day"
+                                            <field name="carryover_day" widget="accrual_day" monthField="carryover_month" placeholder="select a day"
                                                    required="carryover_date == 'other'"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"


### PR DESCRIPTION
Steps to reproduce: Open accrual milstone form containing the custom day selection field. Select "February" as the month and observe that "31" remains a selectable option in the day dropdown.

Bug Cause: The standard selection field used static values (1-31) and lacked dynamic cross-field validation between the month and day inputs.

Solution: Created a new Odoo field widget to handle day selection. This widget dynamically calculates the maximum number of days allowed based on the selected month and year, effectively disabling or removing invalid dates like February 31st.