### PR TITLE
[ADD]l10n_es: add delivery date into the header

### DIFF
--- a/addons/l10n_es/__manifest__.py
+++ b/addons/l10n_es/__manifest__.py
@@ -27,6 +27,7 @@ Spanish charts of accounts (PGCE 2008).
         'base_iban',
         'base_vat',
         'account_edi_ubl_cii',
+        'web'
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_es/models/account_move.py
+++ b/addons/l10n_es/models/account_move.py
@@ -29,3 +29,11 @@ class AccountMove(models.Model):
     def _l10n_es_is_dua(self):
         self.ensure_one()
         return any(t.l10n_es_type == 'dua' for t in self.invoice_line_ids.tax_ids.flatten_taxes_hierarchy())
+
+    @api.depends('state')
+    def _compute_delivery_date(self):
+        super()._compute_delivery_date()
+        for record in self:
+            if record.state == 'posted' and not record.delivery_date:
+                record.delivery_date = record.invoice_date
+                

--- a/addons/l10n_es/views/account_move_views.xml
+++ b/addons/l10n_es/views/account_move_views.xml
@@ -5,6 +5,9 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='delivery_date']" position="attributes">
+                <attribute name="invisible"></attribute>
+            </xpath>
             <xpath expr="//page[@id='other_tab']//field[@name='delivery_date']" position="after">
                 <field name="l10n_es_is_simplified"/>
             </xpath>

--- a/addons/l10n_es/views/report_invoice.xml
+++ b/addons/l10n_es/views/report_invoice.xml
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+
+    <template id="report_header_invoice_document" inherit_id="web.external_layout_standard">
+        <xpath expr="//div[@name='company_address']" position="after">
+            <div class="col-6" name="delivery_date_company_header">
+                <t t-if="docs and docs._name == 'account.move' and docs.company_id.country_code == 'ES' and docs.delivery_date">
+                    <strong>Delivery Date:</strong>
+                    <span t-esc="docs.delivery_date"/>
+                </t>
+                <t t-else="">
+                    <strong>Invoice Date:</strong>
+                    <span t-esc="docs.invoice_date"/>
+                </t>
+            </div>
+        </xpath>
+    </template>
+
+
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
         <!-- add company id -->
         <xpath expr="//div[@id='partner_vat_address_not_same_as_shipping']" position="after">


### PR DESCRIPTION
- Delivery date in the header of account.move report
- Change the logic of the field delivery_date to always display it and fill it with info when it's empty

TaskID - 5867738