### PR TITLE
[IMP] l10n_fr_account: tax report field 25 manual editing

### DIFF
--- a/addons/l10n_fr_account/data/tax_report_data.xml
+++ b/addons/l10n_fr_account/data/tax_report_data.xml
@@ -2427,9 +2427,15 @@
                             <record id="tax_report_25_formula" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">box_23.balance - box_16.balance</field>
+                                <field name="formula">box_23.balance - box_16.balance + box_25.adjustment</field>
                                 <field name="subformula">if_above(EUR(0))</field>
                             </record>
+							<record id="tax_report_25_formula_adjustment" model="account.report.expression">
+								<field name="label">adjustment</field>
+								<field name="engine">external</field>
+								<field name="formula">sum</field>
+								<field name="subformula">editable;rounding=0</field>
+							</record>
                         </field>
                     </record>
                     <record id="tax_report_TD" model="account.report.line">


### PR DESCRIPTION
We needed to set the field 25 (25 - VAT credit) in the fr tax report editable by the user.