### PR TITLE
[IMP] account: mute 0.00 journal items

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1404,11 +1404,13 @@
                                                sum="Total Debit"
                                                invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"
+                                               decoration-muted="debit == 0"
                                         />
                                         <field name="credit"
                                                sum="Total Credit"
                                                invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"
+                                               decoration-muted="credit == 0"
                                         />
                                         <field name="balance" column_invisible="True"/>
                                         <field name="discount_date"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
muting journal items with 0.00 credit or debit for improved readability

task - 6076225

Current behavior before PR:
text in the debit and credit column with value 0.00 are not muted

Desired behavior after PR is merged:
text is muted in the debit and credit column with value 0.00



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
