### PR TITLE
[FIX] hr_holidays: Traceback on Time Off Type

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -279,7 +279,7 @@ class HrWorkEntryType(models.Model):
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented


### PR DESCRIPTION
When navigating (Time Off >> Configuration >> Time Off Types >> Open any type, navigate to the Smart button Time Off >> Click on New >> Time Off Type), it leads to an error. The nested function is_valid in function _search_virtual_remaining_leaves in hr_work_entry_type uses an operator in it's return statement that has on parameter when it should receive two parameters. the second parameter "value" was added.

Task: 6197121