### PR TITLE
[IMP] account: add new filter for 'To Pay' invoices

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1701,6 +1701,15 @@
                     <separator/>
                     <filter string="To Review" name="to_check" domain="[('checked', '=', False), ('state', '!=', 'draft')]"/>
                     <separator/>
+                    <!-- to pay -->
+                    <filter name="to_pay"
+                            string="To Pay"
+                            domain="[
+                                ('state', '!=', 'cancel'),
+                                ('payment_state', 'not in', ('paid', 'partial')),
+                                ('move_type', '!=', 'entry'),
+                            ]"
+                    />
                     <!-- in_payment & paid -->
                     <filter name="in_payment" string="In payment" domain="[('state', '=', 'posted'), ('payment_state', '=', 'in_payment')]"/>
                     <!-- overdue -->


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
We want a new filter on top of the in payment one for "To Pay" invoices: It should filter invoice where the state of the move is not cancelled, the state of the payment is not paid or in partial and the move type is not an entry 

Task - 6076217

**Current behavior before PR:**
The "To Pay" filter is does not exist

**Desired behavior after PR is merged:**
The "To Pay" filter exists and filters correctly when selected
<img width="852" height="802" alt="image" src="https://github.com/user-attachments/assets/52818db9-f8d9-42ee-b7fa-b0cee3237cb7" />




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
