### PR TITLE
[REF] html_editor, *: continue refactoring resources

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -1,7 +1,7 @@
 declare module "plugins" {
     import { AnchorShared } from "@html_builder/core/anchor/anchor_plugin";
     import { builder_components, BuilderComponentShared } from "@html_builder/core/builder_component_plugin";
-    import { builder_header_middle_buttons, builder_options, BuilderOptionsShared, on_current_options_containers_changed_handlers, clone_disabled_reason_processors, container_title, elements_to_options_title_components, options_container_top_buttons_providers, has_overlay_options, should_keep_overlay_options_predicates, no_parent_containers, on_will_restore_containers_handlers, remove_disabled_reason_processors } from "@html_builder/core/builder_options_plugin";
+    import { builder_header_middle_buttons, builder_options, BuilderOptionsShared, on_current_options_containers_changed_handlers, clone_disabled_reason_providers, container_title, elements_to_options_title_components, options_container_top_buttons_providers, has_overlay_options, should_keep_overlay_options_predicates, no_parent_containers, on_will_restore_containers_handlers, remove_disabled_reason_providers } from "@html_builder/core/builder_options_plugin";
     import { BuilderOverlayShared } from "@html_builder/core/builder_overlay/builder_overlay_plugin";
     import { CachedModelShared } from "@html_builder/core/cached_model_plugin";
     import { CloneShared, on_cloned_handlers, on_will_clone_handlers } from "@html_builder/core/clone_plugin";
@@ -113,18 +113,18 @@ declare module "plugins" {
         is_valid_for_sibling_dropzone_predicates: is_valid_for_sibling_dropzone_predicates;
 
         // Processors
-        clone_disabled_reason_processors: clone_disabled_reason_processors;
-        remove_disabled_reason_processors: remove_disabled_reason_processors;
         snippet_preview_dialog_stylesheets_processors: snippet_preview_dialog_stylesheets_processors;
 
         // Providers
         background_filter_target_providers: background_filter_target_providers;
         background_shape_groups_providers: background_shape_groups_providers;
         background_shape_target_providers: background_shape_target_providers;
+        clone_disabled_reason_providers: clone_disabled_reason_providers;
         default_shape_providers: default_shape_providers;
         dirty_els_providers: dirty_els_providers;
         image_shape_groups_providers: image_shape_groups_providers;
         options_container_top_buttons_providers: options_container_top_buttons_providers;
+        remove_disabled_reason_providers: remove_disabled_reason_providers;
         target_element_providers: target_element_providers;
 
         // Data

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -92,9 +92,8 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
  */
 /**
  * @typedef {((
- *      reasons: Array<string|Markup|LazyTranslatedString>,
  *      el: HTMLElement
- * ) => Array<string|Markup|LazyTranslatedString>)[]} clone_disabled_reason_processors
+ * ) => string|Markup|LazyTranslatedString|undefined)[]} clone_disabled_reason_providers
  *
  * Appends new reasons to the `reasons` array given as a parameter.
  *
@@ -107,9 +106,8 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
  */
 /**
  * @typedef {((
- *      reasons: Array<string|Markup|LazyTranslatedString>,
  *      el: HTMLElement
- * ) => Array<string|Markup|LazyTranslatedString>)[]} remove_disabled_reason_processors
+ * ) => string|Markup|LazyTranslatedString|undefined)[]} remove_disabled_reason_providers
  *
  * Appends new reasons to the `reasons` array given as a parameter.
  *
@@ -428,7 +426,8 @@ export class BuilderOptionsPlugin extends Plugin {
         const parentEl = el.parentElement;
         const isAloneInColumn = parentEl?.children.length === 1 && parentEl.matches(".row > div");
         const isInnerSnippet = this.config.snippetModel.isInnerContent(el);
-        const keepOptions = this.checkPredicates("should_keep_overlay_options_predicates", el) ?? false;
+        const keepOptions =
+            this.checkPredicates("should_keep_overlay_options_predicates", el) ?? false;
         if (isInnerSnippet && isAloneInColumn && !keepOptions) {
             return false;
         }
@@ -443,7 +442,9 @@ export class BuilderOptionsPlugin extends Plugin {
 
     getOptionsContainerTopButtons(el) {
         const buttons = [];
-        for (const getContainerButtons of this.getResource("options_container_top_buttons_providers")) {
+        for (const getContainerButtons of this.getResource(
+            "options_container_top_buttons_providers"
+        )) {
             buttons.push(...getContainerButtons(el));
             for (const button of buttons) {
                 const handler = button.handler;
@@ -534,13 +535,19 @@ export class BuilderOptionsPlugin extends Plugin {
 
     getRemoveDisabledReason(el) {
         return (
-            this.processThrough("remove_disabled_reason_processors", [], el).join(" ") || undefined
+            this.getResource("remove_disabled_reason_providers")
+                .map((p) => p(el))
+                .filter(Boolean)
+                .join(" ") || undefined
         );
     }
 
     getCloneDisabledReason(el) {
         return (
-            this.processThrough("clone_disabled_reason_processors", [], el).join(" ") || undefined
+            this.getResource("clone_disabled_reason_providers")
+                .map((p) => p(el))
+                .filter(Boolean)
+                .join(" ") || undefined
         );
     }
 

--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -89,7 +89,9 @@ export class ImageShapeOptionPlugin extends Plugin {
         },
         on_will_process_image_handlers: this.processImageWarmup.bind(this),
         on_image_processed_handlers: this.processImagePost.bind(this),
-        can_have_hover_effect_async_predicates: (el) => this.canHaveHoverEffect(el),
+        can_have_hover_effect_predicates: (el, dataset) => this.canHaveHoverEffect(el, dataset),
+        hover_effect_image_dataset_providers: async (imgEl) =>
+            Object.assign({}, imgEl.dataset, await loadImageInfo(imgEl)),
         image_shape_groups_providers: withSequence(0, () => deepCopy(imageShapeDefinitions)),
     };
     setup() {
@@ -101,8 +103,7 @@ export class ImageShapeOptionPlugin extends Plugin {
             this.imageShapes[oldShapeId] = this.imageShapes[shapeId];
         }
     }
-    async canHaveHoverEffect(imgEl) {
-        const dataset = Object.assign({}, imgEl.dataset, await loadImageInfo(imgEl));
+    canHaveHoverEffect(imgEl, dataset) {
         return (
             imgEl.tagName === "IMG" &&
             !this.isDeviceShape(imgEl) &&

--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -106,14 +106,17 @@ class ImageToolOptionPlugin extends Plugin {
                 }
             }
         },
-        can_have_hover_effect_async_predicates: (el) => this.canHaveHoverEffect(el),
+        can_have_hover_effect_predicates: (el, dataset) => this.canHaveHoverEffect(el, dataset),
         normalize_processors: this.migrateImages.bind(this),
+        hover_effect_image_dataset_providers: (imgEl) => ({
+            isCorsProtected: isImageCorsProtected(imgEl),
+        }),
     };
     setup() {
         this.htmlStyle = getHtmlStyle(this.document);
     }
-    async canHaveHoverEffect(imgEl) {
-        return imgEl.tagName === "IMG" && !(await isImageCorsProtected(imgEl));
+    canHaveHoverEffect(imgEl, dataset) {
+        return imgEl.tagName === "IMG" && !dataset.isCorsProtected;
     }
     migrateImages(rootEl) {
         for (const el of selectElements(

--- a/addons/html_builder/static/tests/builder_option.test.js
+++ b/addons/html_builder/static/tests/builder_option.test.js
@@ -312,9 +312,9 @@ test("Option containers should update reactively", async () => {
         static id = "test";
         resources = {
             builder_options: [Option],
-            clone_disabled_reason_processors: (reasons, el) => {
+            clone_disabled_reason_providers: (el) => {
                 if (el.classList.contains("disabled_clone")) {
-                    reasons.push("Test reason");
+                    return "Test reason";
                 }
             },
             container_title: {
@@ -357,9 +357,9 @@ test("Option containers dispatched to plugins are updated reactively", async () 
         resources = {
             builder_options: [Option],
             builder_actions: { TestAction },
-            remove_disabled_reason_processors: (reasons, el) => {
+            remove_disabled_reason_providers: (el) => {
                 if (el.classList.contains("not_removable")) {
-                    reasons.push("Class list has 'not_removable'");
+                    return "Class list has 'not_removable'";
                 }
             },
             on_current_options_containers_changed_handlers: (containers) => {

--- a/addons/html_editor/static/src/core/content_editable_plugin.js
+++ b/addons/html_editor/static/src/core/content_editable_plugin.js
@@ -45,7 +45,8 @@ export class ContentEditablePlugin extends Plugin {
         }
         const filteredContentEditableEls = contentEditableEls.filter(
             (contentEditableEl) =>
-                this.checkPredicates("is_valid_contenteditable_predicates", contentEditableEl) ?? true
+                this.checkPredicates("is_valid_contenteditable_predicates", contentEditableEl) ??
+                true
         );
         for (const contentEditableEl of filteredContentEditableEls) {
             if (

--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -2,7 +2,12 @@ import { MAIN_PLUGINS, MOBILE_OS_EXCLUDED_PLUGINS } from "./plugin_sets";
 import { createBaseContainer, SUPPORTED_BASE_CONTAINER_NAMES } from "./utils/base_container";
 import { fillShrunkPhrasingParent, removeClass } from "./utils/dom";
 import { isEmpty } from "./utils/dom_info";
-import { resourceSequenceSymbol, warnOfNamingConvention, withSequence } from "./utils/resource";
+import {
+    FUNCTION_SUFFIX_PAIRS,
+    resourceSequenceSymbol,
+    warnOfNamingConvention,
+    withSequence,
+} from "./utils/resource";
 import { fixInvalidHTML, initElementForEdition } from "./utils/sanitize";
 import { setElementContent } from "@web/core/utils/html";
 import { isMobileOS } from "@web/core/browser/feature_detection";
@@ -284,6 +289,24 @@ export class Editor {
      * @returns {GlobalResources[R]}
      */
     getResource(resourceId) {
+        const targetFunction = FUNCTION_SUFFIX_PAIRS.find((pair) =>
+            resourceId.endsWith(pair[1])
+        )?.[0];
+        if (targetFunction) {
+            warnOfNamingConvention("getResource", resourceId, { targetFunction });
+        }
+        return this.resources[resourceId] || [];
+    }
+
+    /**
+     * Private version of `getResource` to call locally without enforcing naming
+     * conventions.
+     *
+     * @template {GlobalResourcesId} R
+     * @param {R} resourceId
+     * @returns {GlobalResources[R]}
+     */
+    _getResource(resourceId) {
         return this.resources[resourceId] || [];
     }
 
@@ -312,7 +335,7 @@ export class Editor {
                 suffix: "handlers",
             });
         }
-        return this.getResource(resourceId).map((handler) => handler(...args));
+        return this._getResource(resourceId).map((handler) => handler(...args));
     }
 
     /**
@@ -340,7 +363,7 @@ export class Editor {
                 suffix: "handlers",
             });
         }
-        for (const handler of this.getResource(resourceId)) {
+        for (const handler of this._getResource(resourceId)) {
             await handler(...args);
         }
     }
@@ -373,7 +396,7 @@ export class Editor {
         if (!resourceId.endsWith("_overrides")) {
             warnOfNamingConvention("delegateTo", resourceId, { suffix: "overrides" });
         }
-        return this.getResource(resourceId).some((fn) => fn(...args));
+        return this._getResource(resourceId).some((fn) => fn(...args));
     }
 
     /**
@@ -402,7 +425,7 @@ export class Editor {
         if (!resourceId.endsWith("_processors")) {
             warnOfNamingConvention("processThrough", resourceId, { suffix: "processors" });
         }
-        this.getResource(resourceId).forEach((processor) => {
+        this._getResource(resourceId).forEach((processor) => {
             item = processor(item, ...args) || item;
         });
         return item;
@@ -433,7 +456,7 @@ export class Editor {
         if (!resourceId.endsWith("_predicates")) {
             warnOfNamingConvention("checkPredicates", resourceId, { suffix: "predicates" });
         }
-        const results = this.getResource(resourceId)
+        const results = this._getResource(resourceId)
             .map((predicate) => predicate(...args))
             .filter((result) => result !== undefined);
         return results.length ? results.every(Boolean) : undefined;

--- a/addons/html_editor/static/src/utils/resource.js
+++ b/addons/html_editor/static/src/utils/resource.js
@@ -24,6 +24,14 @@ export function withSequence(sequenceNumber, object) {
     };
 }
 
+export const FUNCTION_SUFFIX_PAIRS = [
+    ["triggerAsync", "sequential_async_handlers"],
+    ["trigger", "handlers"],
+    ["delegateTo", "overrides"],
+    ["processThrough", "processors"],
+    ["checkPredicates", "predicates"],
+];
+
 export function warnOfNamingConvention(
     functionName,
     resourceId,

--- a/addons/website/static/src/@types/plugins.d.ts
+++ b/addons/website/static/src/@types/plugins.d.ts
@@ -7,7 +7,7 @@ declare module "plugins" {
     import { ImageHoverShared } from "@website/builder/plugins/image/image_hover_plugin";
     import { AddElementOptionShared } from "@website/builder/plugins/layout_option/add_element_option_plugin";
     import { MenuDataShared } from "@website/builder/plugins/menu_data_plugin";
-    import { can_have_hover_effect_async_predicates } from "@website/builder/plugins/options/animate_option";
+    import { can_have_hover_effect_predicates } from "@website/builder/plugins/options/animate_option";
     import { AnimateOptionShared, on_hover_animation_mode_cleaned_handlers, on_hover_animation_mode_applied_handlers } from "@website/builder/plugins/options/animate_option_plugin";
     import { WebsiteBackgroundVideoShared } from "@website/builder/plugins/options/background_option_plugin";
     import { CardImageOptionShared } from "@website/builder/plugins/options/card_image_option_plugin";
@@ -81,7 +81,7 @@ declare module "plugins" {
         on_visibility_toggled_handlers: on_visibility_toggled_handlers;
 
         // Predicates
-        can_have_hover_effect_async_predicates: can_have_hover_effect_async_predicates;
+        can_have_hover_effect_predicates: can_have_hover_effect_predicates;
 
         // Processors
         reorder_items_processors: reorder_items_processors;

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -114,33 +114,29 @@ export class FormOptionPlugin extends Plugin {
                 },
             },
         ],
-        clone_disabled_reason_processors: (reasons, el) => {
+        clone_disabled_reason_providers: (el) => {
             if (
                 el.classList.contains("s_website_form_field") &&
                 !el.classList.contains("s_website_form_custom")
             ) {
-                reasons.push(_t("You cannot duplicate this field."));
+                return _t("You cannot duplicate this field.");
             }
-            return reasons;
         },
-        remove_disabled_reason_processors: (reasons, el) => {
+        remove_disabled_reason_providers: (el) => {
             if (el.classList.contains("s_website_form_model_required")) {
                 const models = this.modelsCache.get();
                 const modelName = el.closest("form")?.dataset.model_name;
                 const model = models?.find((model) => model.model === modelName);
                 const fieldName = getFieldName(el);
-                reasons.push(
-                    model
+                return model
                         ? _t(
                               'The field "%(fieldName)s" is mandatory for the action "%(actionName)s".',
                               { fieldName, actionName: model.website_form_label }
                           )
                         : _t("The field “%(fieldName)s” is mandatory for the selected action.", {
                               fieldName,
-                          })
-                );
+                          });
             }
-            return reasons;
         },
         builder_options: [FormOption, FormFieldOptionRedraw, WebsiteFormSubmitOption],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/animate_option.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option.js
@@ -9,7 +9,7 @@ import {
 } from "@html_builder/plugins/image/replace_media_option";
 
 /**
- * @typedef {((el: HTMLElement) => Promise<boolean>)[]} can_have_hover_effect_async_predicates
+ * @typedef {((el: HTMLElement) => Promise<boolean>)[]} can_have_hover_effect_predicates
  */
 
 export class AnimateOption extends BaseOptionComponent {
@@ -85,8 +85,9 @@ export class AnimateOption extends BaseOptionComponent {
         return hasDirection;
     }
     async canHaveHoverEffect(el) {
-        const proms = this.getResource("can_have_hover_effect_async_predicates").map((p) => p(el));
-        const settledProms = await Promise.all(proms);
-        return settledProms.length && settledProms.every(Boolean);
+        const proms = this.getResource("hover_effect_image_dataset_providers").map((p) => p(el));
+        const datasets = await Promise.all(proms);
+        const dataset = Object.assign({}, ...datasets);
+        return checkPredicates("is_hover_effect_allowed_predicates", el, dataset) ?? false;
     }
 }


### PR DESCRIPTION
\*: `html_builder`, `website`

This makes `can_have_hover_effect_async_predicates` synchronous so it can use `checkPredicates` and be renamed to
`can_have_hover_effect_predicates`.

This adds a warning in the console when the `getResource` method is used for a resource with a suffix that suggests it could be handled by a special utility function.

This refactors `remove_disabled_reason_processors` and `clone_disabled_reason_processors` so they don't process an array of reasons but provide it instead. They are therefore renamed to `remove_disabled_reason_providers` and
`clone_disabled_reason_providers`, respectively.

task-5207637