### PR TITLE
[IMP] hr_holidays: add dynamic day filtering for accrual plans

### DIFF
--- a/addons/hr_holidays/static/src/components/accrual_selection_day/accrual_selection_day.js
+++ b/addons/hr_holidays/static/src/components/accrual_selection_day/accrual_selection_day.js
@@ -1,0 +1,34 @@
+import { selectionField, SelectionField } from "@web/views/fields/selection/selection_field";
+import { registry } from "@web/core/registry";
+
+export class AccrualSelectionDay extends SelectionField {
+    static props = {
+        ...SelectionField.props,
+        monthField: { type: String },
+    };
+
+    get options() {
+        const monthField = this.props.monthField;
+        const month = monthField ? this.props.record.data[monthField] : null;
+        const allOptions = super.options;
+
+        if (!month) {
+            return allOptions;
+        }
+
+        const maxDays = new Date(2020, parseInt(month), 0).getDate();
+
+        return allOptions.filter((opt) => parseInt(opt[0]) <= maxDays);
+    }
+}
+
+
+registry.category("fields").add("accrual_selection_day",{
+    ...selectionField,
+    component: AccrualSelectionDay,
+    extractProps: (fieldInfo, dynamicInfo) => {
+        const props = selectionField.extractProps(fieldInfo,dynamicInfo);
+        props.monthField = fieldInfo.options.month_field;
+        return props;
+    },
+});

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,17 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'" widget="accrual_selection_day" options="{'month_field': 'first_month'}"/>
                                     of
                                     <field name="first_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'" widget="accrual_selection_day" options="{'month_field': 'second_month'}"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a day" widget="accrual_selection_day" options="{'month_field': 'yearly_month'}"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>


### PR DESCRIPTION
Prevent selection of invalid dates (e.g., Feb 31st) by introducing 
the 'accrual_selection_day' widget. The widget uses 'extractProps' 
to read a 'month_field' from XML options and dynamically filters 
the day selection list based on the chosen month's length.

Task: 6197119