### PR TITLE
[FIX] hr_payroll_account: restrict invalid days in accrual plans and milestones

### DIFF
--- a/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.scss
+++ b/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.scss
@@ -10,7 +10,7 @@
 }
 
 .o_accrual {
-  .o_field_accrual, .o_field_selection, .o_field_filterable_selection {
+  .o_field_accrual, .o_field_selection, .o_field_day_selection, .o_field_filterable_selection {
     width: fit-content !important;
 
     &:not(.o_readonly_modifier) > *:first-child {

--- a/addons/hr_holidays/static/src/components/day_selection/day_selection.js
+++ b/addons/hr_holidays/static/src/components/day_selection/day_selection.js
@@ -1,0 +1,34 @@
+import { registry } from "@web/core/registry";
+import { SelectionField, selectionField } from "@web/views/fields/selection/selection_field";
+
+export class DaySelection extends SelectionField {
+    static props = {
+        ...SelectionField.props,
+        month: { type: String, optional: true },
+    };
+
+    get options() {
+        const options = super.options;
+        const selectedMonth = this.props.record.data[this.props.month];
+        if (!selectedMonth) return options;
+
+        const maxDays = new Date(2024, parseInt(selectedMonth), 0).getDate();
+        return options.filter(option => parseInt(option[0]) <= maxDays);
+    }
+}
+
+export const daySelection = {
+    ...selectionField,
+    component: DaySelection,
+    extractProps({ attrs }) {
+        const props = selectionField.extractProps(...arguments);
+        props.month = attrs.month;
+        return props;
+    },
+    fieldDependencies: ({ attrs }) => [
+        { name: attrs.month, type: "selection" },
+    ],
+};
+
+
+registry.category("fields").add("day_selection", daySelection);

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,17 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" widget="day_selection" month="first_month" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field name="first_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" widget="day_selection" month="second_month" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" widget="day_selection" month="yearly_month" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_hr_narrow_field-5" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -204,8 +204,8 @@
                                                options="{'links': {'other': 'carryover_custom_date'}, 'observe': 'carryover'}"/>
                                         <span id="carryover_custom_date">
                                             : the
-                                            <field name="carryover_day" placeholder="select a day"
-                                                   required="carryover_date == 'other'"/>
+                                            <field name="carryover_day" placeholder="select a day" widget="day_selection" month="carryover_month"
+                                                   required="carryover_date == 'other'" class="w-100"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"
                                                    required="carryover_date == 'other'"/>


### PR DESCRIPTION
Currently, it's possible to select non-existent days like February 31st when configuring accrual plans and their milestones.

Restricts the day selection according to the month.

Task-6297384