### PR TITLE
[PERF] mail: fix memory leak from running mail tests

### DIFF
--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -12,7 +12,7 @@ export class Attachment extends FileModelMixin(Record) {
     static new() {
         /** @type {import("models").Attachment} */
         const attachment = super.new(...arguments);
-        Record.onChange(attachment, ["extension", "name"], () => {
+        attachment.registerRecordOnChange(attachment, ["extension", "name"], () => {
             if (!attachment.extension && attachment.name) {
                 attachment.extension = attachment.name.split(".").pop();
             }

--- a/addons/mail/static/src/discuss/call/common/call_invitations.js
+++ b/addons/mail/static/src/discuss/call/common/call_invitations.js
@@ -1,5 +1,4 @@
 import { CallInvitation } from "@mail/discuss/call/common/call_invitation";
-import { onChange } from "@mail/utils/common/misc";
 
 import { Component } from "@odoo/owl";
 
@@ -21,6 +20,7 @@ export class CallInvitations extends Component {
 export const callInvitationsService = {
     dependencies: ["discuss.rtc", "mail.store", "overlay"],
     start(env, services) {
+        /** @type {import("models").Store} */
         const store = services["mail.store"];
         let removeOverlay;
         const onChangeRingingThreadsLength = () => {
@@ -34,7 +34,7 @@ export const callInvitationsService = {
             }
         };
         onChangeRingingThreadsLength();
-        onChange(store.ringingChannels, "length", onChangeRingingThreadsLength);
+        store.registerOnChange(store.ringingChannels, "length", onChangeRingingThreadsLength);
     },
 };
 registry.category("services").add("discuss.call_invitations", callInvitationsService);

--- a/addons/mail/static/src/discuss/call/common/call_preview.js
+++ b/addons/mail/static/src/discuss/call/common/call_preview.js
@@ -60,46 +60,62 @@ export class CallPreview extends Component {
             ]
         );
         if (this.hasRtcSupport) {
-            onChange(this.rtc, "microphonePermission", () => {
-                if (this.rtc.microphonePermission !== "granted") {
-                    this.disableMicrophone();
-                }
-            });
-            onChange(this.rtc, "cameraPermission", () => {
-                if (this.rtc.cameraPermission !== "granted") {
-                    this.disableCamera();
-                }
-            });
-            onChange(this.store.settings, "audioInputDeviceId", () => {
-                if (this.state.audioStream) {
-                    closeStream(this.state.audioStream);
-                    this.enableMicrophone();
-                }
-            });
-            onChange(this.store.settings, "cameraInputDeviceId", () => {
-                if (this.state.videoStream) {
-                    closeStream(this.state.videoStream);
-                    this.enableCamera();
-                }
-            });
-            onChange(this.store.settings, "audioOutputDeviceId", (deviceId) => {
-                this.audioRef.el?.setSinkId?.(deviceId).catch(() => {});
-            });
-            onChange(this.store.settings, "useBlur", () => {
-                if (this.store.settings.useBlur) {
-                    this.enableBlur();
-                } else {
-                    this.disableBlur();
-                }
-            });
-            onChange(this.store.settings, ["edgeBlurAmount", "backgroundBlurAmount"], () => {
-                if (this.state.blurManager) {
-                    this.state.blurManager.edgeBlur = this.store.settings.edgeBlurAmount;
-                    this.state.blurManager.backgroundBlur =
-                        this.store.settings.backgroundBlurAmount;
-                }
-            });
+            const disposeFns = [];
+            disposeFns.push(
+                onChange(this.rtc, "microphonePermission", () => {
+                    if (this.rtc.microphonePermission !== "granted") {
+                        this.disableMicrophone();
+                    }
+                })
+            );
+            disposeFns.push(
+                onChange(this.rtc, "cameraPermission", () => {
+                    if (this.rtc.cameraPermission !== "granted") {
+                        this.disableCamera();
+                    }
+                })
+            );
+            disposeFns.push(
+                onChange(this.store.settings, "audioInputDeviceId", () => {
+                    if (this.state.audioStream) {
+                        closeStream(this.state.audioStream);
+                        this.enableMicrophone();
+                    }
+                })
+            );
+            disposeFns.push(
+                onChange(this.store.settings, "cameraInputDeviceId", () => {
+                    if (this.state.videoStream) {
+                        closeStream(this.state.videoStream);
+                        this.enableCamera();
+                    }
+                })
+            );
+            disposeFns.push(
+                onChange(this.store.settings, "audioOutputDeviceId", (deviceId) => {
+                    this.audioRef.el?.setSinkId?.(deviceId).catch(() => {});
+                })
+            );
+            disposeFns.push(
+                onChange(this.store.settings, "useBlur", () => {
+                    if (this.store.settings.useBlur) {
+                        this.enableBlur();
+                    } else {
+                        this.disableBlur();
+                    }
+                })
+            );
+            disposeFns.push(
+                onChange(this.store.settings, ["edgeBlurAmount", "backgroundBlurAmount"], () => {
+                    if (this.state.blurManager) {
+                        this.state.blurManager.edgeBlur = this.store.settings.edgeBlurAmount;
+                        this.state.blurManager.backgroundBlur =
+                            this.store.settings.backgroundBlurAmount;
+                    }
+                })
+            );
             onWillDestroy(() => {
+                disposeFns.forEach((f) => f());
                 closeStream(this.state.audioStream);
                 closeStream(this.state.videoStream);
             });

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -6,7 +6,7 @@ import { CALL_PROMOTE_FULLSCREEN } from "@mail/discuss/call/common/discuss_chann
 import { monitorAudio } from "@mail/utils/common/media_monitoring";
 import { CallPermissionDeniedDialog } from "@mail/discuss/call/common/call_permission_denied_dialog";
 import { rpc } from "@web/core/network/rpc";
-import { assignDefined, closeStream, onChange } from "@mail/utils/common/misc";
+import { assignDefined, closeStream } from "@mail/utils/common/misc";
 
 import { toRaw } from "@odoo/owl";
 
@@ -486,31 +486,39 @@ export class Rtc extends Record {
          * @type {import("@mail/discuss/call/common/peer_to_peer").PeerToPeer}
          */
         this.p2pService = services["discuss.p2p"];
-        onChange(this.store.settings, "useBlur", () => {
+        this.registerOnChange(this.store.settings, "useBlur", () => {
             if (this.isSendingCamera) {
                 this.toggleVideo("camera", { force: true });
             }
         });
-        onChange(this.store.settings, ["edgeBlurAmount", "backgroundBlurAmount"], () => {
-            if (this.blurManager) {
-                this.blurManager.edgeBlur = this.store.settings.edgeBlurAmount;
-                this.blurManager.backgroundBlur = this.store.settings.backgroundBlurAmount;
+        this.registerOnChange(
+            this.store.settings,
+            ["edgeBlurAmount", "backgroundBlurAmount"],
+            () => {
+                if (this.blurManager) {
+                    this.blurManager.edgeBlur = this.store.settings.edgeBlurAmount;
+                    this.blurManager.backgroundBlur = this.store.settings.backgroundBlurAmount;
+                }
             }
-        });
-        onChange(this.store.settings, ["voiceActivationThreshold", "usePushToTalk"], () => {
-            this.linkVoiceActivationDebounce();
-        });
-        onChange(this.store.settings, "audioInputDeviceId", async () => {
+        );
+        this.registerOnChange(
+            this.store.settings,
+            ["voiceActivationThreshold", "usePushToTalk"],
+            () => {
+                this.linkVoiceActivationDebounce();
+            }
+        );
+        this.registerOnChange(this.store.settings, "audioInputDeviceId", async () => {
             if (this.localSession) {
                 await this.resetMicAudioTrack({ force: true });
             }
         });
-        onChange(this.store.settings, "audioOutputDeviceId", async () => {
+        this.registerOnChange(this.store.settings, "audioOutputDeviceId", async () => {
             if (this.localSession) {
                 await this.setOutputDevice(this.store.settings.audioOutputDeviceId);
             }
         });
-        onChange(this.store.settings, "cameraInputDeviceId", async () => {
+        this.registerOnChange(this.store.settings, "cameraInputDeviceId", async () => {
             if (this.localSession && this.cameraTrack) {
                 await this.toggleVideo("camera", { force: true, refreshStream: true });
             }
@@ -2418,7 +2426,7 @@ export const rtcService = {
         const store = env.services["mail.store"];
         const rtc = store.rtc;
         rtc.pipService = services["discuss.pip_service"];
-        onChange(rtc.pipService.state, "active", () => {
+        rtc.registerOnChange(rtc.pipService.state, "active", () => {
             const isPipMode = rtc.pipService.state.active;
             if (!isPipMode) {
                 if (rtc.hadFullscreen && rtc.channel) {
@@ -2434,7 +2442,7 @@ export const rtcService = {
             });
         });
         rtc.fullscreen = services["mail.fullscreen"];
-        onChange(rtc.fullscreen, "id", () => {
+        rtc.registerOnChange(rtc.fullscreen, "id", () => {
             const wasFullscreen = rtc.isFullscreen;
             rtc.isFullscreen = rtc.fullscreen.id === CALL_FULLSCREEN_ID;
             if (

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -2,6 +2,7 @@ import { markup, toRaw } from "@odoo/owl";
 import {
     IS_DELETED_SYM,
     OR_SYM,
+    STORE_SYM,
     isCommandList,
     isMany,
     isOne,
@@ -11,6 +12,7 @@ import {
     technicalKeysOnRecords,
 } from "./misc";
 import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
+import { onChange } from "@mail/utils/common/misc";
 
 /** @typedef {import("./misc").FieldDefinition} FieldDefinition */
 /** @typedef {import("./record_list").RecordList} RecordList */
@@ -402,6 +404,28 @@ export class Record {
     }
 
     /**
+     * Register an `onChange()`. Equivalent to `onChange` but auto-saves the disposeFn in the record and store,
+     * so that this is automatically disposed on record deletion or in-between tests.
+     *
+     * @param  {...any} args
+     */
+    registerOnChange(...args) {
+        const disposeFn = onChange(...args);
+        this._registerDisposeFn(disposeFn);
+    }
+
+    /**
+     * Register a `Record.onChange()`. Equivalent to `Record.onChange` but auto-saves the disposeFn in the record and store,
+     * so that this is automatically disposed on record deletion or in-between tests.
+     *
+     * @param  {...any} args
+     */
+    registerRecordOnChange(...args) {
+        const disposeFn = Record.onChange(...args);
+        this._registerDisposeFn(disposeFn);
+    }
+
+    /**
      * Converts the current record and its related data into Store insert-able data.
      * @param {Array<string> | { depth: boolean }} options Configuration options or an array of field names.
      * @returns {Object} A data object grouped by model names.
@@ -423,6 +447,29 @@ export class Record {
 
     _cleanupData(data) {
         technicalKeysOnRecords.forEach((field) => delete data[field]);
+    }
+
+    /** @param {Function} disposeFn */
+    _registerDisposeFn(disposeFn) {
+        this._.disposeFns.add(disposeFn);
+        if (!this[STORE_SYM]) {
+            this.store._.disposeFns.add(disposeFn);
+        }
+    }
+
+    /** @param {Function} f */
+    _runDisposeFn(f) {
+        f();
+        this._.disposeFns.delete(f);
+        if (!this[STORE_SYM]) {
+            this.store._.disposeFns.delete(f);
+        }
+    }
+
+    _runDisposeFns() {
+        for (const f of this._.disposeFns) {
+            this._runDisposeFn(f);
+        }
     }
 
     /**

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -12,10 +12,17 @@ import { RecordList } from "./record_list";
 import { immediateEffect, toRaw, untrack } from "@odoo/owl";
 import { RecordUses } from "./record_uses";
 import { LocalStorageEntry } from "@mail/utils/common/local_storage";
-import { onChange } from "@mail/utils/common/misc";
 
 export class RecordInternal {
     [IS_RECORD_SYM] = true;
+    /**
+     * All dispose functions for this records.
+     * For the store, this stores the dispose functions of all records.
+     * Useful to automatically call the dispose functions when the record is deleted or in-between each tests.
+     *
+     * @type {Set<Function>}
+     */
+    disposeFns = new Set();
     // Note: state of fields in Maps rather than object is intentional for improved performance.
     /**
      * For computed field, determines whether the field is computing its value.
@@ -139,7 +146,7 @@ export class RecordInternal {
         }
         if (Model._.fieldsCompute.get(fieldName)) {
             if (!Model._.fieldsEager.get(fieldName)) {
-                onChange(recordProxy, fieldName, () => {
+                record.registerOnChange(recordProxy, fieldName, () => {
                     if (this.fieldsComputing.get(fieldName)) {
                         /**
                          * Use a reactive to reset the computeInNeed flag when there is
@@ -157,7 +164,7 @@ export class RecordInternal {
         }
         if (Model._.fieldsSort.get(fieldName)) {
             if (!Model._.fieldsEager.get(fieldName)) {
-                onChange(recordProxy, fieldName, () => {
+                record.registerOnChange(recordProxy, fieldName, () => {
                     if (this.fieldsSorting.get(fieldName)) {
                         /**
                          * Use a reactive to reset the inNeed flag when there is a
@@ -248,7 +255,10 @@ export class RecordInternal {
         if (!Model._.fieldsCompute.get(fieldName)) {
             return;
         }
-        this.fieldsComputeStop.get(fieldName)?.();
+        const prevStopFn = this.fieldsComputeStop.get(fieldName);
+        if (prevStopFn) {
+            record._runDisposeFn(prevStopFn);
+        }
         let triggered = false;
         const stopFn = untrack(() =>
             immediateEffect(() => {
@@ -273,6 +283,7 @@ export class RecordInternal {
             })
         );
         this.fieldsComputeStop.set(fieldName, stopFn);
+        record._registerDisposeFn(stopFn);
         if (fromInNeed) {
             this.fieldsComputeInNeed.set(fieldName, true);
         }
@@ -292,7 +303,10 @@ export class RecordInternal {
         if (!Model._.fieldsSort.get(fieldName)) {
             return;
         }
-        this.fieldsSortStop.get(fieldName)?.();
+        const prevStopFn = this.fieldsSortStop.get(fieldName);
+        if (prevStopFn) {
+            record._runDisposeFn(prevStopFn);
+        }
         let triggered = false;
         const stopFn = untrack(() =>
             immediateEffect(() => {
@@ -324,6 +338,7 @@ export class RecordInternal {
             })
         );
         this.fieldsSortStop.set(fieldName, stopFn);
+        record._registerDisposeFn(stopFn);
         if (fromInNeed) {
             this.fieldsSortInNeed.set(fieldName, true);
         }

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -181,6 +181,7 @@ export class Store extends Record {
                     // effectively delete the record
                     /** @type {Record} */
                     const record = RHD_QUEUE.keys().next().value;
+                    record._runDisposeFns();
                     RHD_QUEUE.delete(record);
                     deletingRecordsByLocalId.delete(record.localId);
                 }
@@ -296,27 +297,31 @@ export class Store extends Record {
             }
         }
         if (Array.isArray(key)) {
+            /** @type {Function[]} */
+            const arrayDisposeFns = [];
+            arrayDisposeFns.forEach((f) => f());
+            arrayDisposeFns.length = 0;
             for (const k of key) {
-                this._onChange(record, k, callback);
+                arrayDisposeFns.push(this._onChange(record, k, callback));
             }
-            return;
+            return () => {
+                arrayDisposeFns.forEach((f) => f());
+                arrayDisposeFns.length = 0;
+            };
         }
         let running = false;
-        let ready = true;
         proxy = reactive(record);
-        untrack(() =>
+        const disposeFn = untrack(() =>
             immediateEffect(() => {
                 if (!running) {
                     _observe();
-                } else if (ready) {
+                } else {
                     callback(_observe);
                 }
             })
         );
         running = true;
-        return () => {
-            ready = false;
-        };
+        return disposeFn;
     }
     _cleanupData(data) {
         super._cleanupData(data);

--- a/addons/mail/static/src/utils/common/misc.js
+++ b/addons/mail/static/src/utils/common/misc.js
@@ -80,6 +80,7 @@ export function isDragSourceExternalFile(dataTransfer) {
  * @param {Object} target
  * @param {string|string[]} key
  * @param {Function} callback
+ * @returns {Function} dispose function
  */
 export function onChange(target, key, callback) {
     let proxy;
@@ -95,14 +96,21 @@ export function onChange(target, key, callback) {
         }
     }
     if (Array.isArray(key)) {
+        /** @type {Function[]} */
+        const arrayDisposeFns = [];
+        arrayDisposeFns.forEach((f) => f());
+        arrayDisposeFns.length = 0;
         for (const k of key) {
-            onChange(target, k, callback);
+            arrayDisposeFns.push(onChange(target, k, callback));
         }
-        return;
+        return () => {
+            arrayDisposeFns.forEach((f) => f());
+            arrayDisposeFns.length = 0;
+        };
     }
     let running = false;
     proxy = reactive(target);
-    untrack(() =>
+    const disposeFn = untrack(() =>
         immediateEffect(() => {
             _observe();
             if (running) {
@@ -111,7 +119,7 @@ export function onChange(target, key, callback) {
         })
     );
     running = true;
-    return proxy;
+    return disposeFn;
 }
 
 /**

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -1,7 +1,7 @@
 import { reactive } from "@web/owl2/utils";
 import { toRawValue } from "@mail/utils/common/local_storage";
 import { defineMailModels, start as start2 } from "@mail/../tests/mail_test_helpers";
-import { afterEach, beforeEach, describe, expect, test, tick } from "@odoo/hoot";
+import { after, afterEach, beforeEach, describe, expect, test, tick } from "@odoo/hoot";
 import { immediateEffect, markup, toRaw } from "@odoo/owl";
 import { mockService, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
@@ -49,7 +49,10 @@ afterEach(() => {
 
 async function start() {
     const env = await start2();
-    return env.services.store;
+    /** @type {Store} */
+    const store = env.services.store;
+    after(() => store._runDisposeFns());
+    return store;
 }
 
 test("Insert by passing only single-id value (non-relational)", async () => {
@@ -530,7 +533,7 @@ test("Set on attr should invoke onChange", async () => {
     }).register(localRegistry);
     const store = await start();
     const message = store.Message.insert(1);
-    Record.onChange(message, "body", () => expect.step("BODY_CHANGED"));
+    store.registerRecordOnChange(message, "body", () => expect.step("BODY_CHANGED"));
     expect.verifySteps([]);
     message.update({ body: "test1" });
     message.body = "test2";
@@ -563,9 +566,10 @@ test("record list sort should be manually observable", async () => {
     }
     const observedMessages = reactive(thread.messages);
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
-    immediateEffect(() => {
+    const disposeFn = immediateEffect(() => {
         sortMessages();
     });
+    after(() => disposeFn());
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
     expect.verifySteps(["sortMessages"]);
     messages[0].body = "c";
@@ -670,22 +674,20 @@ test("lazy compute should re-compute while they are observed", async () => {
     }).register(localRegistry);
     const store = await start();
     const channel = store.Channel.insert(1);
-    let observe = true;
     const reactiveChannel = reactive(channel);
     function render() {
         expect.step(`render ${reactiveChannel.multiplicity}`);
     }
-    immediateEffect(() => {
-        if (observe) {
-            render();
-        }
+    const disposeFn1 = immediateEffect(() => {
+        render();
     });
+    after(() => disposeFn1?.());
     expect.verifySteps(["computing", "render few"]);
     channel.count = 2;
     expect.verifySteps(["computing"]);
     channel.count = 5;
     expect.verifySteps(["computing", "render many"]);
-    observe = false;
+    disposeFn1();
     channel.count = 6;
     expect.verifySteps([]);
     channel.count = 7;
@@ -700,9 +702,10 @@ test("lazy compute should re-compute while they are observed", async () => {
     expect.verifySteps([]);
     expect(channel.multiplicity).toBe("few");
     expect.verifySteps(["computing"]);
-    immediateEffect(() => {
+    const disposeFn2 = immediateEffect(() => {
         render();
     });
+    after(() => disposeFn2());
     expect.verifySteps(["render few"]);
     channel.count = 7;
     expect.verifySteps(["computing", "render many"]);
@@ -725,17 +728,14 @@ test("lazy sort should re-sort while they are observed", async () => {
     const thread = store.Thread.insert(1);
     thread.messages.push({ id: 1, sequence: 1 }, { id: 2, sequence: 2 });
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
-    let observe = true;
     function render() {
         expect.step(`render ${reactiveChannel.messages.map((m) => m.id)}`);
     }
     const reactiveChannel = reactive(thread);
-    immediateEffect(() => {
-        if (!observe) {
-            return;
-        }
+    const disposeFn1 = immediateEffect(() => {
         render();
     });
+    after(() => disposeFn1?.());
     const message = thread.messages[0];
     expect.verifySteps(["render 1,2"]);
     message.sequence = 3;
@@ -746,7 +746,7 @@ test("lazy sort should re-sort while they are observed", async () => {
     expect.verifySteps([]);
     message.sequence = 1;
     expect.verifySteps(["render 1,2"]);
-    observe = false;
+    disposeFn1();
     message.sequence = 10;
     expect(
         `${toRaw(thread)._raw.messages.data.map(
@@ -761,9 +761,10 @@ test("lazy sort should re-sort while they are observed", async () => {
         )}`
     ).toBe("2,1", { message: "no longer observed" });
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
-    immediateEffect(() => {
+    const disposeFn2 = immediateEffect(() => {
         render();
     });
+    after(() => disposeFn2());
     expect.verifySteps(["render 1,2"]);
     message.sequence = 10;
     expect.verifySteps(["render 2,1"]);
@@ -781,17 +782,14 @@ test("sort works on fields.Attr()", async () => {
     const thread = store.Thread.insert(1);
     thread.messages.push({ id: 1, sequence: 1 }, { id: 2, sequence: 2 });
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
-    let observe = true;
     function render() {
         expect.step(`render ${reactiveChannel.messages.map((m) => m.id)}`);
     }
     const reactiveChannel = reactive(thread);
-    immediateEffect(() => {
-        if (!observe) {
-            return;
-        }
+    const disposeFn1 = immediateEffect(() => {
         render();
     });
+    after(() => disposeFn1?.());
     const message = thread.messages[0];
     expect.verifySteps(["render 1,2"]);
     message.sequence = 3;
@@ -802,7 +800,7 @@ test("sort works on fields.Attr()", async () => {
     expect.verifySteps([]);
     message.sequence = 1;
     expect.verifySteps(["render 1,2"]);
-    observe = false;
+    disposeFn1();
     message.sequence = 10;
     expect(`${toRaw(thread)._raw.messages.map((msg) => toRaw(msg).id)}`).toBe("2,1", {
         message: "observed one last time when it changes",
@@ -813,9 +811,10 @@ test("sort works on fields.Attr()", async () => {
         message: "no longer observed",
     });
     expect(`${thread.messages.map((m) => m.id)}`).toBe("1,2");
-    immediateEffect(() => {
+    const disposeFn2 = immediateEffect(() => {
         render();
     });
+    after(() => disposeFn2());
     expect.verifySteps(["render 1,2"]);
     message.sequence = 10;
     expect.verifySteps(["render 2,1"]);
@@ -828,9 +827,10 @@ test("store updates can be observed", async () => {
     }
     const rawStore = toRaw(store)._raw;
     const reactiveStore = reactive(store);
-    immediateEffect(() => {
+    const disposeFn = immediateEffect(() => {
         onUpdate();
     });
+    after(() => disposeFn());
     expect.verifySteps(["abc:undefined"]);
     store.abc = 1;
     expect.verifySteps(["abc:1"]); // observable from makeStore"
@@ -1590,13 +1590,14 @@ test("Record exists is reactive", async () => {
     }).register(localRegistry);
     const store = await start();
     const thread = store.Thread.insert("General");
-    immediateEffect(() => {
+    const disposeFn = immediateEffect(() => {
         if (thread.exists()) {
             expect.step("thread exists");
         } else {
             expect.step("thread does not exist");
         }
     });
+    after(() => disposeFn());
     expect.verifySteps(["thread exists"]);
     thread.delete();
     expect.verifySteps(["thread does not exist"]);

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -405,6 +405,8 @@ export async function start(options) {
     // Note that loading the emojis cannot be called before setting up the env because
     // it depends on translations being loaded.
     await Promise.all([mountWithCleanup(WebClient, { env, target }), emojiLoader.load()]);
+    const storeService = env.services["mail.store"];
+    after(() => storeService._runDisposeFns());
     return Object.assign(env, { ...options?.env, target });
 }
 


### PR DESCRIPTION
Before this commit, running the whole `@mail` HOOT tests suite leads to heavy memory leak.

This happens for one main reason: internal effects in `@mail` are not properly disposed in-between tests. This includes `onChange` utility function, which internally uses `immediateEffect`.

1. `onChange` was returning a proxy, but this return value was never used. This commit now makes it return a function to dispose effects that are internally used. Some components that were using `onChange` now can properly dispose these effects on destroy

2. `onChange` and `Record.onChange` (= a version of `onChange` that follows the store's update cycle) made in store, services, and JS models had no dispose strategy. This commit now adds several functions for `register(Record)OnChange` and `runDisposeFn(s)`, so that all these dispose functions are executed in-between each test.

Browser tab RAM of running whole `@mail test`:
- before this commit: 2GB
- after this commit: 250MB