### PR TITLE
[IMP] l10n_fr_account: make tax report line 25 editable

### DIFF
--- a/addons/l10n_fr_account/data/tax_report_data.xml
+++ b/addons/l10n_fr_account/data/tax_report_data.xml
@@ -2427,8 +2427,14 @@
                             <record id="tax_report_25_formula" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">box_23.balance - box_16.balance</field>
+                                <field name="formula">box_23.balance - box_16.balance + box_25.adjustment</field>
                                 <field name="subformula">if_above(EUR(0))</field>
+                            </record>
+                            <record id="tax_report_25_adjustment" model="account.report.expression">
+                                <field name="label">adjustment</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">editable;rounding=0</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
Accountants occasionally need to manually adjust the VAT credit amount (Line 25) before submitting their tax declarations. These corrections are often required to account for specific edge cases.

task-6076313