### PR TITLE
[FIX] hr_holidays: fix search on virtual remaining leaves

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -279,7 +279,7 @@ class HrWorkEntryType(models.Model):
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented

--- a/addons/hr_holidays/tests/test_hr_work_entry_type.py
+++ b/addons/hr_holidays/tests/test_hr_work_entry_type.py
@@ -232,3 +232,35 @@ class TestHrWorkEntryType(TestHrHolidaysCommon):
 
         with self.assertRaises(ValidationError):
             work_entry_type.count_days_as = 'working'
+
+    def test_search_virtual_remaining_leaves(self):
+        """Test search method on virtual_remaining_leaves."""
+        employee = self.env['hr.employee'].create({
+            'name': 'Test Employee',
+        })
+
+        work_entry_type = self.env['hr.work.entry.type'].create({
+            'name': 'Test Type',
+            'code': 'TEST_TYPE',
+            'requires_allocation': True,
+            'request_unit': 'day',
+        })
+
+        self.env['hr.leave.allocation'].sudo().create({
+            'state': 'confirm',
+            'employee_id': employee.id,
+            'work_entry_type_id': work_entry_type.id,
+            'number_of_days': 1,
+        }).action_approve()
+
+        work_entry_types = self.env['hr.work.entry.type'].with_context(
+            employee_id=employee.id,
+        ).search([
+            ('virtual_remaining_leaves', '>', 0),
+        ])
+
+        self.assertIn(
+            work_entry_type,
+            work_entry_types,
+            "Search on virtual_remaining_leaves should return the work entry type with available leaves."
+        )


### PR DESCRIPTION
Step to reproduce:
Search on the virtual_remaining_leaves field using a comparison operator such as '>'.

Cause:
The search method called the comparison operator with only the field value, while operators such as operator.gt expect both the field value and the domain value.

Solution:
Pass the domain value to the comparison operator and add a test covering a search on virtual_remaining_leaves with an allocated leave type.

Task: 6327165