### PR TITLE
[IMP] i10n_es_facturae: add missing field FileReference to invoice 

### DIFF
--- a/addons/l10n_es_edi_facturae/data/facturae_templates.xml
+++ b/addons/l10n_es_edi_facturae/data/facturae_templates.xml
@@ -165,6 +165,7 @@
                     <EndDate t-out="line['LineItemPeriod']['EndDate']"/>
                 </LineItemPeriod>
                 <TransactionDate t-out="line.get('TransactionDate')"/>
+                <FileReference t-out="line.get('FileReference')"/>
             </InvoiceLine>
         </template>
 
@@ -207,6 +208,7 @@
                     <LanguageName t-out="invoice['InvoiceIssueData']['LanguageName']"/>
                     <ReceiverTransactionReference t-out="invoice['InvoiceIssueData']['ReceiverTransactionReference']"/>
                     <ReceiverContractReference t-out="invoice['InvoiceIssueData']['ReceiverContractReference']"/>
+                    <FileReference t-out="invoice['InvoiceIssueData']['FileReference']"/>
                 </InvoiceIssueData>
                 <TaxesOutputs>
                     <t t-foreach="invoice['TaxOutputs']" t-as="tax"><t t-call="l10n_es_edi_facturae.tax_type"/></t>

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -323,6 +323,7 @@ class AccountMove(models.Model):
             'DiscountsAndRebates': [],
             'Charges': [],
             'GrossAmount': float_round(tax_details['raw_total_excluded_currency'], precision_digits=8),
+            'FileReference': invoice_ref
         }
 
         if line.discount == 100.0:
@@ -421,6 +422,7 @@ class AccountMove(models.Model):
                 'InvoicingPeriod': None,
                 'ReceiverTransactionReference': invoice_ref,
                 'ReceiverContractReference': invoice_ref,
+                'FileReference': invoice_ref,
             },
             'TaxOutputs': [],
             'TaxesWithheld': [],

--- a/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
@@ -81,6 +81,7 @@
         <LanguageName>en</LanguageName>
         <ReceiverTransactionReference>ABCD-2023-001</ReceiverTransactionReference>
         <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
+        <FileReference>ABCD-2023-001</FileReference>
       </InvoiceIssueData>
       <TaxesOutputs>
         <Tax>
@@ -136,6 +137,7 @@
               </TaxAmount>
             </Tax>
           </TaxesOutputs>
+          <FileReference>ABCD-2023-001</FileReference>
         </InvoiceLine>
         <InvoiceLine>
           <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
@@ -159,6 +161,7 @@
               </TaxAmount>
             </Tax>
           </TaxesOutputs>
+          <FileReference>ABCD-2023-001</FileReference>
         </InvoiceLine>
       </Items>
     </Invoice>


### PR DESCRIPTION
Add file reference in invoice xml in "invoice issue data" and in the "invoice lines"

-add the FileReference in xml_lines in _l10n_es_edi_facturae_prepare_inv_line
-add the FileReference in invoice_values {'InvoiceIssueData'}
- adjust test adding FIleReference to expected_refund_document.xml