### PR TITLE
[IMP] l10n_es Add delivery date

### DIFF
--- a/addons/l10n_es/models/account_move.py
+++ b/addons/l10n_es/models/account_move.py
@@ -29,3 +29,20 @@ class AccountMove(models.Model):
     def _l10n_es_is_dua(self):
         self.ensure_one()
         return any(t.l10n_es_type == 'dua' for t in self.invoice_line_ids.tax_ids.flatten_taxes_hierarchy())
+
+
+    @api.depends('delivery_date')
+    def _compute_show_delivery_date(self):
+        super()._compute_show_delivery_date(self)
+        for move in self:
+            if move.country_code == 'ES':
+                move.show_delivery_date = move.is_sale_document()
+
+    
+    @api.depends('state')
+    def _compute_delivery_date(self):
+        super()._compute_delivery_date()
+        for move in self:
+            if move.country_code == 'ES' and move.state == 'posted' and move.invoice_date and not move.delivery_date:
+                move.delivery_date == move.invoice_date
+                


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Add Delivery date to invoice if the company is spanish
Current behavior before PR:
The Delivery date didn't appear always and sometimes it was not specified.

Desired behavior after PR is merged:
It will always now be specified if it is a spanish company. 
Therefore, it will always appear in the invoice.

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)