### PR TITLE
[IMP] account: mute credit and debit fields if value is 0

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1404,11 +1404,13 @@
                                                sum="Total Debit"
                                                invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"
+                                               decoration-muted="debit == 0"
                                         />
                                         <field name="credit"
                                                sum="Total Credit"
                                                invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"
+                                                decoration-muted="credit == 0"
                                         />
                                         <field name="balance" column_invisible="True"/>
                                         <field name="discount_date"


### PR DESCRIPTION
To improve the readability of journal items, the credit and debit fields are now muted when their value is zero.

task-6076316