### PR TITLE
[IMP] l10n_se: Show delivery date and add default

### DIFF
--- a/addons/l10n_se/models/account_move.py
+++ b/addons/l10n_se/models/account_move.py
@@ -54,6 +54,14 @@ class AccountMove(models.Model):
         self.ensure_one()
         return self._get_invoice_reference_se_ocr4(self.partner_id.ref if str(self.partner_id.ref).isdecimal() else str(self.partner_id.id))
 
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.country_code == 'SE':
+                move.show_delivery_date = move.is_sale_document()
+
     @api.onchange('partner_id')
     def _onchange_partner_id(self):
         """ If Vendor Bill and Vendor OCR is set, add it. """
@@ -75,3 +83,11 @@ class AccountMove(models.Model):
                     luhn.validate(invoice.payment_reference)
                 except Exception:
                     raise ValidationError(_("Vendor require OCR Number as payment reference. Payment reference isn't a valid OCR Number."))
+
+    def _post(self, soft=True):
+        # EXTENDS 'account'
+        res = super()._post(soft)
+        for move in self:
+            if move.country_code == 'SE' and move.is_sale_document() and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
+        return res


### PR DESCRIPTION
New Swedish legislation require a delivery date on the invoice. In the customer invoice, the delivery date is no longer hidden on the move when not set. When the invoice is posted, if the delivery date is not set, it will be set to the invoice date.

task-6076294