### PR TITLE
[IMP] account: (l10n_fr) allow manual editing of line 25 on FR tax re…

### DIFF
--- a/addons/l10n_fr_account/data/tax_report_data.xml
+++ b/addons/l10n_fr_account/data/tax_report_data.xml
@@ -2427,8 +2427,14 @@
                             <record id="tax_report_25_formula" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">box_23.balance - box_16.balance</field>
+                                <field name="formula">box_23.balance - box_16.balance + box_25.adjustment</field>
                                 <field name="subformula">if_above(EUR(0))</field>
+                            </record>
+                            <record id="tax_report_25_adjustment" model="account.report.expression">
+                                <field name="label">adjustment</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">editable;rounding=0</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
We want to allow line 25 of the FR tax return to be manually adjustable

Current behavior before PR:
Line 25 is computed by a formula and cannot be manually adjusted inside of the FR localized tax return

Desired behavior after PR is merged:
Line 25 is still computed, but may be adjusted manually afterwards inside of the FR localized tax return

task-6076159
runbot-https://runbot.odoo.com/runbot/bundle/190-l10n-fr-adjust-tr-field-25-andha-454118

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
