### PR TITLE
[IMP] hr_holidays: restricted the day selection according to the month

### DIFF
--- a/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.scss
+++ b/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.scss
@@ -10,7 +10,7 @@
 }
 
 .o_accrual {
-  .o_field_accrual, .o_field_selection, .o_field_filterable_selection {
+  .o_field_accrual, .o_field_selection, .o_field_day_selection, .o_field_filterable_selection {
     width: fit-content !important;
 
     &:not(.o_readonly_modifier) > *:first-child {
@@ -20,7 +20,7 @@
       field-sizing: content;
     }
 
-    &:not(.o_field_selection, .o_field_filterable_selection) > *:first-child {
+    &:not(.o_field_selection, .o_field_day_selection, .o_field_filterable_selection) > *:first-child {
       max-width: 8ch;
     }
   }

--- a/addons/hr_holidays/static/src/components/day_selection/day_selection.js
+++ b/addons/hr_holidays/static/src/components/day_selection/day_selection.js
@@ -1,0 +1,44 @@
+import { selectionField, SelectionField } from "@web/views/fields/selection/selection_field";
+import { registry } from "@web/core/registry";
+
+export class DaySelectionField extends SelectionField {
+    static props = {
+        ...SelectionField.props,
+        month_field: {
+            type: String,
+            optional: true
+        },
+    }
+
+    get options() {
+        let month = parseInt(this.props.record.data[this.props.month_field]);
+        if (month) {
+            let days_number = new Date(2024, month, 0).getDate()
+            let new_options = []
+            for (let i = 0 ; i < days_number ; i++) new_options[i] = [i + 1, i + 1]
+            return new_options
+        }
+        else {
+            return super.options
+        }
+    }
+}
+
+export const daySelection = {
+    ...selectionField,
+    component: DaySelectionField,
+    extractProps({ options }) {
+        const props = selectionField.extractProps(...arguments);
+        props.month_field = options["month_field"];
+        return props;
+    },
+    fieldDependencies({ options }){
+        if (options["month_field"]) {
+            return [{
+                "name": options["month_field"]
+            }]
+        }
+    },
+};
+
+registry.category("fields").add("day_selection", daySelection);

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,17 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" widget="day_selection" options="{'month_field' : 'first_month'}" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field name="first_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" widget="day_selection" options="{'month_field' : 'second_month'}"  class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" widget="day_selection" options="{'month_field' : 'yearly_month'}" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_hr_narrow_field-5" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -204,7 +204,7 @@
                                                options="{'links': {'other': 'carryover_custom_date'}, 'observe': 'carryover'}"/>
                                         <span id="carryover_custom_date">
                                             : the
-                                            <field name="carryover_day" placeholder="select a day"
+                                            <field name="carryover_day" widget="day_selection" options="{'month_field': 'carryover_month'}" placeholder="select a day"
                                                    required="carryover_date == 'other'"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"


### PR DESCRIPTION
Problem:
Currently it's possible to select the "31st of February" in accrual plan and in its milestones, see: https://imgur.com/a/z3PqyE6

Solution:
Created a new day_selection field component, extending from the selection field component. This new component takes a month_field as an option. It retrieves the selected month and compute the allowed days list.

Task-6289950