### PR TITLE
[FIX] hr_employee: make permit_no versioned

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -201,7 +201,6 @@ class HrEmployee(models.Model):
     }
     """
 
-    permit_no = fields.Char('Work Permit No', groups="hr.group_hr_user", tracking=True)
     visa_no = fields.Char('Visa No', groups="hr.group_hr_user", tracking=True)
     visa_expire = fields.Date('Visa Expiration Date', groups="hr.group_hr_user", tracking=True)
     work_permit_expiration_date = fields.Date('Work Permit Expiration Date', groups="hr.group_hr_user", tracking=True)
@@ -239,6 +238,8 @@ class HrEmployee(models.Model):
         related='version_id.country_id.code',
         groups="hr.group_hr_user"
     )
+    permit_no = fields.Char('Work Permit No', readonly=False, related="version_id.permit_no", inherited=True, groups="hr.group_hr_user", tracking=True)
+
     # Direct subordinates
     parent_id = fields.Many2one('hr.employee', 'Manager', tracking=True, index=True,
                                 domain="['|', ('company_id', '=', False), ('company_id', 'in', allowed_company_ids)]")

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -115,6 +115,7 @@ class HrVersion(models.Model):
     spouse_complete_name = fields.Char(string="Spouse Legal Name", groups="hr.group_hr_user", tracking=1)
     spouse_birthdate = fields.Date(string="Spouse Birthdate", groups="hr.group_hr_user", tracking=1)
     children = fields.Integer(string='Dependent Children', groups="hr.group_hr_user", tracking=1)
+    permit_no = fields.Char('Work Permit No', groups="hr.group_hr_user", tracking=1)
 
     # Work Information
     department_id = fields.Many2one('hr.department', check_company=True, tracking=1, index=True)


### PR DESCRIPTION
The work permit number is stored on hr.employee.  This store permit_no on hr.version instead and make hr.employee read it from employee version record.

Task-6271434