### PR TITLE
[IMP] account: zeroed credit and debit values show muted in the Journ…

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1404,11 +1404,13 @@
                                                sum="Total Debit"
                                                invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"
+                                               decoration-muted="debit == 0"
                                         />
                                         <field name="credit"
                                                sum="Total Credit"
                                                invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"
+                                               decoration-muted="credit == 0"
                                         />
                                         <field name="balance" column_invisible="True"/>
                                         <field name="discount_date"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the Journal Items tab of an invoice, zero values under the debit and credit columns show up with the same text decoration as non-zero values. This decreases readability, so we want to make the appearance of zeroes more subtle.

Current behavior before PR:
Zero values have the same styling as non-zero values in the debit/credit columns

Desired behavior after PR is merged:
Zero values appear muted in the debit/credit columns

task-6076162
runbot-https://runbot.odoo.com/runbot/bundle/190-mute-zeroed-jounral-items-andha-454163

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
