### PR TITLE
[IMP] account: add more visibility about the sent status of invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -665,6 +665,14 @@ class AccountMove(models.Model):
         help="Is the move being sent asynchronously",
         compute='_compute_is_being_sent'
     )
+    move_sent_status = fields.Selection(
+        selection = [
+            ('sent', "Sent"),
+            ('not_sent', "Not Sent")
+        ],
+        string="Sent Status",
+        compute = '_compute_move_sent_status',
+    )
 
     invoice_user_id = fields.Many2one(
         string='Salesperson',
@@ -809,6 +817,11 @@ class AccountMove(models.Model):
     def _compute_is_being_sent(self):
         for move in self:
             move.is_being_sent = bool(move.sending_data)
+
+    @api.depends('is_move_sent')
+    def _compute_move_sent_status(self):
+        for move in self:
+            move.move_sent_status = 'sent' if move.is_move_sent else 'not_sent'
 
     def _compute_payment_reference(self):
         for move in self.filtered(lambda m: (

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -556,6 +556,14 @@
                            invisible="payment_state == 'invoicing_legacy' or move_type == 'entry'"
                            optional="show"
                     />
+                    <field name="move_sent_status"
+                           string="Sent Status"
+                           widget="badge"
+                           decoration-danger="move_sent_status == 'not_sent'"
+                           decoration-success="move_sent_status == 'sent'"
+                           column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')"
+                           optional="hide"
+                    />
                     <field name="move_type" column_invisible="context.get('default_move_type', True)"/>
                     <field name="abnormal_amount_warning" column_invisible="1"/>
                     <field name="abnormal_date_warning" column_invisible="1"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
added optional column in invoice list view that displays if an invoice has been sent or not. the field will be green if the invoice has been sent, and will be red if not

task-6076231

**Current behavior before PR:**
Sent status on invoice list view does not exist

**Desired behavior after PR is merged:**
Sent status on invoice list view exists and correctly displays if an invoice has been sent or not