### PR TITLE
[IMP] account: Make due date invisible for cancelled invoices

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -532,7 +532,8 @@
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" readonly="state != 'draft'" string="Bill Date" decoration-warning="abnormal_date_warning"/>
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')" readonly="state != 'draft'" string="Invoice Date" decoration-warning="abnormal_date_warning"/>
                     <field name="date" optional="hide" string="Accounting Date" readonly="state in ['cancel', 'posted']"/>
-                    <field name="invoice_date_due" widget="remaining_days" optional="show" invisible="payment_state in ('paid', 'in_payment', 'reversed')"/>
+                    <field name="invoice_date_due" widget="remaining_days" optional="show"
+                        invisible="payment_state in ('paid', 'in_payment', 'reversed') or state == 'cancel'" />
                     <field name="invoice_origin" optional="hide" string="Source Document"/>
                     <field name="payment_reference" optional="hide" column_invisible="context.get('default_move_type') in ('out_invoice', 'out_refund', 'out_receipt')"/>
                     <field name="ref" optional="hide"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When an invoice is cancelled, it's due date should no longer be visible in the invoices list view

Current behavior before PR:
Due dates are still visible on invoices in their list view

Desired behavior after PR is merged:
Due dates are no longer visible on invoices in their list view

task-6076155
runbot-https://runbot.odoo.com/runbot/bundle/190-cancel-invoice-invis-due-date-andha-454105

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
