### PR TITLE
[FIX] hr_holidays: don't allow user to select impossible day for month

### DIFF
--- a/addons/hr_holidays/static/src/components/accrual_day_selection/accrual_day_selection.js
+++ b/addons/hr_holidays/static/src/components/accrual_day_selection/accrual_day_selection.js
@@ -1,0 +1,49 @@
+import { registry } from "@web/core/registry";
+import { SelectionField, selectionField } from "@web/views/fields/selection/selection_field";
+
+export class AccrualDaySelection extends SelectionField {
+    get options() {
+        const options = super.options;
+        const monthFieldName = this.props.monthField; 
+
+        if (!monthFieldName) {
+            return options;
+        }
+
+        const month = this.props.record.data[monthFieldName];
+        if (!month) {
+            return options;
+        }
+
+        // Hardcode a known leap year (e.g., 2024) instead of using the current year.
+        // This guarantees February will always evaluate to 29 days.
+        const leapYear = 2024;
+        const daysInMonth = new Date(leapYear, parseInt(month), 0).getDate();
+
+        return options.filter((option) => {
+            const day = parseInt(option[0]);
+            return isNaN(day) || day <= daysInMonth;
+        });
+    }
+}
+
+export const accrualDaySelectionField = {
+    ...selectionField,
+    component: AccrualDaySelection,
+    
+    extractProps: ({ attrs, options }) => {
+        const props = selectionField.extractProps({ attrs, options });
+        props.monthField = options.month_field;
+        return props;
+    },
+    
+    fieldDependencies: ({ options }) => {
+        const deps = selectionField.fieldDependencies ? selectionField.fieldDependencies({ options }) : [];
+        if (options && options.month_field) {
+            deps.push({ name: options.month_field, type: "selection" });
+        }
+        return deps;
+    },
+};
+
+registry.category("fields").add("accrual_day_selection", accrualDaySelectionField);

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,41 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field
+                                        nolabel="1"
+                                        name="first_month_day"
+                                        class="o_hr_narrow_field-3"
+                                        placeholder="select a day"
+                                        required="frequency == 'biyearly'"
+                                        widget="accrual_day_selection"
+                                        options="{'month_field': 'first_month'}"
+                                    />
                                     of
                                     <field name="first_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field
+                                        nolabel="1"
+                                        name="second_month_day"
+                                        class="o_hr_narrow_field-3"
+                                        placeholder="select a day"
+                                        required="frequency == 'biyearly'"
+                                        widget="accrual_day_selection"
+                                        options="{'month_field': 'second_month'}"
+                                    />
                                     of
                                     <field nolabel="1" name="second_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field
+                                        nolabel="1" 
+                                        name="yearly_day"
+                                        class="o_hr_narrow_field-3"
+                                        required="frequency == 'yearly'"
+                                        placeholder="select a day"
+                                        widget="accrual_day_selection"
+                                        options="{'month_field': 'yearly_month'}"
+                                    />
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_hr_narrow_field-5" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -204,8 +228,14 @@
                                                options="{'links': {'other': 'carryover_custom_date'}, 'observe': 'carryover'}"/>
                                         <span id="carryover_custom_date">
                                             : the
-                                            <field name="carryover_day" placeholder="select a day"
-                                                   required="carryover_date == 'other'"/>
+                                            <field
+                                                name="carryover_day"
+                                                placeholder="select a day"
+                                                required="carryover_date == 'other'"
+                                                class="o_hr_narrow_field-3"
+                                                widget="accrual_day_selection"
+                                                options="{'month_field': 'carryover_month'}"
+                                            />
                                             of
                                             <field name="carryover_month" placeholder="select a month"
                                                    required="carryover_date == 'other'"/>


### PR DESCRIPTION
Steps to reproduce: Time Off >> Configuration >> Accrual plans >> New > Create milestone >> Set frequency

This code fixes the problem where a user could potentially (in the UX) choose an invalid day for the specified month, like 31 of February. Now this is not possible anymore.
The user is able to choose 29 of February which is not always valid but this will be handled by backend.

Task: 6333684