### PR TITLE
[FIX] hr_holidays: New time off request crashed when listing time off type

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -279,7 +279,7 @@ class HrWorkEntryType(models.Model):
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented


### PR DESCRIPTION
When requesting a new time off, the form view required the time type to be selected. If the user listed the time off types the app would crash. The search setup for that list required a validation function to run which held a bug.