### PR TITLE
[IMP] l10n_fr_account: add adjustment on field 25 of tax return

### DIFF
--- a/addons/l10n_fr_account/data/tax_report_data.xml
+++ b/addons/l10n_fr_account/data/tax_report_data.xml
@@ -2430,6 +2430,12 @@
                                 <field name="formula">box_23.balance - box_16.balance</field>
                                 <field name="subformula">if_above(EUR(0))</field>
                             </record>
+                            <record id="tax_report_25_adjustment" model="account.report.expression">
+                                <field name="label">adjustment</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">editable;rounding=0</field>
+                            </record>
                         </field>
                     </record>
                     <record id="tax_report_TD" model="account.report.line">


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Add the adjustment for that field, to allow user to adjust manually the line 25 of the french tax report

**Current behavior before PR:**
Adjustment for line 25 is not available

**Desired behavior after PR is merged:**
Adjustment for line 25 is available
<img width="1161" height="154" alt="image" src="https://github.com/user-attachments/assets/84e1115c-e707-413c-a5bf-377fda4b31c0" />
