### PR TITLE
[IMP] account: add 'To Pay' filter on invoices

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1701,6 +1701,8 @@
                     <separator/>
                     <filter string="To Review" name="to_check" domain="[('checked', '=', False), ('state', '!=', 'draft')]"/>
                     <separator/>
+                    <!-- to_pay -->
+                    <filter name="to_pay" string="To Pay" domain="[('state', '!=', 'cancel'), ('payment_state', 'not in', ('paid', 'partial')), ('move_type', '!=', 'entry')]"/>
                     <!-- in_payment & paid -->
                     <filter name="in_payment" string="In payment" domain="[('state', '=', 'posted'), ('payment_state', '=', 'in_payment')]"/>
                     <!-- overdue -->


### PR DESCRIPTION
Add a new 'To Pay' filter for customer invoices.

This allows users to easily identify invoices awaiting payment by filtering records where:
- The move state is not cancelled
- The payment state is neither paid nor partial
- The move type is not a journal entry