### PR TITLE
[IMP] account: Improve visibility of invoice sent status

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -614,6 +614,14 @@ class AccountMove(models.Model):
         compute='_compute_status_in_payment',
         copy=False,
     )
+    status_sent = fields.Selection(
+        selection=[
+            ('sent', "Sent"),
+            ('not_sent', "Not Sent"),
+        ],
+        compute='_compute_status_sent',
+        copy=False,
+    )
     amount_total_words = fields.Char(
         string="Amount total in words",
         compute="_compute_amount_total_words",
@@ -1313,6 +1321,11 @@ class AccountMove(models.Model):
 
             if not move.status_in_payment:
                 move.status_in_payment = move.state
+
+    @api.depends('is_move_sent')
+    def _compute_status_sent(self):
+        for move in self:
+            move.status_sent = "sent" if move.is_move_sent else "not_sent"
 
     def _field_to_sql(self, alias: str, fname: str, query=None) -> SQL:
         if fname == 'status_in_payment':

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -556,6 +556,14 @@
                            invisible="payment_state == 'invoicing_legacy' or move_type == 'entry'"
                            optional="show"
                     />
+                    <field name="status_sent"
+                           string="Sent"
+                           widget="badge"
+                           decoration-danger="status_sent == 'not_sent'"
+                           decoration-success="status_sent == 'sent'"
+                           optional="hide"
+                           column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')"
+                    />
                     <field name="move_type" column_invisible="context.get('default_move_type', True)"/>
                     <field name="abnormal_amount_warning" column_invisible="1"/>
                     <field name="abnormal_date_warning" column_invisible="1"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
We want to improve the visibility of the sent status of invoices

Current behavior before PR:
There is no additional column available to show in the account move list view to showcase an invoice's sent status.

Desired behavior after PR is merged:
There is an optional column that can be enabled in the account move list view that allows us to see whether an invoice has been sent or not, with corresponding decoration for the sent status.

task-6076168
runbot-https://runbot.odoo.com/runbot/bundle/190-improve-invoice-sent-status-visibility-andha-454841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
