### PR TITLE
[IMP] hr_holidays: restrict day selection by month

### DIFF
--- a/addons/hr_holidays/static/src/components/day_selection_by_month/day_selection_by_month.js
+++ b/addons/hr_holidays/static/src/components/day_selection_by_month/day_selection_by_month.js
@@ -1,0 +1,36 @@
+import { registry } from "@web/core/registry";
+import { selectionField, SelectionField } from "@web/views/fields/selection/selection_field";
+
+const LEAP_YEAR = 2020;
+
+function getLastDayOfMonth(month) {
+    return month
+        ? new Date(LEAP_YEAR, Number(month), 0).getDate()
+        : 31;
+}
+
+export class DaySelectionByMonthField extends SelectionField {
+    static props = {
+        ...SelectionField.props,
+        selectedMonth: { type: String, optional: true },
+    };
+
+    get options() {
+        const selectedMonth = this.props.record.data[this.props.selectedMonth];
+        const lastDay = getLastDayOfMonth(selectedMonth);
+
+        return super.options.filter(([day]) => day <= lastDay);
+    }
+}
+
+export const daySelectionByMonthField = {
+    ...selectionField,
+    component: DaySelectionByMonthField,
+    extractProps: (fieldInfo, dynamicInfo) => {
+        const props = selectionField.extractProps(fieldInfo, dynamicInfo);
+        props.selectedMonth = fieldInfo.options.selected_month;
+        return props;
+    },
+};
+
+registry.category("fields").add("day_selection_by_month", daySelectionByMonthField);

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,17 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" widget="day_selection_by_month" options="{'selected_month': 'first_month'}" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field name="first_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" widget="day_selection_by_month" options="{'selected_month': 'second_month'}" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" widget="day_selection_by_month" options="{'selected_month': 'yearly_month'}" required="frequency == 'yearly'" placeholder="select a day"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_hr_narrow_field-5" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -205,6 +205,7 @@
                                         <span id="carryover_custom_date">
                                             : the
                                             <field name="carryover_day" placeholder="select a day"
+                                                   widget="day_selection_by_month" options="{'selected_month': 'carryover_month'}"
                                                    required="carryover_date == 'other'"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"


### PR DESCRIPTION
Before this commit, it was possible to select an invalid day for a given month in accrual plans (e.g. February 31st).

This commit introduces a dedicated field widget that dynamically restricts the available day values according to the selected month, preventing invalid selections while providing a better user experience.

Task: 6334330