### PR TITLE
[FIX] point_of_sale: owl3 computed signals on deleted records

### DIFF
--- a/addons/point_of_sale/static/src/app/components/list_container/list_container.js
+++ b/addons/point_of_sale/static/src/app/components/list_container/list_container.js
@@ -1,5 +1,5 @@
-import { useRef } from "@web/owl2/utils";
-import { Component, xml, useEffect } from "@odoo/owl";
+import { useLayoutEffect, useRef } from "@web/owl2/utils";
+import { Component, xml } from "@odoo/owl";
 import { useIsChildLarger } from "@point_of_sale/app/hooks/hooks";
 import { useService } from "@web/core/utils/hooks";
 import { Dialog } from "@web/core/dialog/dialog";
@@ -64,9 +64,12 @@ export class ListContainer extends Component {
         this.ui = useService("ui");
         this.dialog = useService("dialog");
 
-        useEffect(() => {
-            Promise.resolve().then(() => this.sizing.reload());
-        });
+        useLayoutEffect(
+            () => {
+                this.sizing.reload();
+            },
+            () => [this.props.items]
+        );
     }
     shouldBeInvisible(itemIndex) {
         return itemIndex >= this.sizing.maxItems;

--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
@@ -100,6 +100,9 @@ export class PosOrderlineAccounting extends Base {
      * This is the preferred way to get prices of an orderline since its rounded globally.
      */
     get prices() {
+        if (!this.order_id) {
+            return undefined;
+        }
         const data = this.order_id.prices.baseLineByLineUuids[this.uuid];
         return data.tax_details;
     }
@@ -108,11 +111,17 @@ export class PosOrderlineAccounting extends Base {
      * Same as "get prices" but the prices are computed as if the quantity was 1.
      */
     get unitPrices() {
+        if (!this.order_id) {
+            return undefined;
+        }
         const data = this.order_id.unitPrices.baseLineByLineUuids[this.uuid];
         return data.tax_details;
     }
 
     get productProductPrice() {
+        if (!this.product_id) {
+            return 0;
+        }
         return this.product_id.getPrice(
             this.config.pricelist_id,
             1,
@@ -138,6 +147,9 @@ export class PosOrderlineAccounting extends Base {
     }
 
     get taxGroupLabels() {
+        if (!this.order_id) {
+            return "";
+        }
         let taxes_id = this.tax_ids;
         if (this.order_id.fiscal_position_id) {
             taxes_id = this.order_id.fiscal_position_id.getTaxesAfterFiscalPosition(this.tax_ids);

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -66,6 +66,9 @@ export class PosOrderline extends PosOrderlineAccounting {
     }
 
     get quantityStr() {
+        if (!this.product_id) {
+            return "";
+        }
         let unitPart = "";
         let decimalPart = "";
         const unit = this.product_id.uom_id;


### PR DESCRIPTION
In OWL2, lazy getter caching used effect() which only invalidated the cache on dependency change — the getter was never eagerly re-evaluated. When a record was deleted and its relational fields disconnected, no getter code ran because the stale cache was simply never accessed again (the record was gone from the store).

In OWL3, lazy getters are wrapped in computed() signals that participate in the reactive graph via markDownstream. When a record is deleted and _disconnect clears relational fields like product_id/order_id, the signal change propagates: the computed is marked STALE → markDownstream reaches the component's render computation → processEffects processes it → updateComputation eagerly re-evaluates the stale source computed → the getter runs on the dead record with undefined relations → crash.

Guard the order line getters that access relational fields (product_id, order_id) so they return a safe default when the relation is undefined during deletion.

Also restore useLayoutEffect (with items dependency) in ListContainer — it was incorrectly replaced with useEffect (no dependencies), so the floating order tab sizing was never recalculated when orders changed.