### PR TITLE
[FIX] Hr: Hiding new contract button if missing contract start

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -360,7 +360,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite" widget="date_dynamic_min" options="{'min_date_field': 'contract_date_start'}"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <label for="wage"/>
                                         <div class="o_row" name="wage">


### PR DESCRIPTION
The new contract option under the hr employee payroll tab will be conditionally visible in case the employee already had a contract. Otherwise the user is not permitted to initiate a new contract without an older one

Task: 5904916