### PR TITLE
[IMP] hr_holidays: limit accrual plans and levels day selection based on selected month

### DIFF
--- a/addons/hr_holidays/static/src/components/day_selection/day_selection.js
+++ b/addons/hr_holidays/static/src/components/day_selection/day_selection.js
@@ -1,0 +1,36 @@
+import { selectionField, SelectionField } from "@web/views/fields/selection/selection_field";
+import { registry } from "@web/core/registry";
+
+export class DaySelectionField extends SelectionField {
+    static props = {
+        ...SelectionField.props,
+        month: String,
+    };
+
+    get options() {
+        let allOptions = super.options;
+        const monthValue = this.props.record.data[this.props.month];
+        const maxDay = new Date(2020, monthValue, 0).getDate();
+        allOptions = allOptions.filter((option) => option[0] <= maxDay);
+        return allOptions;
+    }
+}
+
+export const daySelectionField = {
+    ...selectionField,
+    component: DaySelectionField,
+    extractProps({ attrs }) {
+        return {
+            ...selectionField.extractProps(...arguments),
+            month: attrs.month,
+        };
+    },
+    fieldDependencies: ({ attrs }) => [
+        {
+            name: attrs.month,
+            type: "selection",
+        },
+    ],
+};
+
+registry.category("fields").add("day_selection", daySelectionField);

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,17 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" class="o_field_accrual" widget="day_selection" month="first_month" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field name="first_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_field_accrual" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" class="o_field_accrual" widget="day_selection" month="second_month" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_field_accrual" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" class="o_field_accrual" widget="day_selection" month="yearly_month" required="frequency == 'yearly'" placeholder="select a day"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_field_accrual" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -195,7 +195,7 @@
                                                options="{'links': {'other': 'carryover_custom_date'}, 'observe': 'carryover'}"/>
                                         <span id="carryover_custom_date">
                                             : the
-                                            <field name="carryover_day" placeholder="select a day"
+                                            <field name="carryover_day" widget="day_selection" month="carryover_month" style="width: 50px;" placeholder="select a day"
                                                    required="carryover_date == 'other'"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"


### PR DESCRIPTION
The day selection for accrual plans carryover date and accrual levels yearly date is now limited to 29 or 30 depending on which month is selected.

Task: 6191776