### PR TITLE
[FIX] mail: make Discuss work with owl3 (for the most part)

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -487,6 +487,7 @@ export class Composer extends Component {
     }
 
     get navigableListProps() {
+        void this.suggestion.state.count;
         const props = {
             anchorRef: this.inputContainerRef.el,
             position: this.env.inChatter ? "bottom-fit" : "top-fit",

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -68,6 +68,7 @@ export class Composer extends Record {
             const prettifiedHtml = prettifyMessageText(this.composerText, {
                 validMentions,
                 thread: this.targetThread,
+                trim: false,
             });
             if (this.composerHtml.toString() !== prettifiedHtml.toString()) {
                 this.updateFrom = "text";
@@ -92,7 +93,7 @@ export class Composer extends Record {
             }
             const prettifiedText = isHtmlEmpty(this.composerHtml)
                 ? ""
-                : convertBrToLineBreak(this.composerHtml);
+                : convertBrToLineBreak(this.composerHtml, { trim: false });
             if (this.composerText !== prettifiedText) {
                 this.updateFrom = "html";
                 this.composerText = prettifiedText;

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -14,7 +14,11 @@ export class Composer extends Record {
         this.attachments.length = 0;
         this.replyToMessage = undefined;
         this.restoredFromFullComposer = false;
-        this.composerHtml = markup("<div class='o-paragraph'><br></div>");
+        if (this.updateFrom === "html") {
+            this.composerHtml = markup("<div class='o-paragraph'><br></div>");
+        } else {
+            this.composerText = "";
+        }
         Object.assign(this.selection, {
             start: 0,
             end: 0,

--- a/addons/mail/static/src/core/common/navigable_list.js
+++ b/addons/mail/static/src/core/common/navigable_list.js
@@ -38,7 +38,6 @@ export class NavigableList extends Component {
         });
         this.hotkey = useService("hotkey");
         this.hotkeysToRemove = [];
-
         useExternalListener(window, "keydown", this.onKeydown, true);
         onExternalClick("root", async (ev) => {
             // Let event be handled by bubbling handlers first.
@@ -54,7 +53,7 @@ export class NavigableList extends Component {
             () => {
                 this.open();
             },
-            () => [this.props]
+            () => [this.props?.options]
         );
         useLayoutEffect(
             () => {

--- a/addons/mail/static/src/model/make_store.js
+++ b/addons/mail/static/src/model/make_store.js
@@ -88,13 +88,13 @@ export function makeStore(env, { localRegistry } = {}) {
                             if (Model._.fieldsCompute.get(name) && !Model._.fieldsEager.get(name)) {
                                 record._.fieldsComputeInNeed.set(name, true);
                                 if (record._.fieldsComputeOnNeed.get(name)) {
-                                    record._.compute(record, name);
+                                    record._.compute(record, name, { fromInNeed: true });
                                 }
                             }
                             if (Model._.fieldsSort.get(name) && !Model._.fieldsEager.get(name)) {
                                 record._.fieldsSortInNeed.set(name, true);
                                 if (record._.fieldsSortOnNeed.get(name)) {
-                                    record._.sort(record, name);
+                                    record._.sort(record, name, { fromInNeed: true });
                                 }
                             }
                             record._.gettingField = true;

--- a/addons/mail/static/src/model/make_store.js
+++ b/addons/mail/static/src/model/make_store.js
@@ -77,7 +77,6 @@ export function makeStore(env, { localRegistry } = {}) {
                                 }
                                 return Reflect.get(parentRecordFullProxy, name);
                             }
-                            recordFullProxy = record._.downgradeProxy(record, recordFullProxy);
                             if (record._.gettingField || !Model._.fields.get(name)) {
                                 let res = Reflect.get(...arguments);
                                 if (typeof res === "function") {

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -346,12 +346,4 @@ export class RecordInternal {
         });
         this.prepareFieldOnUpdate(record, fieldName, recordProxy);
     }
-    /**
-     * The internal reactive is only necessary to trigger outer reactives when
-     * writing on it. As it has no callback, reading through it has no effect,
-     * except slowing down performance and complexifying the stack.
-     */
-    downgradeProxy(record, fullProxy) {
-        return record._proxy === fullProxy ? record._proxyInternal : fullProxy;
-    }
 }

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -11,7 +11,7 @@ import {
     makeRecordFieldLocalId,
 } from "./misc";
 import { RecordList } from "./record_list";
-import { immediateEffect, toRaw } from "@odoo/owl";
+import { immediateEffect, toRaw, untrack } from "@odoo/owl";
 import { RecordUses } from "./record_uses";
 import { LocalStorageEntry } from "@mail/utils/common/local_storage";
 
@@ -58,8 +58,13 @@ export class RecordInternal {
      * @type {Map<string, boolean>}
      */
     fieldsComputeOnNeed = new Map();
-    /** @type {Map<string, () => void>} */
-    fieldsOnUpdateObserves = new Map();
+    /**
+     * Fields that have an `onUpdate` defined. Key is fieldName, Value is function of ongoing `onChange` that allow to stop it.
+     * Useful to prevent any ongoing onChange and restart if need be.
+     *
+     * @type {Map<string, Function>}
+     */
+    fieldsOnUpdateStop = new Map();
     /** @type {Map<string, Record>} */
     fieldsSortProxy2 = new Map();
     /** @type {Map<string, Record>} */
@@ -170,16 +175,26 @@ export class RecordInternal {
             this.fieldsSortProxy2.set(fieldName, sortProxy2);
         }
         if (Model._.fieldsOnUpdate.get(fieldName)) {
-            const store = Model.store;
-            store._onChange(recordProxy, fieldName, (obs) => {
-                this.fieldsOnUpdateObserves.set(fieldName, obs);
-                if (store._.UPDATE !== 0) {
-                    store._.ADD_QUEUE("onUpdate", record, fieldName);
-                } else {
-                    this.onUpdate(record, fieldName);
-                }
-            });
+            this.prepareFieldOnUpdate(record, fieldName, recordProxy);
         }
+    }
+
+    /**
+     * @param {Record} record
+     * @param {string} fieldName
+     * @param {Record} recordProxy
+     */
+    prepareFieldOnUpdate(record, fieldName, recordProxy) {
+        const Model = toRaw(record).Model;
+        const store = Model.store;
+        const fn = store._onChange(recordProxy, fieldName, (obs) => {
+            if (store._.UPDATE !== 0) {
+                untrack(() => store._.ADD_QUEUE("onUpdate", record, fieldName));
+            } else {
+                this.onUpdate(record, fieldName);
+            }
+        });
+        this.fieldsOnUpdateStop.set(fieldName, fn);
     }
 
     requestCompute(record, fieldName, { force = false } = {}) {
@@ -284,20 +299,22 @@ export class RecordInternal {
         if (!Model._.fieldsOnUpdate.get(fieldName)) {
             return;
         }
-        immediateEffect(() => {
-            /**
-             * Forward internal proxy for performance as onUpdate does not
-             * need reactive (observe is called separately).
-             */
+        this.fieldsOnUpdateStop.get(fieldName)?.();
+        const recordProxy = record._proxy;
+        untrack(() => {
             try {
+                /**
+                 * Forward internal proxy for performance as onUpdate does not
+                 * need reactive (observe is called separately).
+                 */
                 Model._.fieldsOnUpdate
                     .get(fieldName)
-                    .forEach((fn) => fn.call(record._proxy, record._proxy[fieldName]));
+                    .forEach((fn) => fn.call(recordProxy, recordProxy[fieldName]));
             } catch (err) {
                 store.handleError(err);
             }
-            this.fieldsOnUpdateObserves.get(fieldName)?.();
         });
+        this.prepareFieldOnUpdate(record, fieldName, recordProxy);
     }
     /**
      * The internal reactive is only necessary to trigger outer reactives when

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -1,4 +1,3 @@
-import { reactive } from "@web/owl2/utils";
 /** @typedef {import("./record").Record} Record */
 /** @typedef {import("./record_list").RecordList} RecordList */
 
@@ -72,8 +71,13 @@ export class RecordInternal {
      * @type {Map<string, Function>}
      */
     fieldsOnUpdateStop = new Map();
-    /** @type {Map<string, Record>} */
-    fieldsSortProxy2 = new Map();
+    /**
+     * Fields that have an `sort` defined. Key is fieldName, Value is function of ongoing `immediateEffect` that let it stop.
+     * Useful to prevent any ongoing `immediateEffect` and restart if need be.
+     *
+     * @type {Map<string, Function>}
+     */
+    fieldsSortStop = new Map();
     /** @type {Map<string, any>} */
     fieldsDefault = new Map();
     uses = new RecordUses();
@@ -100,7 +104,6 @@ export class RecordInternal {
      * @param {Record} recordProxy
      */
     prepareField(record, fieldName, recordProxy) {
-        const self = this;
         const Model = toRaw(record).Model;
         if (isRelation(Model, fieldName)) {
             // Relational fields contain symbols for detection in original class.
@@ -169,10 +172,6 @@ export class RecordInternal {
                 this.fieldsComputeInNeed.delete(fieldName);
                 this.fieldsSortInNeed.delete(fieldName);
             }
-            const sortProxy2 = reactive(recordProxy, function sortObserver() {
-                self.requestSort(record, fieldName);
-            });
-            this.fieldsSortProxy2.set(fieldName, sortProxy2);
         }
         if (Model._.fieldsOnUpdate.get(fieldName)) {
             this.prepareFieldOnUpdate(record, fieldName, recordProxy);
@@ -278,27 +277,35 @@ export class RecordInternal {
         if (!Model._.fieldsSort.get(fieldName)) {
             return;
         }
-        const store = record._rawStore;
-        this.fieldsSortOnNeed.delete(fieldName);
-        this.fieldsSorting.set(fieldName, true);
-        const proxy2Sort = this.fieldsSortProxy2.get(fieldName);
-        const func = Model._.fieldsSort.get(fieldName).bind(proxy2Sort);
-        if (isRelation(Model, fieldName)) {
-            try {
-                store._.sortRecordList(proxy2Sort[fieldName]._proxy, func);
-            } catch (err) {
-                store.handleError(err);
+        this.fieldsSortStop.get(fieldName)?.();
+        let triggered = false;
+        const stopFn = immediateEffect(() => {
+            if (triggered) {
+                return untrack(() => this.requestSort(record, fieldName));
             }
-        } else {
-            // sort on copy of list so that reactive observers not triggered while sorting
-            const copy = [...proxy2Sort[fieldName]];
-            copy.sort(func);
-            const hasChanged = copy.some((item, index) => item !== record[fieldName][index]);
-            if (hasChanged) {
-                proxy2Sort[fieldName] = copy;
+            const store = record._rawStore;
+            this.fieldsSortOnNeed.delete(fieldName);
+            this.fieldsSorting.set(fieldName, true);
+            const func = Model._.fieldsSort.get(fieldName).bind(record._proxy);
+            if (isRelation(Model, fieldName)) {
+                try {
+                    store._.sortRecordList(record._proxy[fieldName]._proxy, func);
+                } catch (err) {
+                    store.handleError(err);
+                }
+            } else {
+                // sort on copy of list so that reactive observers not triggered while sorting
+                const copy = [...record._proxy[fieldName]];
+                copy.sort(func);
+                const hasChanged = copy.some((item, index) => item !== record[fieldName][index]);
+                if (hasChanged) {
+                    record._proxy[fieldName] = copy;
+                }
             }
-        }
-        this.fieldsSorting.delete(fieldName);
+            this.fieldsSorting.delete(fieldName);
+        });
+        this.fieldsSortStop.set(fieldName, stopFn);
+        triggered = true;
     }
     onUpdate(record, fieldName) {
         const store = record._rawStore;

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -59,6 +59,13 @@ export class RecordInternal {
      */
     fieldsComputeOnNeed = new Map();
     /**
+     * Fields that have an `compute` defined. Key is fieldName, Value is function of ongoing `immediateEffect` that let it stop.
+     * Useful to prevent any ongoing `immediateEffect` and restart if need be.
+     *
+     * @type {Map<string, Function>}
+     */
+    fieldsComputeStop = new Map();
+    /**
      * Fields that have an `onUpdate` defined. Key is fieldName, Value is function of ongoing `onChange` that allow to stop it.
      * Useful to prevent any ongoing onChange and restart if need be.
      *
@@ -67,8 +74,6 @@ export class RecordInternal {
     fieldsOnUpdateStop = new Map();
     /** @type {Map<string, Record>} */
     fieldsSortProxy2 = new Map();
-    /** @type {Map<string, Record>} */
-    fieldsComputeProxy2 = new Map();
     /** @type {Map<string, any>} */
     fieldsDefault = new Map();
     uses = new RecordUses();
@@ -146,11 +151,6 @@ export class RecordInternal {
                 this.fieldsComputeInNeed.delete(fieldName);
                 this.fieldsSortInNeed.delete(fieldName);
             }
-            const cb = function computeObserver() {
-                self.requestCompute(record, fieldName);
-            };
-            const computeProxy2 = reactive(recordProxy, cb);
-            this.fieldsComputeProxy2.set(fieldName, computeProxy2);
         }
         if (Model._.fieldsSort.get(fieldName)) {
             if (!Model._.fieldsEager.get(fieldName)) {
@@ -244,23 +244,30 @@ export class RecordInternal {
         if (!Model._.fieldsCompute.get(fieldName)) {
             return;
         }
-        immediateEffect(() => {
+        this.fieldsComputeStop.get(fieldName)?.();
+        let triggered = false;
+        const stopFn = immediateEffect(() => {
+            if (triggered) {
+                return untrack(() => this.requestCompute(record, fieldName));
+            }
             const store = record._rawStore;
             this.fieldsComputing.set(fieldName, true);
             this.fieldsComputeOnNeed.delete(fieldName);
             let computedValue;
             try {
-                computedValue = Model._.fieldsCompute
-                    .get(fieldName)
-                    .call(this.fieldsComputeProxy2.get(fieldName));
+                computedValue = Model._.fieldsCompute.get(fieldName).call(record._proxy);
             } catch (err) {
                 store.handleError(err);
             }
-            store._.updateFields(record, {
-                [fieldName]: computedValue,
-            });
+            untrack(() =>
+                store._.updateFields(record, {
+                    [fieldName]: computedValue,
+                })
+            );
             this.fieldsComputing.delete(fieldName);
         });
+        this.fieldsComputeStop.set(fieldName, stopFn);
+        triggered = true;
     }
     /**
      * @param {Record} record

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -1,7 +1,6 @@
 /** @typedef {import("./record").Record} Record */
 /** @typedef {import("./record_list").RecordList} RecordList */
 
-import { onChange } from "@mail/utils/common/misc";
 import {
     IS_DELETED_SYM,
     IS_RECORD_SYM,
@@ -13,6 +12,7 @@ import { RecordList } from "./record_list";
 import { immediateEffect, toRaw, untrack } from "@odoo/owl";
 import { RecordUses } from "./record_uses";
 import { LocalStorageEntry } from "@mail/utils/common/local_storage";
+import { onChange } from "@mail/utils/common/misc";
 
 export class RecordInternal {
     [IS_RECORD_SYM] = true;
@@ -237,8 +237,13 @@ export class RecordInternal {
     /**
      * @param {Record} record
      * @param {string} fieldName
+     * @param {Object} [param2={}]
+     * @param {boolean} [param2.fromInNeed] whether the compute is triggered from an "in-need" observer.
+     *  Useful to force keeping the "in-need" flag, as the "in-need" is automatically reset whenever a computing value has changed.
+     *  The "in-need" flag is expected to be set again by observed on the next read, but if the compute is immediately triggered
+     *  by the "in-need" then that's the case the `fromInNeed: true` and it should preserve for this ongoing compute.
      */
-    compute(record, fieldName) {
+    compute(record, fieldName, { fromInNeed } = {}) {
         const Model = record.Model;
         if (!Model._.fieldsCompute.get(fieldName)) {
             return;
@@ -266,13 +271,21 @@ export class RecordInternal {
             this.fieldsComputing.delete(fieldName);
         });
         this.fieldsComputeStop.set(fieldName, stopFn);
+        if (fromInNeed) {
+            this.fieldsComputeInNeed.set(fieldName, true);
+        }
         triggered = true;
     }
     /**
      * @param {Record} record
      * @param {string} fieldName
+     * @param {Object} [param2={}]
+     * @param {boolean} [param2.fromInNeed] whether the sort is triggered from an "in-need" observer.
+     *  Useful to force keeping the "in-need" flag, as the "in-need" is automatically reset whenever a sorting value has changed.
+     *  The "in-need" flag is expected to be set again by observed on the next read, but if the sort is immediately triggered
+     *  by the "in-need" then that's the case the `fromInNeed: true` and it should preserve for this ongoing sort.
      */
-    sort(record, fieldName) {
+    sort(record, fieldName, { fromInNeed } = {}) {
         const Model = record.Model;
         if (!Model._.fieldsSort.get(fieldName)) {
             return;
@@ -305,6 +318,9 @@ export class RecordInternal {
             this.fieldsSorting.delete(fieldName);
         });
         this.fieldsSortStop.set(fieldName, stopFn);
+        if (fromInNeed) {
+            this.fieldsSortInNeed.set(fieldName, true);
+        }
         triggered = true;
     }
     onUpdate(record, fieldName) {

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -284,18 +284,20 @@ export class RecordInternal {
         if (!Model._.fieldsOnUpdate.get(fieldName)) {
             return;
         }
-        /**
-         * Forward internal proxy for performance as onUpdate does not
-         * need reactive (observe is called separately).
-         */
-        try {
-            Model._.fieldsOnUpdate
-                .get(fieldName)
-                .forEach((fn) => fn.call(record._proxyInternal, record._proxyInternal[fieldName]));
-        } catch (err) {
-            store.handleError(err);
-        }
-        this.fieldsOnUpdateObserves.get(fieldName)?.();
+        immediateEffect(() => {
+            /**
+             * Forward internal proxy for performance as onUpdate does not
+             * need reactive (observe is called separately).
+             */
+            try {
+                Model._.fieldsOnUpdate
+                    .get(fieldName)
+                    .forEach((fn) => fn.call(record._proxy, record._proxy[fieldName]));
+            } catch (err) {
+                store.handleError(err);
+            }
+            this.fieldsOnUpdateObserves.get(fieldName)?.();
+        });
     }
     /**
      * The internal reactive is only necessary to trigger outer reactives when

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -11,7 +11,7 @@ import {
     makeRecordFieldLocalId,
 } from "./misc";
 import { RecordList } from "./record_list";
-import { toRaw } from "@odoo/owl";
+import { immediateEffect, toRaw } from "@odoo/owl";
 import { RecordUses } from "./record_uses";
 import { LocalStorageEntry } from "@mail/utils/common/local_storage";
 
@@ -229,21 +229,23 @@ export class RecordInternal {
         if (!Model._.fieldsCompute.get(fieldName)) {
             return;
         }
-        const store = record._rawStore;
-        this.fieldsComputing.set(fieldName, true);
-        this.fieldsComputeOnNeed.delete(fieldName);
-        let computedValue;
-        try {
-            computedValue = Model._.fieldsCompute
-                .get(fieldName)
-                .call(this.fieldsComputeProxy2.get(fieldName));
-        } catch (err) {
-            store.handleError(err);
-        }
-        store._.updateFields(record, {
-            [fieldName]: computedValue,
+        immediateEffect(() => {
+            const store = record._rawStore;
+            this.fieldsComputing.set(fieldName, true);
+            this.fieldsComputeOnNeed.delete(fieldName);
+            let computedValue;
+            try {
+                computedValue = Model._.fieldsCompute
+                    .get(fieldName)
+                    .call(this.fieldsComputeProxy2.get(fieldName));
+            } catch (err) {
+                store.handleError(err);
+            }
+            store._.updateFields(record, {
+                [fieldName]: computedValue,
+            });
+            this.fieldsComputing.delete(fieldName);
         });
-        this.fieldsComputing.delete(fieldName);
     }
     /**
      * @param {Record} record

--- a/addons/mail/static/src/model/record_list.js
+++ b/addons/mail/static/src/model/record_list.js
@@ -2,6 +2,8 @@ import { reactive } from "@web/owl2/utils";
 import { markRaw, toRaw } from "@odoo/owl";
 import { isRecord } from "./misc";
 
+/** @typedef {import("./record").Record} Record */
+
 /** @param {RecordList} reclist */
 function getInverse(reclist) {
     return reclist._.owner.Model._.fieldsInverse.get(reclist._.name);
@@ -49,12 +51,12 @@ function isSortOnNeed(reclist) {
 
 /** @param {RecordList} reclist */
 function computeField(reclist) {
-    reclist._.owner._.compute(reclist._.owner, reclist._.name);
+    reclist._.owner._.compute(reclist._.owner, reclist._.name, { fromInNeed: true });
 }
 
 /** @param {RecordList} reclist */
 function sortField(reclist) {
-    reclist._.owner._.sort(reclist._.owner, reclist._.name);
+    reclist._.owner._.sort(reclist._.owner, reclist._.name, { fromInNeed: true });
 }
 
 /** @param {RecordList} reclist */

--- a/addons/mail/static/src/model/record_list.js
+++ b/addons/mail/static/src/model/record_list.js
@@ -67,6 +67,11 @@ export class RecordListInternal {
     name;
     /** @type {Record} */
     owner;
+    /**
+     * @type {boolean} Technical flag to immediately read attribute.
+     * Useful to read `data` while passing to owl's proxy getter again to register observer.
+     */
+    gettingField = false;
 
     /**
      * Version of add() that does not update the inverse.
@@ -274,7 +279,14 @@ export class RecordList extends Array {
             /** @param {RecordList<R>} receiver */
             get(recordList, name, recordListFullProxy) {
                 recordListFullProxy = recordList._.downgradeProxy(recordList, recordListFullProxy);
+                if (name === "data" && !recordList._.gettingField) {
+                    recordList._.gettingField = true;
+                    const res = recordList._proxy.data;
+                    recordList._.gettingField = false;
+                    return res;
+                }
                 if (
+                    recordList._.gettingField ||
                     typeof name === "symbol" ||
                     Object.keys(recordList).includes(name) ||
                     Object.prototype.hasOwnProperty.call(recordList.constructor.prototype, name)

--- a/addons/mail/static/src/model/record_list.js
+++ b/addons/mail/static/src/model/record_list.js
@@ -191,17 +191,6 @@ export class RecordListInternal {
         }
     }
     /**
-     * The internal reactive is only necessary to trigger outer reactives when
-     * writing on it. As it has no callback, reading through it has no effect,
-     * except slowing down performance and complexifying the stack.
-     *
-     * @param {RecordList} recordList
-     * @param {RecordList} fullProxy
-     */
-    downgradeProxy(recordList, fullProxy) {
-        return recordList._proxy === fullProxy ? recordList._proxyInternal : fullProxy;
-    }
-    /**
      * @param {RecordList} recordList
      * @param {R|any} val
      * @param {(R) => void} [fn] function that is called in-between preinsert and
@@ -280,7 +269,6 @@ export class RecordList extends Array {
         const recordListProxyInternal = new Proxy(recordList, {
             /** @param {RecordList<R>} receiver */
             get(recordList, name, recordListFullProxy) {
-                recordListFullProxy = recordList._.downgradeProxy(recordList, recordListFullProxy);
                 if (name === "data" && !recordList._.gettingField) {
                     recordList._.gettingField = true;
                     const res = recordList._proxy.data;
@@ -396,7 +384,7 @@ export class RecordList extends Array {
     /** @param {R[]} records */
     push(...records) {
         const recordList = toRaw(this)._raw;
-        const recordListFullProxy = recordList._.downgradeProxy(recordList, this);
+        const recordListFullProxy = this;
         const store = recordList._store;
         return store.MAKE_UPDATE(function recordListPush() {
             for (const val of records) {
@@ -421,7 +409,7 @@ export class RecordList extends Array {
     /** @returns {R} */
     pop() {
         const recordList = toRaw(this)._raw;
-        const recordListFullProxy = recordList._.downgradeProxy(recordList, this);
+        const recordListFullProxy = this;
         const store = recordList._store;
         return store.MAKE_UPDATE(function recordListPop() {
             /** @type {R} */
@@ -435,7 +423,7 @@ export class RecordList extends Array {
     /** @returns {R} */
     shift() {
         const recordList = toRaw(this)._raw;
-        const recordListFullProxy = recordList._.downgradeProxy(recordList, this);
+        const recordListFullProxy = this;
         const store = recordList._store;
         return store.MAKE_UPDATE(function recordListShift() {
             const recordProxy = recordListFullProxy._store.recordByLocalId.get(
@@ -458,7 +446,7 @@ export class RecordList extends Array {
     /** @param {R[]} records */
     unshift(...records) {
         const recordList = toRaw(this)._raw;
-        const recordListFullProxy = recordList._.downgradeProxy(recordList, this);
+        const recordListFullProxy = this;
         const store = recordList._store;
         return store.MAKE_UPDATE(function recordListUnshift() {
             for (let i = records.length - 1; i >= 0; i--) {
@@ -478,8 +466,7 @@ export class RecordList extends Array {
     }
     /** @param {R} recordProxy */
     indexOf(recordProxy) {
-        const recordList = toRaw(this)._raw;
-        const recordListFullProxy = recordList._.downgradeProxy(recordList, this);
+        const recordListFullProxy = this;
         return recordListFullProxy.data.indexOf(toRaw(recordProxy)?._raw.localId);
     }
     /**
@@ -489,7 +476,7 @@ export class RecordList extends Array {
      */
     splice(start, deleteCount, ...newRecordsProxy) {
         const recordList = toRaw(this)._raw;
-        const recordListFullProxy = recordList._.downgradeProxy(recordList, this);
+        const recordListFullProxy = this;
         const store = recordList._store;
         return store.MAKE_UPDATE(function recordListSplice() {
             const oldRecordLocalIds = recordList.data.slice(start, start + deleteCount);
@@ -535,7 +522,7 @@ export class RecordList extends Array {
     /** @param {(a: R, b: R) => boolean} func */
     sort(func) {
         const recordList = toRaw(this)._raw;
-        const recordListFullProxy = recordList._.downgradeProxy(recordList, this);
+        const recordListFullProxy = this;
         const store = recordList._store;
         return store.MAKE_UPDATE(function recordListSort() {
             recordList._store._.sortRecordList(recordListFullProxy, func);
@@ -544,8 +531,7 @@ export class RecordList extends Array {
     }
     /** @param {...R[]|...RecordList[R]} collections */
     concat(...collections) {
-        const recordList = toRaw(this)._raw;
-        const recordListFullProxy = recordList._.downgradeProxy(recordList, this);
+        const recordListFullProxy = this;
         return recordListFullProxy.data
             .map((localId) => recordListFullProxy._store.recordByLocalId.get(localId))
             .concat(...collections.map((c) => [...c]));
@@ -623,8 +609,7 @@ export class RecordList extends Array {
     }
     /** @yields {R} */
     *[Symbol.iterator]() {
-        const recordList = toRaw(this)._raw;
-        const recordListFullProxy = recordList._.downgradeProxy(recordList, this);
+        const recordListFullProxy = this;
         for (const localId of recordListFullProxy.data) {
             yield recordListFullProxy._store.recordByLocalId.get(localId);
         }
@@ -632,8 +617,7 @@ export class RecordList extends Array {
     /** @param {number} index */
     at(index) {
         // this custom implement of "at" is slightly faster than auto-calling unimplement array method
-        const recordList = toRaw(this)._raw;
-        const recordListFullProxy = recordList._.downgradeProxy(recordList, this);
+        const recordListFullProxy = this;
         return recordListFullProxy._store.recordByLocalId.get(recordListFullProxy.data.at(index));
     }
 }

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -2,7 +2,7 @@ import { reactive } from "@web/owl2/utils";
 import { PgSnapshot } from "@mail/model/field_version";
 import { Record } from "./record";
 import { STORE_SYM, modelRegistry } from "./misc";
-import { immediateEffect, toRaw } from "@odoo/owl";
+import { immediateEffect, toRaw, untrack } from "@odoo/owl";
 
 /** @typedef {import("./record_list").RecordList} RecordList */
 
@@ -255,11 +255,13 @@ export class Store extends Record {
         return this._onChange(record, name, (observe) => {
             const fn = () => {
                 observe();
-                try {
-                    cb();
-                } catch (err) {
-                    this.handleError(err);
-                }
+                untrack(() => {
+                    try {
+                        cb();
+                    } catch (err) {
+                        this.handleError(err);
+                    }
+                });
             };
             if (this._.UPDATE !== 0) {
                 if (!this._.RO_QUEUE.has(fn)) {

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -2,7 +2,7 @@ import { reactive } from "@web/owl2/utils";
 import { PgSnapshot } from "@mail/model/field_version";
 import { Record } from "./record";
 import { STORE_SYM, modelRegistry } from "./misc";
-import { toRaw } from "@odoo/owl";
+import { immediateEffect, toRaw } from "@odoo/owl";
 
 /** @typedef {import("./record_list").RecordList} RecordList */
 
@@ -299,13 +299,17 @@ export class Store extends Record {
             }
             return;
         }
+        let running = false;
         let ready = true;
-        proxy = reactive(record, () => {
-            if (ready) {
+        proxy = reactive(record);
+        immediateEffect(() => {
+            if (!running) {
+                _observe();
+            } else if (ready) {
                 callback(_observe);
             }
         });
-        _observe();
+        running = true;
         return () => {
             ready = false;
         };

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -32,20 +32,24 @@ const messageUrlRegExp = new RegExp(`^${escapeRegExp(getOrigin())}/mail/message/
 
 /**
  * @param {string|ReturnType<markup>} rawBody
- * @param {Object} validMentions
- * @param {import("models").Persona[]} validMentions.partners
+ * @param {Object} [param1]
+ * @param {Object} [param1.validMentions]
+ * @param {import("models").Persona[]} [param1.validMentions.partners]
+ * @param {import("models").Thread[]} [param1.thread]
+ * @param {boolean} [param1.trim=true] whether the text content should be trimmed or not.
+ *   Trim is useful for when posting message and having the auto-trim of content, but when using auto-sync between html and text the whitespaces should be preserved and should have trim=false.
  * @returns {Promise<string|ReturnType<markup>>}
  */
-export function prettifyMessageText(rawBody, { validMentions = {}, thread } = {}) {
+export function prettifyMessageText(rawBody, { validMentions = {}, thread, trim = true } = {}) {
     if (rawBody instanceof markup().constructor) {
         // markup is already "pretty"
         return rawBody;
     }
-    let body = htmlTrim(rawBody);
+    let body = trim ? htmlTrim(rawBody) : htmlJoin([rawBody]);
     body = htmlReplace(body, /(\r|\n){2,}/g, () => markup`<br/><br/>`);
     body = htmlReplace(body, /(\r|\n)/g, () => markup`<br/>`);
     body = htmlReplace(body, /&nbsp;/g, () => " ");
-    body = htmlTrim(body);
+    body = trim ? htmlTrim(body) : htmlJoin([body]);
     // This message will be received from the mail composer as html content
     // subtype but the urls will not be linkified. If the mail composer
     // takes the responsibility to linkify the urls we end up with double
@@ -369,9 +373,13 @@ export function htmlToTextContentInline(htmlString) {
         .replace(/\s\s+/g, " ");
 }
 
-export function convertBrToLineBreak(str) {
-    str = htmlReplace(str, /<br\s*\/?>/gi, () => "\n");
-    return createDocumentFragmentFromContent(str).body.textContent;
+export function convertBrToLineBreak(str, { trim = true } = {}) {
+    const regex = trim ? /<br\s*\/?>/gi : /<br\/?>/gi;
+    str = htmlReplace(str, regex, () => "\n");
+    if (!trim) {
+        str = htmlReplace(str, /\s/g, () => markup`&nbsp;`);
+    }
+    return createDocumentFragmentFromContent(str).body.textContent.replaceAll(" ", " ");
 }
 
 export function convertLineBreakToBr(str) {

--- a/addons/mail/static/src/utils/common/misc.js
+++ b/addons/mail/static/src/utils/common/misc.js
@@ -2,6 +2,7 @@ import { reactive, useLayoutEffect } from "@web/owl2/utils";
 import { AssetsLoadingError, getBundle } from "@web/core/assets";
 import { memoize } from "@web/core/utils/functions";
 import { effect } from "@web/core/utils/reactive";
+import { immediateEffect } from "@odoo/owl";
 
 export function assignDefined(obj, data, keys = Object.keys(data)) {
     for (const key of keys) {
@@ -100,11 +101,15 @@ export function onChange(target, key, callback) {
         }
         return;
     }
-    proxy = reactive(target, () => {
+    let running = false;
+    proxy = reactive(target);
+    immediateEffect(() => {
         _observe();
-        callback();
+        if (running) {
+            callback();
+        }
     });
-    _observe();
+    running = true;
     return proxy;
 }
 

--- a/addons/mail/static/src/utils/common/misc.js
+++ b/addons/mail/static/src/utils/common/misc.js
@@ -2,7 +2,7 @@ import { reactive, useLayoutEffect } from "@web/owl2/utils";
 import { AssetsLoadingError, getBundle } from "@web/core/assets";
 import { memoize } from "@web/core/utils/functions";
 import { effect } from "@web/core/utils/reactive";
-import { immediateEffect } from "@odoo/owl";
+import { immediateEffect, untrack } from "@odoo/owl";
 
 export function assignDefined(obj, data, keys = Object.keys(data)) {
     for (const key of keys) {
@@ -106,7 +106,7 @@ export function onChange(target, key, callback) {
     immediateEffect(() => {
         _observe();
         if (running) {
-            callback();
+            untrack(() => callback());
         }
     });
     running = true;

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -415,7 +415,7 @@ test("Computed fields: lazy (default) vs. eager", async () => {
     expect(thread.typeLazy).toBe("empty chat");
     expect.verifySteps(["LAZY"]);
     members.add("John");
-    expect.verifySteps(["EAGER"]);
+    expect.verifySteps(["EAGER", "LAZY"]); // extra-lazy because "in-need" release observed only on lazy observers no longer observing.
     expect(thread.typeEager).toBe("self-chat");
     expect.verifySteps([]);
     members.add("Antony");
@@ -670,25 +670,27 @@ test("lazy compute should re-compute while they are observed", async () => {
     const store = await start();
     const channel = store.Channel.insert(1);
     let observe = true;
+    const reactiveChannel = reactive(channel);
     function render() {
-        if (observe) {
-            expect.step(`render ${reactiveChannel.multiplicity}`);
-        }
+        expect.step(`render ${reactiveChannel.multiplicity}`);
     }
-    const reactiveChannel = reactive(channel, render);
-    render();
-    expect.verifySteps(["computing", "render few", "render few"]);
+    immediateEffect(() => {
+        if (observe) {
+            render();
+        }
+    });
+    expect.verifySteps(["computing", "render few"]);
     channel.count = 2;
     expect.verifySteps(["computing"]);
     channel.count = 5;
     expect.verifySteps(["computing", "render many"]);
     observe = false;
     channel.count = 6;
-    expect.verifySteps(["computing"]);
+    expect.verifySteps([]);
     channel.count = 7;
-    expect.verifySteps(["computing"]);
+    expect.verifySteps([]);
     channel.count = 1;
-    expect.verifySteps(["computing"]);
+    expect.verifySteps([]);
     channel.count = 0;
     expect.verifySteps([]);
     channel.count = 7;
@@ -697,8 +699,9 @@ test("lazy compute should re-compute while they are observed", async () => {
     expect.verifySteps([]);
     expect(channel.multiplicity).toBe("few");
     expect.verifySteps(["computing"]);
-    observe = true;
-    render();
+    immediateEffect(() => {
+        render();
+    });
     expect.verifySteps(["render few"]);
     channel.count = 7;
     expect.verifySteps(["computing", "render many"]);

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -2,7 +2,7 @@ import { reactive } from "@web/owl2/utils";
 import { toRawValue } from "@mail/utils/common/local_storage";
 import { defineMailModels, start as start2 } from "@mail/../tests/mail_test_helpers";
 import { afterEach, beforeEach, describe, expect, test, tick } from "@odoo/hoot";
-import { markup, toRaw } from "@odoo/owl";
+import { immediateEffect, markup, toRaw } from "@odoo/owl";
 import { mockService, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 import { Record, Store, makeStore } from "@mail/model/export";
@@ -815,8 +815,10 @@ test("store updates can be observed", async () => {
         expect.step(`abc:${reactiveStore.abc}`);
     }
     const rawStore = toRaw(store)._raw;
-    const reactiveStore = reactive(store, onUpdate);
-    onUpdate();
+    const reactiveStore = reactive(store);
+    immediateEffect(() => {
+        onUpdate();
+    });
     expect.verifySteps(["abc:undefined"]);
     store.abc = 1;
     expect.verifySteps(["abc:1"]); // observable from makeStore"

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -9,7 +9,6 @@ import { Record, Store, makeStore } from "@mail/model/export";
 import { AND, fields, makeRecordFieldLocalId, normalizeManyCommands } from "@mail/model/misc";
 import { serializeDateTime } from "@web/core/l10n/dates";
 import { registry } from "@web/core/registry";
-import { effect } from "@web/core/utils/reactive";
 import { browser } from "@web/core/browser/browser";
 
 const Markup = markup().constructor;
@@ -1591,19 +1590,16 @@ test("Record exists is reactive", async () => {
     }).register(localRegistry);
     const store = await start();
     const thread = store.Thread.insert("General");
-    effect(
-        (rec) => {
-            if (rec.exists()) {
-                expect.step("thread exists");
-            } else {
-                expect.step("thread does not exist");
-            }
-        },
-        [thread]
-    );
-    await expect.waitForSteps(["thread exists"]);
+    immediateEffect(() => {
+        if (thread.exists()) {
+            expect.step("thread exists");
+        } else {
+            expect.step("thread does not exist");
+        }
+    });
+    expect.verifySteps(["thread exists"]);
     thread.delete();
-    await expect.waitForSteps(["thread does not exist"]);
+    expect.verifySteps(["thread does not exist"]);
 });
 
 test("Normalize many commands", () => {

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -562,14 +562,16 @@ test("record list sort should be manually observable", async () => {
         observedMessages.sort((m1, m2) => (m1.body < m2.body ? -1 : 1));
         expect.step(`sortMessages`);
     }
-    const observedMessages = reactive(thread.messages, sortMessages);
+    const observedMessages = reactive(thread.messages);
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
-    sortMessages();
+    immediateEffect(() => {
+        sortMessages();
+    });
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
     expect.verifySteps(["sortMessages"]);
     messages[0].body = "c";
     expect(`${thread.messages.map((m) => m.id)}`).toBe("2,1");
-    expect.verifySteps(["sortMessages", "sortMessages"]);
+    expect.verifySteps(["sortMessages"]);
     messages[0].body = "d";
     expect(`${thread.messages.map((m) => m.id)}`).toBe("2,1");
     expect.verifySteps(["sortMessages"]);
@@ -726,12 +728,15 @@ test("lazy sort should re-sort while they are observed", async () => {
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
     let observe = true;
     function render() {
-        if (observe) {
-            expect.step(`render ${reactiveChannel.messages.map((m) => m.id)}`);
-        }
+        expect.step(`render ${reactiveChannel.messages.map((m) => m.id)}`);
     }
-    const reactiveChannel = reactive(thread, render);
-    render();
+    const reactiveChannel = reactive(thread);
+    immediateEffect(() => {
+        if (!observe) {
+            return;
+        }
+        render();
+    });
     const message = thread.messages[0];
     expect.verifySteps(["render 1,2"]);
     message.sequence = 3;
@@ -757,8 +762,9 @@ test("lazy sort should re-sort while they are observed", async () => {
         )}`
     ).toBe("2,1", { message: "no longer observed" });
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
-    observe = true;
-    render();
+    immediateEffect(() => {
+        render();
+    });
     expect.verifySteps(["render 1,2"]);
     message.sequence = 10;
     expect.verifySteps(["render 2,1"]);
@@ -778,12 +784,15 @@ test("sort works on fields.Attr()", async () => {
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
     let observe = true;
     function render() {
-        if (observe) {
-            expect.step(`render ${reactiveChannel.messages.map((m) => m.id)}`);
-        }
+        expect.step(`render ${reactiveChannel.messages.map((m) => m.id)}`);
     }
     const reactiveChannel = reactive(thread, render);
-    render();
+    immediateEffect(() => {
+        if (!observe) {
+            return;
+        }
+        render();
+    });
     const message = thread.messages[0];
     expect.verifySteps(["render 1,2"]);
     message.sequence = 3;
@@ -805,8 +814,9 @@ test("sort works on fields.Attr()", async () => {
         message: "no longer observed",
     });
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
-    observe = true;
-    render();
+    immediateEffect(() => {
+        render();
+    });
     expect.verifySteps(["render 1,2"]);
     message.sequence = 10;
     expect.verifySteps(["render 2,1"]);

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -247,7 +247,7 @@ test("Editing message keeps the mentioned channels", async () => {
     await press("Enter");
     await contains(".o_channel_redirect:text('other')");
     await click(".o-mail-Message [title='Edit']");
-    await contains(".o-mail-Message .o-mail-Composer-input", { value: "#other" });
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "#other " });
     await insertText(".o-mail-Message .o-mail-Composer-input", "#other bye", { replace: true });
     await click(".o-mail-Message button:text('save')");
     await contains(".o-mail-Message-content:text('other bye (edited)')");
@@ -276,7 +276,7 @@ test("Editing message keeps the mentioned roles", async () => {
     await press("Enter");
     await contains(".o-discuss-mention", { text: "@admin" });
     await click(".o-mail-Message [title='Edit']");
-    await contains(".o-mail-Message .o-mail-Composer-input", { value: "@admin" });
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "@admin " });
     await insertText(".o-mail-Message .o-mail-Composer-input", "@admin edit", { replace: true });
     await click(".o-mail-Message button", { text: "save" });
     await contains(".o-mail-Message-content", { text: "@admin edit (edited)" });


### PR DESCRIPTION
Summary:
- "owned" reactive no longer works, hence computed fields not working. Solution is replace the "owned" proxy with `immediateEffect` that complies with store update cycle.
- some miscellaneous issues in Discuss code that were relying on implementation details of owl2 that are no longer true with owl3.