### PR TITLE
[IMP] account: Add new filter for 'To Pay' invoices

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1701,6 +1701,12 @@
                     <separator/>
                     <filter string="To Review" name="to_check" domain="[('checked', '=', False), ('state', '!=', 'draft')]"/>
                     <separator/>
+                    <!-- to_pay -->
+                    <filter name="to_pay" string="To pay" domain="[
+                        ('state', '!=', 'cancel'),
+                        ('payment_state', 'not in', ('paid', 'partial')),
+                        ('move_type', '!=', 'entry')
+                    ]"/>
                     <!-- in_payment & paid -->
                     <filter name="in_payment" string="In payment" domain="[('state', '=', 'posted'), ('payment_state', '=', 'in_payment')]"/>
                     <!-- overdue -->


### PR DESCRIPTION
[IMP] accountant: Add new filter for 'To Pay' invoices#5051

Description of the issue/feature this PR addresses:
A new filter needs to be added in the list of filters available by default for invoices. This filter should be called "To Pay" and it should allow us to see invoices that are not cancelled, are not entries, and have either not been paid or are partially paid

Current behavior before PR:
There is currently no "To Pay" filter on invoices.

Desired behavior after PR is merged:
When the filter menu is selected in the invoicing page, a new option called "To Pay" should appear, which filters for invoices corresponding to the criteria define in the spec.

task-6076155
runbot-https://runbot.odoo.com/runbot/bundle/190-accounting-onboarding-andha-454010

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
