### PR TITLE
[FIX] hr: make new contract button invisible

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -375,7 +375,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite" widget="date_dynamic_min" options="{'min_date_field': 'contract_date_start'}"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start" required="fixed_term"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <field name="fixed_term" string="Fixed Term"/>
                                         <label for="wage"/>


### PR DESCRIPTION
Added an invisible condition on the new contract button in hr_employee_view to make the new contract button invisible when there's no start date.

Task: 5379422
