### PR TITLE
[IMP] hr: made work permit no versioned

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -201,7 +201,7 @@ class HrEmployee(models.Model):
     }
     """
 
-    permit_no = fields.Char('Work Permit No', groups="hr.group_hr_user", tracking=True)
+    permit_no = fields.Char(readonly=False, related='version_id.permit_no', inherited=True, groups="hr.group_hr_user")
     visa_no = fields.Char('Visa No', groups="hr.group_hr_user", tracking=True)
     visa_expire = fields.Date('Visa Expiration Date', groups="hr.group_hr_user", tracking=True)
     work_permit_expiration_date = fields.Date('Work Permit Expiration Date', groups="hr.group_hr_user", tracking=True)

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -151,6 +151,7 @@ class HrVersion(models.Model):
     is_flexible = fields.Boolean(compute='_compute_is_flexible', store=True, groups="hr.group_hr_user")
     is_fully_flexible = fields.Boolean(compute='_compute_is_flexible', store=True, groups="hr.group_hr_user")
     tz = fields.Selection(_tz_get, string='Timezone', required=True, default=lambda self: self.env.context.get('tz') or self.env.user.tz or 'UTC')
+    permit_no = fields.Char(string='Work Permit No', tracking=True, groups="hr.group_hr_user")
 
     # Contract Information
     contract_date_start = fields.Date('Contract Start Date', tracking=1, groups="hr.group_hr_manager")


### PR DESCRIPTION
Problem:
Work permit number was not versioned, which didn't allow users to have records with different permit numbers.

Solution:
Added a "permit no" field to the hr.version model and made the hr.employee model inherit it.

Task-6272196