### PR TITLE
[IMP] l10n_se: add delivery date on move

### DIFF
--- a/addons/l10n_se/models/account_move.py
+++ b/addons/l10n_se/models/account_move.py
@@ -75,3 +75,23 @@ class AccountMove(models.Model):
                     luhn.validate(invoice.payment_reference)
                 except Exception:
                     raise ValidationError(_("Vendor require OCR Number as payment reference. Payment reference isn't a valid OCR Number."))
+
+    # -------------------------------------------------------------------------
+    # COMPUTE METHODS
+    # -------------------------------------------------------------------------
+
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.country_code == 'SE':
+                move.show_delivery_date = move.is_sale_document()
+
+    def _post(self, soft=True):
+        # EXTENDS 'account'
+        posted = super()._post(soft)
+        for move in self:
+            if move.country_code == 'SE' and move.is_sale_document() and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
+        return posted


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
the delivery date already exists in the "Other Info" tab, however we want to add the delivery date to the top section beside the due date. We also want to put the delivery date on post if it is not already filled

task-6076232

**Current behavior before PR:**
the delivery date is not seen on the top section of the move

**Desired behavior after PR is merged:**
the delivery date is seen on the top section of the move, and the delivery date is filled out on post if it is not already filled



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
