### PR TITLE
[FIX] hr_holidays: fixed traceback on time off type

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -279,7 +279,7 @@ class HrWorkEntryType(models.Model):
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -38,3 +38,4 @@ from . import test_work_entry_holidays
 from . import test_timeoff_overview_my_department_tour
 from . import test_hr_leave_report
 from . import test_member_of_department
+from . import test_work_entry_type_search

--- a/addons/hr_holidays/tests/test_work_entry_type_search.py
+++ b/addons/hr_holidays/tests/test_work_entry_type_search.py
@@ -1,0 +1,40 @@
+from odoo.tests import tagged
+
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+
+
+@tagged("work_entry_search")
+class TestWorkEntryTypeSearch(TestHrHolidaysCommon):
+    def test_work_entry_type_search(self):
+        employee_test = self.env["hr.employee"].create({"name": "Test Employee"})
+
+        work_entry_type_test = self.env["hr.work.entry.type"].create(
+            {
+                "name": "Paid Time Off",
+                "code": "Paid Time Off",
+                "requires_allocation": True,
+                "allocation_validation_type": "no_validation",
+                "request_unit": "day",
+                "unit_of_measure": "day",
+            }
+        )
+
+        self.env["hr.leave.allocation"].create(
+            {
+                "employee_id": employee_test.id,
+                "work_entry_type_id": work_entry_type_test.id,
+                "number_of_days": 1,
+            }
+        )
+
+        work_entry_type_search_test = (
+            self.env["hr.work.entry.type"]
+            .with_context(employee_id=employee_test.id)
+            .search([("virtual_remaining_leaves", ">", 0)])
+        )
+
+        self.assertIn(
+            work_entry_type_test,
+            work_entry_type_search_test,
+            "Should have found the work entry type that was created.",
+        )


### PR DESCRIPTION
Problem:
A traceback appeared whenever the user tried to select the time type field in the time off creation form.

Solution:
The value parameter was missing in the call to op() function inside the search function of the virtual_remaining_leaves computed field from hr_work_entry_type_model.

To reproduce the bug:
- First, you need to have an existing work entry type that requires allocation.
- Then, you need to have an employee that has allocation for this work entry type.
- Finally, you can reproduce the bug by going to the leave form view and clicking on the work entry type dropdown field.
- A traceback popup will appear, indicating that "gt expected 2 arguments, got 1". This error appears here because the search is triggered by the field domain in the form view.

Task-6273744