### PR TITLE
[FIX] hr_holidays: fix traceback on time off type

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -279,7 +279,7 @@ class HrWorkEntryType(models.Model):
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -38,3 +38,4 @@ from . import test_work_entry_holidays
 from . import test_timeoff_overview_my_department_tour
 from . import test_hr_leave_report
 from . import test_member_of_department
+from . import test_time_off_type

--- a/addons/hr_holidays/tests/test_time_off_type.py
+++ b/addons/hr_holidays/tests/test_time_off_type.py
@@ -1,0 +1,34 @@
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+
+
+class TestTimeOffType(TestHrHolidaysCommon):
+
+    @classmethod
+    def setUpClass(cls):
+
+        super().setUpClass()
+
+        cls.work_entry_type_paid = cls.env['hr.work.entry.type'].create({
+            'name': 'Paid Time Off',
+            'code': 'Paid Time Off',
+            'requires_allocation': True,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+            'allows_negative': False,
+        })
+
+        cls.allocation = cls.env['hr.leave.allocation'].create({
+                'name': 'Regular allocation',
+                'date_from': '2024-01-04',
+                'work_entry_type_id': cls.work_entry_type_paid.id,
+                'employee_id': cls.employee_emp.id,
+                'number_of_days': 10,
+        })
+        cls.allocation.action_approve()
+
+    def test_time_off_type_selection_with_existing_allocations(self):
+        self.env['hr.work.entry.type'].with_context(
+                default_employee_id=self.employee_emp.id,
+        ).search([
+            ('virtual_remaining_leaves', '>', 0),
+        ])


### PR DESCRIPTION
There was an error when selecting a Time Off Type with existing allocations.

Step to reproduce:
- Create and validate an allocation for a Time Off Type that requires allocations
- Open this Time Off Type and create a new Time Off request from the smart button
- In the creation popup, click on the 'Time off Type' field
- A traceback is raised: TypeError: gt expected 2 arguments, got 1

Reason:
The search method for virtual_remaining_leaves was missing a required parameter

Solution:
Pass the missing value parameter when calling op()

Task-6276095