### PR TITLE
[IMP] i10n_es: delivery date always visible in account_move form; fill with invoice date at post if not set

### DIFF
--- a/addons/l10n_es/models/account_move.py
+++ b/addons/l10n_es/models/account_move.py
@@ -29,3 +29,17 @@ class AccountMove(models.Model):
     def _l10n_es_is_dua(self):
         self.ensure_one()
         return any(t.l10n_es_type == 'dua' for t in self.invoice_line_ids.tax_ids.flatten_taxes_hierarchy())
+
+    @api.depends("country_code", "move_type")
+    def _compute_show_delivery_date(self):
+        # EXTEND 'account'
+        super()._compute_show_delivery_date()
+        for move in self.filtered(lambda m: m.country_code == 'ES'):
+            move.show_delivery_date = move.is_sale_document()
+
+    def action_post(self):
+        res = super().action_post()
+        for move in self.filtered(lambda m: m.country_code == 'ES'):
+            if not move.delivery_date:
+                move.delivery_date = move.invoice_date
+        return res


### PR DESCRIPTION

Due to change in legislation for ES companies, delivery date should always be present on the account_move form and filled with invoice date if the delivery date is not set 

AccountMove: 
- _compute_show_delivery_date - extend to always show delivery_date when ES company
-  action_post - use invoice date if delivery date not set at post

task - 5867579

