### PR TITLE
[IMP] l10n_se: Invoices include delivery date 

### DIFF
--- a/addons/l10n_se/models/account_move.py
+++ b/addons/l10n_se/models/account_move.py
@@ -75,3 +75,19 @@ class AccountMove(models.Model):
                     luhn.validate(invoice.payment_reference)
                 except Exception:
                     raise ValidationError(_("Vendor require OCR Number as payment reference. Payment reference isn't a valid OCR Number."))
+
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTEND account
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.country_code == 'SE':
+                move.show_delivery_date = move.is_sale_document()
+
+    def _post(self, soft=True):
+        # EXTEND account
+        posted = super()._post(soft)
+        for move in self:
+            if move.country_code == 'SE' and move.is_sale_document() and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
+        return posted


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Due to new legislation in Sweden, invoices are required to show the delivery date.

Current behavior before PR:
Invoices in Sweden do not show the delivery date.

Desired behavior after PR is merged:
When an invoice is created in Sweden, the option to add a delivery date is available in the draft. If a delivery date is not added manually, a default delivery date is set (this date is equivalent to the invoice date).

task-6076169
runbot-https://runbot.odoo.com/runbot/bundle/190-l10n-se-delivery-date-on-invoice-andha-454602



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
