### PR TITLE
[FIX] hr: make new contract button invisible

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -388,7 +388,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite" widget="date_dynamic_min" options="{'min_date_field': 'contract_date_start'}"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <field name="fixed_term" string="Fixed Term" invisible="1"/>
                                         <label for="wage"/>


### PR DESCRIPTION
PROBLEM
The New Contract button should not be visible when there is no contract start date.

SOLUTION
This makes the new contract button invisible when there is no contract start date.

Task: 6308004