### PR TITLE
[IMP] l10n_se: added delivery date on invoice

### DIFF
--- a/addons/l10n_se/models/account_move.py
+++ b/addons/l10n_se/models/account_move.py
@@ -54,6 +54,22 @@ class AccountMove(models.Model):
         self.ensure_one()
         return self._get_invoice_reference_se_ocr4(self.partner_id.ref if str(self.partner_id.ref).isdecimal() else str(self.partner_id.id))
 
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.country_code == 'SE':
+                move.show_delivery_date = move.is_sale_document()
+
+    def _post(self, soft=True):
+        # EXTENDS 'account'
+        post = super()._post(soft)
+        for move in self:
+            if move.country_code == 'SE' and move.is_sale_document() and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
+        return post
+
     @api.onchange('partner_id')
     def _onchange_partner_id(self):
         """ If Vendor Bill and Vendor OCR is set, add it. """


### PR DESCRIPTION
The delivery date was in the other info tab only, but now it's displayed on the move next to the due date, also in case of posting the invoice when the delivery date is not set, it will be set to the invoice date.

task-6076136
