### PR TITLE
[FIX] hr_holidays: error upon trying to select time type

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -279,7 +279,7 @@ class HrWorkEntryType(models.Model):
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented

--- a/addons/hr_holidays/tests/test_hr_work_entry_type.py
+++ b/addons/hr_holidays/tests/test_hr_work_entry_type.py
@@ -232,3 +232,31 @@ class TestHrWorkEntryType(TestHrHolidaysCommon):
 
         with self.assertRaises(ValidationError):
             work_entry_type.count_days_as = 'working'
+
+    def test_search_virtual_remaining_leaves(self):
+        """Test search method on virtual_remaining_leaves"""
+        employee = self.env['hr.employee'].create({'name': 'Test Employee'})
+
+        allocated_work_entry_type = self.env['hr.work.entry.type'].create({
+            'name': 'Test Time Off',
+            'code': 'Test Time Off 5',
+            'requires_allocation': True,
+            'request_unit': 'day',
+        })
+
+        self.env['hr.leave.allocation'].sudo().create({
+            'state': 'confirm',
+            'work_entry_type_id': allocated_work_entry_type.id,
+            'employee_id': employee.id,
+            'number_of_days': 10,
+        }).action_approve()
+
+        env_with_context = self.env['hr.work.entry.type'].with_context(employee_id=employee.id)
+
+        types_greater_than_5 = env_with_context.search([('virtual_remaining_leaves', '>', 5)])
+
+        self.assertIn(
+            allocated_work_entry_type,
+            types_greater_than_5,
+            "Search failed: Should have found the work entry type within search results"
+        )


### PR DESCRIPTION
PROBLEM
An error occurs when trying to select a time type when creating a new time off. 
The error also occurs on selecting Time Off Type field while creating a time off request via Management. 
The operator contained in op required 2 arguments but only one was passed.

SOLUTION
This fixes the mentionned error by passing two arguments to op.

Task: 6310735