### PR TITLE
[FIX] mail: fix channel and role mention test in discuss app

### DIFF
--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -247,7 +247,7 @@ test("Editing message keeps the mentioned channels", async () => {
     await press("Enter");
     await contains(".o_channel_redirect:text('other')");
     await click(".o-mail-Message [title='Edit']");
-    await contains(".o-mail-Message .o-mail-Composer-input", { value: "#other " });
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "#other" });
     await insertText(".o-mail-Message .o-mail-Composer-input", "#other bye", { replace: true });
     await click(".o-mail-Message button:text('save')");
     await contains(".o-mail-Message-content:text('other bye (edited)')");
@@ -276,7 +276,7 @@ test("Editing message keeps the mentioned roles", async () => {
     await press("Enter");
     await contains(".o-discuss-mention", { text: "@admin" });
     await click(".o-mail-Message [title='Edit']");
-    await contains(".o-mail-Message .o-mail-Composer-input", { value: "@admin " });
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "@admin" });
     await insertText(".o-mail-Message .o-mail-Composer-input", "@admin edit", { replace: true });
     await click(".o-mail-Message button", { text: "save" });
     await contains(".o-mail-Message-content", { text: "@admin edit (edited)" });


### PR DESCRIPTION
Partial revert of [1]

Tests were wrongly adapted: the mentions have an extra space when adding the mentions in composer while composing, but the recovering part from starting edition of a message with already some mentions should not have the extra spaces (message content is trimmed).

The tests were likely adapted because the tests were not passing due to prior steps that insert mention by hand in composer, and there was probably a issue in owl 3 code where the composer's input value of thread was reused with the extra whitespace.

[1]: https://github.com/odoo-dev/odoo/pull/5111/changes/ecbf4911da68f0f5007b25b59ec0c355aa95c7ea