### PR TITLE
Master hr onboarding new contract invisible ahnae

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -375,7 +375,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite" widget="date_dynamic_min" options="{'min_date_field': 'contract_date_start'}"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start" required="fixed_term"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <field name="fixed_term" string="Fixed Term"/>
                                         <label for="wage"/>


### PR DESCRIPTION
[FIX] hr: hide 'new contract' button when dates are missing

Previously, the 'New Contract' widget was visible even if the employee
had no contract dates. This was caused by a missing visibility condition.

This commit adds the 'invisible' attribute to the widget to ensure it
only appears when 'contract_date_start' is set.

Task: 6186258