### PR TITLE
[FIX] hr: made new contract button invisible if no contract start date

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -375,7 +375,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite" widget="date_dynamic_min" options="{'min_date_field': 'contract_date_start'}"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start" required="fixed_term"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <field name="fixed_term" string="Fixed Term"/>
                                         <label for="wage"/>


### PR DESCRIPTION
Problem:
"New Contract" button was still visible when there was no contract start date.

Solution:
Made "New Contract" button invisible if the contract start date is not set.

Task-6269675