### PR TITLE
[FIX] hr_holidays: restrict day selection based on the month

### DIFF
--- a/addons/hr_holidays/static/src/components/day_selection/day_selection.js
+++ b/addons/hr_holidays/static/src/components/day_selection/day_selection.js
@@ -1,0 +1,31 @@
+import { registry } from "@web/core/registry";
+import { selectionField, SelectionField } from "@web/views/fields/selection/selection_field";
+
+export class DaySelectionField extends SelectionField {
+    static props = {
+        ...SelectionField.props,
+        monthField: { type: String },
+    };
+
+    get options() {
+        const options = super.options;
+        const monthNumber = this.props.record.data[this.props.monthField];
+
+        // Use 2024 to get 29 days for February since it's a leap year
+        const lastDay = new Date(2024, parseInt(monthNumber), 0).getDate();
+        return options.filter((options) => parseInt(options[0]) <= lastDay);
+    }
+}
+
+export const daySelectionField = {
+    ...selectionField,
+    component: DaySelectionField,
+    extractProps({ attrs }) {
+        return {
+            ...selectionField.extractProps(...arguments),
+            monthField: attrs.month_field,
+        };
+    },
+};
+
+registry.category("fields").add("day_selection", daySelectionField);

--- a/addons/hr_holidays/static/tests/tours/time_off_accrual_date_filter_tour.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_accrual_date_filter_tour.js
@@ -1,0 +1,189 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_utils";
+
+registry.category("web_tour.tours").add("time_off_accrual_date_filter_tour", {
+    url: "/odoo",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        // Open Time Off app and create new accrual plan
+        {
+            content: "Open Time Off app",
+            trigger: '.o_app[data-menu-xmlid="hr_holidays.menu_hr_holidays_root"]',
+            run: "click",
+        },
+        {
+            content: "Open Configuration",
+            trigger:
+                '.o_menu_sections [data-menu-xmlid="hr_holidays.menu_hr_holidays_configuration"]',
+            run: "click",
+        },
+        {
+            content: "Open Accrual Plans",
+            trigger:
+                '.dropdown-item[data-menu-xmlid="hr_holidays.hr_holidays_accrual_menu_configuration"]',
+            run: "click",
+        },
+        {
+            content: "Click the New button to create a plan",
+            trigger: ".o_list_button_add",
+            run: "click",
+        },
+        {
+            content: "Add a milestone",
+            trigger: 'button[name="action_create_accrual_plan_level"]',
+            run: "click",
+        },
+        {
+            content: "Open the frequency dropdown menu",
+            trigger: '.o_field_widget[name="frequency"] .o_select_menu_toggler',
+            run: "click",
+        },
+        {
+            content: "Wait for the menu to open",
+            trigger: ".o_select_menu_menu",
+        },
+        {
+            content: "Select the Yearly frequency type",
+            trigger: '.o_select_menu_item[data-choice-index="6"]',
+            run: "click",
+        },
+        // Check the number of days available for January (1-31)
+        {
+            content: "Open the month selection menu",
+            trigger: '.o_field_widget[name="yearly_month"] .o_select_menu_toggler',
+            run: "click",
+        },
+        {
+            content: "Select January from the list of months",
+            trigger: '.o_select_menu_item[data-choice-index="0"]',
+            run: function (actions) {
+                actions.click();
+            },
+        },
+        {
+            content: "Wait for dropdown to disappear",
+            trigger: "body:not(:has(.o_select_menu_menu))",
+        },
+        {
+            content: "Open the days menu",
+            trigger: '.o_field_widget[name="yearly_day"] .o_select_menu_toggler',
+            run: "click",
+        },
+        {
+            content: "Verify January shows day 31",
+            trigger: ".o_select_menu_menu:has(.o_select_menu_item:contains('31'))",
+        },
+        {
+            content: "Verify January shows day 30",
+            trigger: ".o_select_menu_menu:has(.o_select_menu_item:contains('30'))",
+        },
+        {
+            content: "Select the last day from the list of months",
+            trigger: '.o_select_menu_item[data-choice-index="30"]',
+            run: function (actions) {
+                actions.click();
+            },
+        },
+        {
+            content: "Wait for dropdown to disappear",
+            trigger: "body:not(:has(.o_select_menu_menu))",
+        },
+        // Check the number of days available for February (1-29)
+        {
+            content: "Open the month selection menu",
+            trigger: '.o_field_widget[name="yearly_month"] .o_select_menu_toggler',
+            run: "click",
+        },
+        {
+            content: "Select February from the list of months",
+            trigger: '.o_select_menu_item[data-choice-index="1"]',
+            run: function (actions) {
+                actions.click();
+            },
+        },
+        {
+            content: "Wait for dropdown to disappear",
+            trigger: "body:not(:has(.o_select_menu_menu))",
+        },
+        {
+            content: "Open the days menu",
+            trigger: '.o_field_widget[name="yearly_day"] .o_select_menu_toggler',
+            run: "click",
+        },
+        {
+            content: "Verify that 29 is the selected item in the open menu",
+            trigger: '.o_select_menu_menu .o_select_menu_item.selected:contains("29")',
+        },
+        {
+            content: "Check that 30 is missing",
+            trigger: ".o_select_menu_menu:not(:has(.o_select_menu_item:contains('30')))",
+        },
+        {
+            content: "Check that 31 is missing",
+            trigger: ".o_select_menu_menu:not(:has(.o_select_menu_item:contains('31')))",
+        },
+        {
+            content: "Select a day from the list of months",
+            trigger: '.o_select_menu_item[data-choice-index="28"]',
+            run: function (actions) {
+                actions.click();
+            },
+        },
+        {
+            content: "Wait for dropdown to disappear",
+            trigger: "body:not(:has(.o_select_menu_menu))",
+        },
+        // Check the number of days available for April (1-30)
+        {
+            content: "Open the month selection menu",
+            trigger: '.o_field_widget[name="yearly_month"] .o_select_menu_toggler',
+            run: "click",
+        },
+        {
+            content: "Select April from the list of months",
+            trigger: '.o_select_menu_item[data-choice-index="3"]',
+            run: function (actions) {
+                actions.click();
+            },
+        },
+        {
+            content: "Wait for dropdown to disappear",
+            trigger: "body:not(:has(.o_select_menu_menu))",
+        },
+        {
+            content: "Open the days menu",
+            trigger: '.o_field_widget[name="yearly_day"] .o_select_menu_toggler',
+            run: "click",
+        },
+        {
+            content: "Check that 31 is missing",
+            trigger: ".o_select_menu_menu:not(:has(.o_select_menu_item:contains('31')))",
+        },
+        {
+            content: "Select a day from the list of months",
+            trigger: '.o_select_menu_item[data-choice-index="28"]',
+            run: function (actions) {
+                actions.click();
+            },
+        },
+        {
+            content: "Wait for RPC and UI to settle",
+            trigger: "body:not(.o_rpc_waiting)",
+        },
+        {
+            trigger: 'button[special="save"]',
+            content: "Save the Accrual Level Modal",
+            run: "click",
+        },
+        {
+            content: "Type the name of the accrual plan",
+            trigger: '.o_field_char[name="name"] input',
+            run: "fill Test Accrual plan",
+        },
+        {
+            content: "Click the cloud save button",
+            trigger: "button.o_form_button_save:has(i.fa-cloud-upload)",
+            run: "click",
+        },
+    ],
+});

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -36,3 +36,4 @@ from . import test_multi_contract
 from . import test_time_off_allocation_tour
 from . import test_flexible_resource_calendar
 from . import test_calendar_leaves_count
+from . import test_time_off_accrual_date_filter_tour

--- a/addons/hr_holidays/tests/test_time_off_accrual_date_filter_tour.py
+++ b/addons/hr_holidays/tests/test_time_off_accrual_date_filter_tour.py
@@ -1,0 +1,9 @@
+from odoo.tests import HttpCase, tagged, users
+
+
+@tagged('post_install', '-at_install')
+class TestTimeOffAccrualDateFilterTour(HttpCase):
+
+    @users('admin')
+    def test_time_off_accrual_date_filter_tour(self):
+        self.start_tour('/odoo', 'time_off_accrual_date_filter_tour', login='admin')

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,17 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" class="o_field_accrual" widget="day_selection" month_field="first_month" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field name="first_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" class="o_field_accrual" widget="day_selection" month_field="second_month" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" class="o_field_accrual" widget="day_selection" month_field="yearly_month" required="frequency == 'yearly'" placeholder="select a day"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -191,9 +191,9 @@
                                                widget="radio_followed_by_element"
                                                options="{'links': {'other': 'carryover_custom_date'}, 'observe': 'carryover'}"/>
                                         <span id="carryover_custom_date">
-                                            : the
-                                            <field name="carryover_day" placeholder="select a day"
-                                                   required="carryover_date == 'other'"/>
+                                            : the <field nolabel="1" name="carryover_day" 
+                                                        class="o_field_accrual" widget="day_selection" month_field="carryover_month" 
+                                                        placeholder="select a day" required="carryover_date == 'other'"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"
                                                    required="carryover_date == 'other'"/>


### PR DESCRIPTION
Problem
-----------
When creating an accrual plan with yearly or twice yearly accrual frequency, days 1-31 are available for every month, so February 31 is a possible date to set.

Objective
------------
The selection field does not filter the days based on the month that is selected, so all months allow days 1-31. Need to change the UI to only show valid days for each month.

Solution
------------
- Created new component to filter day selection options based on the selected month
- Edited the accrual views to use the widget
- Created JS tour to test the widget

Task: 5913447