### PR TITLE
[IMP] hr: contract button invisible belam

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -375,7 +375,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite" widget="date_dynamic_min" options="{'min_date_field': 'contract_date_start'}"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start" required="fixed_term"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <field name="fixed_term" string="Fixed Term"/>
                                         <label for="wage"/>


### PR DESCRIPTION
In the employee view > payroll_informations : the button 'New Contract' nows is displayed only when a start date is provided

**With a start date :**
<img width="632" height="296" alt="image" src="https://github.com/user-attachments/assets/4b47c116-8d33-41fa-8e23-78fb01c5849a" />


**Without start date :**
<img width="648" height="247" alt="image" src="https://github.com/user-attachments/assets/b8a7cf78-3bff-4915-b88c-9aa755f801c7" />
