### PR TITLE
[IMP] website: display only matched tag in search result

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -636,10 +636,9 @@ class Website(Home):
         for search_result in search_results:
             if not len(search_result['results_data']):
                 continue
-            search_result['results_data'].sort(key=lambda r: r.get('name', ''), reverse='name desc' in order)
             mappings.append(search_result['mapping'])
-            group_name = search_result.get("group_name")
-            group_key = search_result.get("model").replace('.', '_')
+            group_name = search_result.get('group_name')
+            group_key = search_result.get('model').replace('.', '_')
             result_data = []
             for record in search_result['results_data']:
                 model = request.env[search_result['model']]
@@ -666,21 +665,22 @@ class Website(Home):
                         if field_type == 'html':
                             skip_matching_area = True
 
-                    if field_type not in ('image', 'binary') and ('ir.qweb.field.%s' % field_type) in request.env:
+                    qweb_field = f'''ir.qweb.field.{field_type}'''
+                    if field_type not in ('image', 'binary') and qweb_field in request.env:
                         opt = {}
                         if field_type == 'monetary':
                             opt['display_currency'] = options['display_currency']
                         elif field_type == 'float':
                             opt['precision'] = field_meta.get('precision', 2)
-                        value = request.env[('ir.qweb.field.%s' % field_type)].value_to_html(value, opt)
+                        value = request.env[qweb_field].value_to_html(value, opt)
                     mapped[mapped_name] = escape(value)
                 result_data.append(mapped)
 
             result[group_key] = {
-                "groupName": group_name,
-                "templateKey": search_result.get("template_key"),
-                "searchCount": search_result.get('count'),
-                "data": result_data,
+                'groupName': group_name,
+                'templateKey': search_result.get('template_key'),
+                'searchCount': search_result.get('count'),
+                'data': result_data,
             }
 
         return {
@@ -734,7 +734,7 @@ class Website(Home):
     ], type='http', auth="public", website=True, sitemap=False, readonly=True)
     def hybrid_list(self, search='', limit=24, search_type='all', **kw):
         if not search:
-            return request.render("website.list_hybrid")
+            return request.render('website.list_hybrid')
 
         options = self._get_hybrid_search_options(**kw)
         data = self.autocomplete(search_type=search_type, term=search, order='name asc', limit=limit, offset=0, max_nb_chars=200, options=options)
@@ -751,7 +751,7 @@ class Website(Home):
             'fuzzy_search': data.get('fuzzy_search'),
             'search_count': search_count,
         }
-        return request.render("website.list_hybrid", values)
+        return request.render('website.list_hybrid', values)
 
     @http.route('/website/load_more_search', type='jsonrpc', auth="public", website=True, readonly=True)
     def load_more_search(self, search='', search_type='all', offset=0, limit=24, **kwargs):

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -647,6 +647,7 @@ class Website(Home):
                 mapped = {
                     '_fa': record.get('_fa'),
                 }
+                skip_matching_area = False
                 for mapped_name, field_meta in mapping.items():
                     value = record.get(field_meta.get('name'))
                     if not value:
@@ -657,9 +658,13 @@ class Website(Home):
                         value = self._shorten_around_match(value, term, max_nb_chars)
 
                     if field_meta.get('match'):
+                        if skip_matching_area and mapped_name not in ['name', 'search_item_metadata']:
+                            continue
                         skip_field, value, field_type = model._search_highlight_field(field_meta, value, term)
                         if skip_field:
                             continue
+                        if field_type == 'html':
+                            skip_matching_area = True
 
                     if field_type not in ('image', 'binary') and ('ir.qweb.field.%s' % field_type) in request.env:
                         opt = {}

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -852,17 +852,15 @@ class WebsiteSearchableMixin(models.AbstractModel):
             - resulting_type (str): 'html' if highlights were added, else 'tags'
         """
         highlighted_tags = []
-        has_highlight = False
 
         for tag in value:
             name = tag.get('name', '')
             parts, tag_highlight = self._split_for_highlight(name, term)
             tag['parts'] = parts
             if tag_highlight:
-                has_highlight = True
-            highlighted_tags.append(tag)
+                highlighted_tags.append(tag)
 
-        if has_highlight:
+        if len(highlighted_tags):
             value = self.env['ir.ui.view'].sudo()._render_template(
                 "website.search_tags_highlight",
                 {'tags': highlighted_tags}

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -860,7 +860,7 @@ class WebsiteSearchableMixin(models.AbstractModel):
             if tag_highlight:
                 highlighted_tags.append(tag)
 
-        if len(highlighted_tags):
+        if len(highlighted_tags) > 0:
             value = self.env['ir.ui.view'].sudo()._render_template(
                 "website.search_tags_highlight",
                 {'tags': highlighted_tags}

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -2067,7 +2067,7 @@ class Website(models.CachedModel):
         :return: list of search details obtained from the `website.searchable.mixin`'s `_search_get_detail()`
         """
         result = []
-        if search_type in ['pages', 'website_page', 'all']:
+        if search_type in ['pages', 'all']:
             result.append(self.env['website.page']._search_get_detail(self, order, options))
         return result
 

--- a/addons/website/static/src/snippets/s_searchbar/search_bar.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar.js
@@ -215,15 +215,7 @@ export class SearchBar extends Interaction {
     }
 
     getFieldsNames() {
-        return [
-            "description",
-            "detail",
-            "detail_extra",
-            "detail_strike",
-            "extra_link",
-            "name",
-            "tags",
-        ];
+        return ["description", "name", "tags", "search_item_metadata"];
     }
 
     async onInput() {

--- a/addons/website_blog/models/website.py
+++ b/addons/website_blog/models/website.py
@@ -35,6 +35,8 @@ class Website(models.Model):
 
     def _search_get_details(self, search_type, order, options):
         result = super()._search_get_details(search_type, order, options)
-        if search_type in ['blogs', 'blog_posts_only', 'blog_post', 'all']:
+        if search_type in ['blogs', 'blogs_only', 'all']:
+            result.append(self.env['blog.blog']._search_get_detail(self, order, options))
+        if search_type in ['blogs', 'blog_posts_only', 'all']:
             result.append(self.env['blog.post']._search_get_detail(self, order, options))
         return result

--- a/addons/website_blog/models/website.py
+++ b/addons/website_blog/models/website.py
@@ -35,7 +35,7 @@ class Website(models.Model):
 
     def _search_get_details(self, search_type, order, options):
         result = super()._search_get_details(search_type, order, options)
-        if search_type in ['blogs', 'blogs_only', 'all']:
+        if search_type in ['blogs', 'all']:
             result.append(self.env['blog.blog']._search_get_detail(self, order, options))
         if search_type in ['blogs', 'blog_posts_only', 'all']:
             result.append(self.env['blog.post']._search_get_detail(self, order, options))

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -330,13 +330,14 @@ class BlogPost(models.Model):
         else:
             domain.append([("website_published", "=", True)])
         search_fields = ['name', 'author_name', 'tag_ids.name', 'content']
-        fetch_fields = ['name', 'website_url', 'tag_ids', 'author_name']
+        fetch_fields = ['name', 'website_url', 'tag_ids', 'author_name', 'content']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
-            'search_item_metadata': {'name': 'author_name', 'type': 'text', 'skip_markup': True},
+            'search_item_metadata': {'name': 'author_name', 'type': 'text', 'match': True},
             'image_url': {'name': 'image_url', 'type': 'html'},
             'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
+            'description': {'name': 'content', 'type': 'text', 'html': True, 'match': True},
         }
         return {
             'model': 'blog.post',

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -330,13 +330,11 @@ class BlogPost(models.Model):
         else:
             domain.append([("website_published", "=", True)])
         search_fields = ['name', 'author_name', 'tag_ids.name', 'content']
-        fetch_fields = ['name', 'website_url', 'tag_ids', 'author_name', 'published_date']
+        fetch_fields = ['name', 'website_url', 'tag_ids', 'author_name']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'search_item_metadata': {'name': 'author_name', 'type': 'text', 'skip_markup': True},
-            'author_avatar_url': {'name': 'author_avatar_url', 'type': 'html', 'truncate': False},
-            'published_date': {'name': 'published_date', 'type': 'date'},
             'image_url': {'name': 'image_url', 'type': 'html'},
             'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
         }
@@ -355,6 +353,5 @@ class BlogPost(models.Model):
         results_data = super()._search_render_results(fetch_fields, mapping, icon, limit)
         for post, data in zip(self, results_data):
             data['tag_ids'] = post.tag_ids.read(['name'])
-            data['author_avatar_url'] = '/web/image/blog.post/%s/author_avatar' % data['id']
             data['image_url'] = post._get_image_url()
         return results_data

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -609,13 +609,14 @@ class EventEvent(models.Model):
                     current_date = date_details[1]
 
         search_fields = ['name', 'tag_ids.name', 'subtitle', 'tag_ids.name']
-        fetch_fields = ['name', 'website_url', 'date_begin', 'tag_ids']
+        fetch_fields = ['name', 'website_url', 'date_begin', 'tag_ids', 'subtitle']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'search_item_metadata': {'name': 'date_begin', 'type': 'date'},
             'image_url': {'name': 'image_url', 'type': 'html'},
             'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
+            'description': {'name': 'subtitle', 'type': 'text', 'html': True, 'match': True},
         }
 
         # Bypassing the access rigths of partner to search the address.

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -609,13 +609,11 @@ class EventEvent(models.Model):
                     current_date = date_details[1]
 
         search_fields = ['name', 'tag_ids.name', 'subtitle', 'tag_ids.name']
-        fetch_fields = ['name', 'website_url', 'address_name', 'date_begin', 'tag_ids']
+        fetch_fields = ['name', 'website_url', 'date_begin', 'tag_ids']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'search_item_metadata': {'name': 'date_begin', 'type': 'date'},
-            'address_name': {'name': 'address_name', 'type': 'text', 'match': True},
-            'lowest_ticket_price': {'name': 'lowest_ticket_price', 'type': 'html'},
             'image_url': {'name': 'image_url', 'type': 'html'},
             'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
         }
@@ -645,40 +643,9 @@ class EventEvent(models.Model):
             'sequence': 40,
         }
 
-    def _get_lowest_ticket_price(self):
-        # Exit early if the price field does not exist
-        if 'price' not in self.env["event.event.ticket"]._fields:
-            return False
-
-        prices = [
-            ticket.price
-            for ticket in self.event_ticket_ids
-            if ticket.price is not None
-        ]
-
-        if not prices:
-            return False
-        price = min(prices)
-        # Zero means free → highest priority
-        if price == 0.0:
-            return Markup("Free")
-
-        currency = self.currency_id or self.env.company.currency_id
-        return self.env['ir.qweb.field.monetary'].value_to_html(
-            price,
-            {'display_currency': currency}
-        )
-
     def _search_render_results(self, fetch_fields, mapping, icon, limit):
         results_data = super()._search_render_results(fetch_fields, mapping, icon, limit)
         for event, data in zip(self, results_data):
-            begin = self.env['ir.qweb.field.date'].record_to_html(event, 'date_begin', {})
-            end = self.env['ir.qweb.field.date'].record_to_html(event, 'date_end', {})
-            data['range'] = (
-                Markup('{} <i class="fa fa-long-arrow-right"></i> {}').format(begin, end)
-                if begin != end else begin
-            )
             data['tag_ids'] = event.tag_ids.read(['name'])
-            data['lowest_ticket_price'] = event._get_lowest_ticket_price()
             data['image_url'] = event._get_image_url()
         return results_data

--- a/addons/website_event/models/website.py
+++ b/addons/website_event/models/website.py
@@ -85,6 +85,6 @@ class Website(models.Model):
 
     def _search_get_details(self, search_type, order, options):
         result = super()._search_get_details(search_type, order, options)
-        if search_type in ['events', 'event_event', 'all']:
+        if search_type in ['events', 'all']:
             result.append(self.env['event.event']._search_get_detail(self, order, options))
         return result

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -179,7 +179,7 @@ class EventSponsor(models.Model):
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
-            'description': {'name': 'website_description', 'type': 'text', 'truncate': True, 'html': True},
+            'description': {'name': 'website_description', 'type': 'text', 'truncate': True, 'html': True, 'match': True},
         }
         return {
             'model': 'event.sponsor',

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -502,10 +502,10 @@ class EventTrack(models.Model):
             ('stage_id.is_visible_in_agenda', '=', True),
         ]
         mapping = {
-            'description': {'name': 'description', 'type': 'text', 'truncate': True, 'html': True},
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
-            'search_item_metadata': {'name': 'partner_name', 'type': 'text', 'match': True, 'html': True},
+            'search_item_metadata': {'name': 'partner_name', 'type': 'text', 'html': True, 'match': True},
+            'description': {'name': 'description', 'type': 'text', 'truncate': True, 'html': True, 'match': True},
         }
         return {
             'model': 'event.track',

--- a/addons/website_forum/models/forum_forum.py
+++ b/addons/website_forum/models/forum_forum.py
@@ -327,7 +327,7 @@ class ForumForum(models.Model):
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'image_url': {'name': 'image_url', 'type': 'html'},
             'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
-            'description': {'name': 'description', 'type': 'text', 'truncate': True},
+            'description': {'name': 'description', 'type': 'text', 'truncate': True, 'match': True},
         }
         return {
             'model': 'forum.forum',

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -852,14 +852,13 @@ class ForumPost(models.Model):
     @api.model
     def _search_get_detail(self, website, order, options):
         search_fields = ['name', 'tag_ids.name', 'content']
-        fetch_fields = ['id', 'name', 'tag_ids', 'website_url', 'content', 'write_date']
+        fetch_fields = ['id', 'name', 'tag_ids', 'website_url', 'content']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'search_item_metadata': {'name': 'created_by', 'type': 'text', 'truncate': False},
             'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
             'description': {'name': 'content', 'type': 'text', 'html': True, 'match': True},
-            'date': {'name': 'write_date', 'type': 'date'},
             'image_url': {'name': 'image_url', 'type': 'html'},
         }
 

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -856,10 +856,10 @@ class ForumPost(models.Model):
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
-            'search_item_metadata': {'name': 'created_by', 'type': 'text', 'truncate': False},
+            'search_item_metadata': {'name': 'created_by', 'type': 'text', 'truncate': False, 'match': True},
+            'image_url': {'name': 'image_url', 'type': 'html'},
             'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
             'description': {'name': 'content', 'type': 'text', 'html': True, 'match': True},
-            'image_url': {'name': 'image_url', 'type': 'html'},
         }
 
         domain = website.website_domain()

--- a/addons/website_forum/models/website.py
+++ b/addons/website_forum/models/website.py
@@ -33,9 +33,9 @@ class Website(models.Model):
 
     def _search_get_details(self, search_type, order, options):
         result = super()._search_get_details(search_type, order, options)
-        if search_type in ['forums', 'forum_posts_only', 'forum_post', 'all']:
+        if search_type in ['forums', 'forum_posts_only', 'all']:
             result.append(self.env['forum.post']._search_get_detail(self, order, options))
-        if search_type in ['forums', 'forum_tags_only', 'forum_tag']:
+        if search_type in ['forums', 'forum_tags_only']:
             result.append(self.env['forum.tag']._search_get_detail(self, order, options))
         return result
 

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -161,15 +161,9 @@
                     display_description.f="true"
                     display_detail.f="true"
                     _modal_id.f="forum_questions"
-                    _form_classes.f="flex-grow-1">
-                    <t t-if="_page_name == 'tags'">
-                        <t t-set="search_type" t-value="'forum_tags_only'"/>
-                        <t t-set="action" t-value="'/forum/%s/tag' % (_forum_slug)"/>
-                    </t>
-                    <t t-else="">
-                        <t t-set="search_type" t-value="'forums'"/>
-                        <t t-set="action" t-value="'/forum/%s' % (_forum_slug)"/>
-                    </t>
+                    _form_classes.f="flex-grow-1"
+                    search_type="'forums' if _page_name != 'tags' else 'forum_tags_only'"
+                    action="'/forum/%s' % (_forum_slug)">
                     <input t-if="filters" type="hidden" name="filters" t-att-value="filters"/>
                     <input t-if="my" type="hidden" name="my" t-att-value="my"/>
                     <input t-if="sorting" type="hidden" name="sorting" t-att-value="sorting"/>

--- a/addons/website_hr_recruitment/models/hr_job.py
+++ b/addons/website_hr_recruitment/models/hr_job.py
@@ -132,11 +132,12 @@ spirit. To be successful, you will have solid solving problem skills.''')
             domain.append([('website_published', '=', True)])
 
         search_fields = ['name', 'description']
-        fetch_fields = ['name', 'website_url']
+        fetch_fields = ['name', 'website_url', 'description']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'search_item_metadata': {'name': 'address', 'type': 'text'},
+            'description': {'name': 'description', 'type': 'text', 'html': True, 'match': True},
         }
         return {
             'model': 'hr.job',

--- a/addons/website_hr_recruitment/models/hr_job.py
+++ b/addons/website_hr_recruitment/models/hr_job.py
@@ -132,13 +132,11 @@ spirit. To be successful, you will have solid solving problem skills.''')
             domain.append([('website_published', '=', True)])
 
         search_fields = ['name', 'description']
-        fetch_fields = ['name', 'website_url', 'no_of_recruitment']
+        fetch_fields = ['name', 'website_url']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'search_item_metadata': {'name': 'address', 'type': 'text'},
-            'department_name': {'name': 'department_name', 'type': 'text'},
-            'no_of_recruitment': {'name': 'no_of_recruitment', 'type': 'integer'},
         }
         return {
             'model': 'hr.job',
@@ -155,9 +153,8 @@ spirit. To be successful, you will have solid solving problem skills.''')
     def _search_render_results(self, fetch_fields, mapping, icon, limit):
         results_data = super()._search_render_results(fetch_fields, mapping, icon, limit)
         for data in results_data:
-            job = self.browse(data['id'])
-            data['department_name'] = job.department_id.name or ''
+            job = self.browse(data['id']).sudo()
             # res.partner address_id is not available in public user group,
             # - require sudo
-            data['address'] = job.sudo().address_id.name or ''
+            data['address'] = job.address_id.name or ''
         return results_data

--- a/addons/website_hr_recruitment/models/website.py
+++ b/addons/website_hr_recruitment/models/website.py
@@ -14,6 +14,6 @@ class Website(models.Model):
 
     def _search_get_details(self, search_type, order, options):
         result = super()._search_get_details(search_type, order, options)
-        if search_type in ['jobs', 'hr_job', 'all']:
+        if search_type in ['jobs', 'all']:
             result.append(self.env['hr.job']._search_get_detail(self, order, options))
         return result

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -165,12 +165,13 @@ class ProductPublicCategory(models.Model):
     @api.model
     def _search_get_detail(self, website, order, options):
         search_fields = ['name', 'website_description']
-        fetch_fields = ['id', 'name', 'parents_and_self']
+        fetch_fields = ['id', 'name', 'parents_and_self', 'website_description']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'url', 'type': 'text', 'truncate': False},
             'search_item_metadata': {'name': 'breadcrumb', 'type': 'text', 'truncate': False},
             'image_url': {'name': 'image_url', 'type': 'html'},
+            'description': {'name': 'website_description', 'type': 'text', 'html': True, 'match': True},
         }
         return {
             'model': 'product.public.category',

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -872,15 +872,12 @@ class ProductTemplate(models.Model):
         if attribute_value_dict:
             domains.extend(self._get_attribute_value_domain(attribute_value_dict))
         search_fields = ['name', 'default_code', 'variants_default_code', 'description', 'description_sale']
-        fetch_fields = ['id', 'name', 'website_url', 'rating_avg', 'description_sale']
+        fetch_fields = ['id', 'name', 'website_url']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'search_item_metadata': {'name': 'list_price', 'type': 'html', 'display_currency': options['display_currency']},
-            'rating': {'name': 'rating_avg', 'type': 'float', 'precision': 1},
-            'extra_link': {'name': 'category', 'type': 'html'},
             'image_url': {'name': 'image_url', 'type': 'html'},
-            'price': {'name': 'price', 'type': 'html', 'display_currency': options['display_currency']},
         }
         return {
             'model': 'product.template',
@@ -894,42 +891,22 @@ class ProductTemplate(models.Model):
         }
 
     def _search_render_results(self, fetch_fields, mapping, icon, limit):
-        with_image = 'image_url' in mapping
-        with_category = 'extra_link' in mapping
-        with_price = 'price' in mapping
         results_data = super()._search_render_results(fetch_fields, mapping, icon, limit)
-        current_website = self.env['website'].get_current_website()
         for product, data in zip(self, results_data):
-            categ_ids = product.public_categ_ids.filtered(lambda c: not c.website_id or c.website_id == current_website)
-            if with_price:
-                combination_info = product._get_combination_info(only_template=True)
-                data['price'], list_price = self._search_render_results_prices(
-                    mapping, combination_info
-                )
-                if list_price:
-                    data['list_price'] = list_price
-
-            if with_image:
-                data['image_url'] = '/web/image/product.template/%s/image_128' % data['id']
-            if with_category and categ_ids:
-                data['category'] = self.env['ir.ui.view']._render_template(
-                    "website_sale.product_category_extra_link",
-                    {
-                        'categories': categ_ids,
-                        'slug': self.env['ir.http']._slug,
-                        'shop_path': SHOP_PATH,
-                    }
-                )
+            combination_info = product._get_combination_info(only_template=True)
+            list_price = self._search_render_results_prices(
+                mapping, combination_info
+            )
+            if list_price:
+                data['list_price'] = list_price
+            data['image_url'] = '/web/image/product.template/%s/image_128' % data['id']
         return results_data
 
     def _search_render_results_prices(self, mapping, combination_info):
         if combination_info.get('prevent_zero_price_sale'):
             return None, None
 
-        monetary_options = {'display_currency': mapping['price']['display_currency']}
-        price = self.env['ir.qweb.field.monetary'].value_to_html(
-            combination_info['price'], monetary_options
-        )
+        monetary_options = {'display_currency': mapping['search_item_metadata']['display_currency']}
         list_price = None
         if combination_info['has_discounted_price']:
             list_price = self.env['ir.qweb.field.monetary'].value_to_html(
@@ -939,8 +916,12 @@ class ProductTemplate(models.Model):
             list_price = self.env['ir.qweb.field.monetary'].value_to_html(
                 combination_info['compare_list_price'], monetary_options
             )
-
-        return price, list_price
+        if list_price:
+            return list_price
+        price = self.env["ir.qweb.field.monetary"].value_to_html(
+            combination_info["price"], monetary_options
+        )
+        return price
 
     def _get_google_analytics_data(self, product, combination_info):
         self.ensure_one()

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -871,13 +871,14 @@ class ProductTemplate(models.Model):
             domains.append([('list_price', '<=', max_price)])
         if attribute_value_dict:
             domains.extend(self._get_attribute_value_domain(attribute_value_dict))
-        search_fields = ['name', 'default_code', 'variants_default_code', 'description', 'description_sale']
-        fetch_fields = ['id', 'name', 'website_url']
+        search_fields = ['name', 'default_code', 'variants_default_code', 'description_ecommerce']
+        fetch_fields = ['id', 'name', 'website_url', 'description_ecommerce']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'search_item_metadata': {'name': 'list_price', 'type': 'html', 'display_currency': options['display_currency']},
             'image_url': {'name': 'image_url', 'type': 'html'},
+            'description': {'name': 'description_ecommerce', 'type': 'text', 'html': True, 'match': True},
         }
         return {
             'model': 'product.template',

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -869,9 +869,9 @@ class Website(models.Model):
         result = super()._search_get_details(search_type, order, options)
         if not self.has_ecommerce_access():
             return result
-        if search_type in ['product_categories_only', 'product_public_category', 'all']:
+        if search_type in ['products', 'all']:
             result.append(self.env['product.public.category']._search_get_detail(self, order, options))
-        if search_type in ['products', 'products_only', 'product_template', 'all']:
+        if search_type in ['products', 'products_only', 'all']:
             result.append(self.env['product.template']._search_get_detail(self, order, options))
         return result
 

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -1049,13 +1049,14 @@ class SlideChannel(models.Model):
         if slide_category and 'nbr_%s' % slide_category in self:
             domain.append([('nbr_%s' % slide_category, '>', 0)])
         search_fields = ['name', 'tag_ids.name', 'description_short']
-        fetch_fields = ['name', 'website_url', 'tag_ids', 'total_time']
+        fetch_fields = ['name', 'website_url', 'tag_ids', 'total_time', 'description_short']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'search_item_metadata': {'name': 'total_time', 'type': 'text'},
             'image_url': {'name': 'image_url', 'type': 'html'},
             'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
+            'description': {'name': 'description_short', 'type': 'text', 'html': True, 'match': True},
         }
         return {
             'model': 'slide.channel',

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -1049,12 +1049,11 @@ class SlideChannel(models.Model):
         if slide_category and 'nbr_%s' % slide_category in self:
             domain.append([('nbr_%s' % slide_category, '>', 0)])
         search_fields = ['name', 'tag_ids.name', 'description_short']
-        fetch_fields = ['name', 'website_url', 'tag_ids', 'total_time', 'rating_avg_stars']
+        fetch_fields = ['name', 'website_url', 'tag_ids', 'total_time']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
             'search_item_metadata': {'name': 'total_time', 'type': 'text'},
-            'rating_avg_stars': {'name': 'rating_avg_stars', 'type': 'float', 'precision': 1},
             'image_url': {'name': 'image_url', 'type': 'html'},
             'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
         }

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -1281,13 +1281,14 @@ class SlideSlide(models.Model):
     @api.model
     def _search_get_detail(self, website, order, options):
         search_fields = ['name', 'tag_ids.name', 'description']
-        fetch_fields = ['id', 'name', 'tag_ids']
+        fetch_fields = ['id', 'name', 'tag_ids', 'description']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'url', 'type': 'text', 'truncate': False},
             'extra_link': {'name': 'course', 'type': 'text'},
             'extra_link_url': {'name': 'course_url', 'type': 'text', 'truncate': False},
             'tags': {'name': 'tag_ids', 'type': 'tags', 'match': True},
+            'description': {'name': 'description', 'type': 'text', 'html': True, 'match': True},
         }
         return {
             'model': 'slide.slide',

--- a/addons/website_slides/models/website.py
+++ b/addons/website_slides/models/website.py
@@ -16,8 +16,8 @@ class Website(models.Model):
 
     def _search_get_details(self, search_type, order, options):
         result = super()._search_get_details(search_type, order, options)
-        if search_type in ['slides', 'slide_channels_only', 'slide_channel', 'all']:
+        if search_type in ['slides', 'slide_channels_only', 'all']:
             result.append(self.env['slide.channel']._search_get_detail(self, order, options))
-        if search_type in ['slides_only', 'slide_slide']:
+        if search_type == 'slides':
             result.append(self.env['slide.slide']._search_get_detail(self, order, options))
         return result


### PR DESCRIPTION
Before this commit:
The search result display all the tags of the searched element irrespective of the matched tag. If any of tag matches with the searched term, all tags are displayed.

After this commit:
The tags are filtered to show only display the matched tag with searched term; extra tags are not passed into result.

task-5264317