### PR TITLE
[FIX] hr: hide new contract button 

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -375,7 +375,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite" widget="date_dynamic_min" options="{'min_date_field': 'contract_date_start'}"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start" required="fixed_term"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start" />
                                         </div>
                                         <field name="fixed_term" string="Fixed Term"/>
                                         <label for="wage"/>


### PR DESCRIPTION
When there is no contract dates, the button 'new contract' is visible. This make 'New Contract' invisible if there is no contract start date.

Task: 6269039