### PR TITLE
[FIX] Hr holidays: fixed the virtual_remaining_leaves computation function

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -283,7 +283,7 @@ class HrLeaveType(models.Model):
         leave_types = self.env['hr.leave.type'].search([])
 
         def is_valid(leave_type):
-            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves)
+            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves, value)
         return [('id', 'in', leave_types.filtered(is_valid).ids)]
 
     @api.depends_context('uid', 'employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -36,3 +36,4 @@ from . import test_multi_contract
 from . import test_time_off_allocation_tour
 from . import test_flexible_resource_calendar
 from . import test_calendar_leaves_count
+from . import test_time_off_type

--- a/addons/hr_holidays/tests/test_time_off_type.py
+++ b/addons/hr_holidays/tests/test_time_off_type.py
@@ -1,0 +1,57 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import tagged
+
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+
+
+@tagged('moali_test', '-at_install')
+class TestTimeOffType(TestHrHolidaysCommon):
+
+    def test_time_off_type(self):
+        """ A test file to check for the time-off type field breaking on time off creation from smart button """
+        trackable_enough_leave_type = self.env['hr.leave.type'].create({
+            'name': 'Trackable Time Off Type 1',
+            'requires_allocation': True,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+        })
+
+        trackable_not_enough_leave_type = self.env['hr.leave.type'].create({
+            'name': 'Trackable Time Off Type 2',
+            'requires_allocation': True,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+        })
+
+        untrackable_leave_type = self.env['hr.leave.type'].create({
+            'name': 'Untrackable Time Off Type',
+            'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+        })
+
+        employee = self.env['hr.employee'].create({
+            'name': 'Test user',
+        })
+
+        enough_allocation = self.env['hr.leave.allocation'].create({
+            'employee_id': employee.id,
+            'number_of_days': 5,
+            'holiday_status_id': trackable_enough_leave_type.id,
+            'state': 'confirm',
+        }).action_approve()
+
+        not_enough_allocation = self.env['hr.leave.allocation'].create({
+            'employee_id': employee.id,
+            'number_of_days': 2,
+            'holiday_status_id': trackable_not_enough_leave_type.id,
+            'state': 'confirm',
+        }).action_approve()
+
+        available_types = self.env['hr.leave.type'].with_context(
+            employee_id=employee.id).search([('virtual_remaining_leaves', '>', 3)])
+
+        self.assertNotIn(trackable_not_enough_leave_type.id, available_types.ids)
+        self.assertIn(trackable_enough_leave_type.id, available_types.ids)
+        self.assertIn(untrackable_leave_type.id, available_types.ids)
+


### PR DESCRIPTION
Due to an error in the virtual_remaining_leaves computation function, leave types that required allocation were throwing an error to the user whenever they tried assigning time off to any employee due to a missing parameter in the method being called. Added a unit test to confirm the fix.

Issue: 5905492