### PR TITLE
[FIX] mail: fix test 'replying to message should only render relevant…

### DIFF
--- a/addons/mail/static/tests/discuss/core/discuss_performance.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss_performance.test.js
@@ -107,7 +107,7 @@ test("replying to message should only render relevant part", async () => {
     replying = false;
     const result = stopObserve();
     expect(result.get(Composer)).toBeLessThan(3);
-    expect(result.get(ActionSwiper)).toBeLessThan(2);
+    expect(result.get(ActionSwiper)).toBeLessThan(3); // Note: ActionSwiper from Message's template
 });
 
 test("right-click message selection should only render relevant part", async () => {
@@ -145,5 +145,5 @@ test("right-click message selection should only render relevant part", async () 
     await contains(".dropdown-menu .o-mail-ActionList");
     rightClicking = false;
     const result = stopObserve();
-    expect(result.get(ActionSwiper)).toBeLessThan(3);
+    expect(result.get(ActionSwiper)).toBeLessThan(3); // Note: ActionSwiper from Message's template
 });


### PR DESCRIPTION
… part'

Test was adapted several time. Initially the patch of Message had:

- onMounted
- onPatched

This was then changed to
- onMounted
- onRendered

And this change over-estimated the rendering by at least 1, as onRendered also includes an extra render.
But when this change was made, the counter was not increased in the assertion.

Then the onMounted was removed, and the counter was reduced.

The test is failing because the counter was changed from lower than 3 to lower than 2, but the initial change from onMounted/onPatched to onRendered should preserve the same counter of lower than 3.

This commit fixes with the correct counter.

Also the assertion on renderers on ActionSwiper were not necessarily made clear that this is related to the Message, so this commit adds comment to make it clear.