### PR TITLE
[IMP] account: added to_pay filter for invoices

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1701,6 +1701,11 @@
                     <separator/>
                     <filter string="To Review" name="to_check" domain="[('checked', '=', False), ('state', '!=', 'draft')]"/>
                     <separator/>
+                    <filter name="to_pay" string="To Pay" domain="[
+                        ('state', '!=', 'cancel'),
+                        ('payment_state', 'in', ('not_paid', 'partial')),
+                        ('move_type', '!=', 'entry')
+                    ]"/>
                     <!-- in_payment & paid -->
                     <filter name="in_payment" string="In payment" domain="[('state', '=', 'posted'), ('payment_state', '=', 'in_payment')]"/>
                     <!-- overdue -->


### PR DESCRIPTION
Added a new filter for invoices to be paid for easier access the new filter shows invoices that are not cancelled and are not paid or in partial payment and is not an entry.

task-6076085