### PR TITLE
[IMP] account: Add sent status to invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -661,6 +661,14 @@ class AccountMove(models.Model):
         copy=False,
         help="It indicates that the invoice/payment has been sent or the PDF has been generated.",
     )
+    move_sent_status = fields.Selection(
+        selection=[
+            ('sent', "Sent"),
+            ('not_sent', "Not Sent"),
+        ],
+        compute='_compute_is_sent',
+        help="It indicates that the invoice has been sent or the PDF has been generated.",
+    )
     is_being_sent = fields.Boolean(
         help="Is the move being sent asynchronously",
         compute='_compute_is_being_sent'
@@ -809,6 +817,11 @@ class AccountMove(models.Model):
     def _compute_is_being_sent(self):
         for move in self:
             move.is_being_sent = bool(move.sending_data)
+
+    @api.depends('is_move_sent')
+    def _compute_is_sent(self):
+        for move in self:
+            move.move_sent_status = 'sent' if move.is_move_sent else 'not_sent'
 
     def _compute_payment_reference(self):
         for move in self.filtered(lambda m: (

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -556,6 +556,14 @@
                            invisible="payment_state == 'invoicing_legacy' or move_type == 'entry'"
                            optional="show"
                     />
+                    <field name="move_sent_status" 
+                           string="Sent Status" 
+                           optional="hide" 
+                           column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund')"
+                           widget="badge" 
+                           decoration-success="move_sent_status == 'sent'" 
+                           decoration-danger="move_sent_status == 'not_sent'"
+                    />
                     <field name="move_type" column_invisible="context.get('default_move_type', True)"/>
                     <field name="abnormal_amount_warning" column_invisible="1"/>
                     <field name="abnormal_date_warning" column_invisible="1"/>


### PR DESCRIPTION
An optional "Sent Status" column is added to the "out" moves to allow a user to easily see the difference between invoices which are sent or not.

task-6076293