### PR TITLE
[FIX] hr_holidays: search virtual remaining leaves

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -278,13 +278,15 @@ class HrWorkEntryType(models.Model):
         return [('id', 'in', valid_leaves)]
 
     def _search_virtual_remaining_leaves(self, operator, value):
-        def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented
         if operator != 'in':
             value = float(value)
+
+        def is_valid(work_entry_type):
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
+
         work_entry_types = self.env['hr.work.entry.type'].search([])
         return [('id', 'in', work_entry_types.filtered(is_valid).ids)]
 

--- a/addons/hr_holidays/tests/test_hr_work_entry_type.py
+++ b/addons/hr_holidays/tests/test_hr_work_entry_type.py
@@ -232,3 +232,8 @@ class TestHrWorkEntryType(TestHrHolidaysCommon):
 
         with self.assertRaises(ValidationError):
             work_entry_type.count_days_as = 'working'
+
+    def test_search_virtual_remaining_leaves(self):
+        """Using _search_virtual_remaining_leaves should not raise erros if using correct arguments"""
+        self.env['hr.work.entry.type'].create({"requires_allocation": True, "code": "something", "name": "something else"})
+        self.env['hr.work.entry.type'].search([('virtual_remaining_leaves', '<', 5)])


### PR DESCRIPTION
Steps to reproduce:
Time Off >> Configuration >> Time Off Types >> Open any type, navigate to the Smart button Time Off >> Click on New >> Time Off Type >> Error

The cause is in **addons/hr_holidays/models/hr_work_entry_type.py**
Specifically, the function **_search_virtual_remaining_leaves()**

The problem is that in this function an operator is being used, this operator expects two values to compare against each other and the current code is only passing one. The solution is to pass the value that is given as a function argument to the operator function.

Task: 6326629