### PR TITLE
[FIX] mail: prevent nested effects of internal effects

### DIFF
--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -250,26 +250,28 @@ export class RecordInternal {
         }
         this.fieldsComputeStop.get(fieldName)?.();
         let triggered = false;
-        const stopFn = immediateEffect(() => {
-            if (triggered) {
-                return untrack(() => this.requestCompute(record, fieldName));
-            }
-            const store = record._rawStore;
-            this.fieldsComputing.set(fieldName, true);
-            this.fieldsComputeOnNeed.delete(fieldName);
-            let computedValue;
-            try {
-                computedValue = Model._.fieldsCompute.get(fieldName).call(record._proxy);
-            } catch (err) {
-                store.handleError(err);
-            }
-            untrack(() =>
-                store._.updateFields(record, {
-                    [fieldName]: computedValue,
-                })
-            );
-            this.fieldsComputing.delete(fieldName);
-        });
+        const stopFn = untrack(() =>
+            immediateEffect(() => {
+                if (triggered) {
+                    return untrack(() => this.requestCompute(record, fieldName));
+                }
+                const store = record._rawStore;
+                this.fieldsComputing.set(fieldName, true);
+                this.fieldsComputeOnNeed.delete(fieldName);
+                let computedValue;
+                try {
+                    computedValue = Model._.fieldsCompute.get(fieldName).call(record._proxy);
+                } catch (err) {
+                    store.handleError(err);
+                }
+                untrack(() =>
+                    store._.updateFields(record, {
+                        [fieldName]: computedValue,
+                    })
+                );
+                this.fieldsComputing.delete(fieldName);
+            })
+        );
         this.fieldsComputeStop.set(fieldName, stopFn);
         if (fromInNeed) {
             this.fieldsComputeInNeed.set(fieldName, true);
@@ -292,31 +294,35 @@ export class RecordInternal {
         }
         this.fieldsSortStop.get(fieldName)?.();
         let triggered = false;
-        const stopFn = immediateEffect(() => {
-            if (triggered) {
-                return untrack(() => this.requestSort(record, fieldName));
-            }
-            const store = record._rawStore;
-            this.fieldsSortOnNeed.delete(fieldName);
-            this.fieldsSorting.set(fieldName, true);
-            const func = Model._.fieldsSort.get(fieldName).bind(record._proxy);
-            if (isRelation(Model, fieldName)) {
-                try {
-                    store._.sortRecordList(record._proxy[fieldName]._proxy, func);
-                } catch (err) {
-                    store.handleError(err);
+        const stopFn = untrack(() =>
+            immediateEffect(() => {
+                if (triggered) {
+                    return untrack(() => this.requestSort(record, fieldName));
                 }
-            } else {
-                // sort on copy of list so that reactive observers not triggered while sorting
-                const copy = [...record._proxy[fieldName]];
-                copy.sort(func);
-                const hasChanged = copy.some((item, index) => item !== record[fieldName][index]);
-                if (hasChanged) {
-                    record._proxy[fieldName] = copy;
+                const store = record._rawStore;
+                this.fieldsSortOnNeed.delete(fieldName);
+                this.fieldsSorting.set(fieldName, true);
+                const func = Model._.fieldsSort.get(fieldName).bind(record._proxy);
+                if (isRelation(Model, fieldName)) {
+                    try {
+                        store._.sortRecordList(record._proxy[fieldName]._proxy, func);
+                    } catch (err) {
+                        store.handleError(err);
+                    }
+                } else {
+                    // sort on copy of list so that reactive observers not triggered while sorting
+                    const copy = [...record._proxy[fieldName]];
+                    copy.sort(func);
+                    const hasChanged = copy.some(
+                        (item, index) => item !== record[fieldName][index]
+                    );
+                    if (hasChanged) {
+                        record._proxy[fieldName] = copy;
+                    }
                 }
-            }
-            this.fieldsSorting.delete(fieldName);
-        });
+                this.fieldsSorting.delete(fieldName);
+            })
+        );
         this.fieldsSortStop.set(fieldName, stopFn);
         if (fromInNeed) {
             this.fieldsSortInNeed.set(fieldName, true);

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -304,13 +304,15 @@ export class Store extends Record {
         let running = false;
         let ready = true;
         proxy = reactive(record);
-        immediateEffect(() => {
-            if (!running) {
-                _observe();
-            } else if (ready) {
-                callback(_observe);
-            }
-        });
+        untrack(() =>
+            immediateEffect(() => {
+                if (!running) {
+                    _observe();
+                } else if (ready) {
+                    callback(_observe);
+                }
+            })
+        );
         running = true;
         return () => {
             ready = false;

--- a/addons/mail/static/src/utils/common/misc.js
+++ b/addons/mail/static/src/utils/common/misc.js
@@ -102,12 +102,14 @@ export function onChange(target, key, callback) {
     }
     let running = false;
     proxy = reactive(target);
-    immediateEffect(() => {
-        _observe();
-        if (running) {
-            untrack(() => callback());
-        }
-    });
+    untrack(() =>
+        immediateEffect(() => {
+            _observe();
+            if (running) {
+                untrack(() => callback());
+            }
+        })
+    );
     running = true;
     return proxy;
 }


### PR DESCRIPTION
Before this commit, test "thread notifications are re-ordered on receiving a new message" was failing.

The test checks that when posting a new message, the message preview in messaging menu is updated and threads are re-ordered. However the messaging menu is not re-rendered as expected.

This happens because the `MessagingMenu` component was observing `newestPersistentOfAllMessage` which is the last message to show as a preview in messaging menu. While this field had its value changed, the component didn't render because somehow the component no longer its effect subscribed to computation that reads this field. The underlying issue comes from the many `immediateEffect` in innner code that were registered in a way that could have them been flagged as nested effects [1]. This is exactly what happened:

- `MessagingMenu` component observes `menuThreads` (list of conversations)` and `newestPersistentOfAllMessage` (last message preview)
- `newestPersistentOfAllMessage` is a computed field.
- `menuThreads` is both a computed and sorted field.
- The `sort` method of `menuThreads` observes `newestPersistentOfAllMessage` (more recent newest message puts conversation at the top of list)

Internal `immediateEffect` of `compute` and `sort` are made with controlled dispose function `stopFn`, so that they follow the update cycle with the ordered queues when requesting compute or sort. This means that whenever a field has to effectively compute or sort again, this disposes the effect. The effects could be parent of other effects, notably `menuThreads`'s `sort` effect could be parent of `newestPersistentOfAllMessage`'s `compute` method. Fields are lazily computed by default, which `newestPersistentOfAllMessage` is, so the sort of `menuThreads` could immediately compute `newestPersistentOfAllMessage`, hence the parent-child link between these 2 effects.

The nested effect is not desirable: internal code of discuss store and model wants to manually manage the internal effect so that they are disposed when needed.

This commit fixes the issue by wrapping the `immediateEffect` around `untrack()`, so that they are never candidate as children effects, which prevents being implicitly disposed like in the scenario of test "thread notifications are re-ordered on receiving a new message".

[1]: https://odoo.github.io/owl/documentation/v3/owl/reference/reactivity.html#nested-effects