### PR TITLE
[FIX] hr: hide new contract button without start date

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -388,7 +388,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite" widget="date_dynamic_min" options="{'min_date_field': 'contract_date_start'}"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <field name="fixed_term" string="Fixed Term" invisible="1"/>
                                         <label for="wage"/>


### PR DESCRIPTION
Steps to reproduce:

- Open an employee without a contract start date.
- Check the contract section.

Cause:
The "New Contract" button was displayed even when no contract start date was defined.

Solution:
Add an invisible condition on the button to hide it when contract_date_start is not set.

Task: 6326571