### PR TITLE
[FIX] l10n_se: Add delivery date on invoice

### DIFF
--- a/addons/l10n_se/models/account_move.py
+++ b/addons/l10n_se/models/account_move.py
@@ -9,6 +9,24 @@ from stdnum import luhn
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.country_code == 'SE':
+                move.show_delivery_date = move.is_sale_document()
+
+    def _post(self, soft=True):
+        res = super()._post(soft)
+        for move in self:
+            if move.country_code == 'SE' and move.is_sale_document():
+                vals = {}
+                if not move.delivery_date:
+                    vals['delivery_date'] = move.invoice_date
+                move.write(vals)
+        return res
+
     def _get_invoice_reference_se_ocr2(self, reference):
         self.ensure_one()
         return reference + luhn.calc_check_digit(reference)
@@ -28,7 +46,6 @@ class AccountMove(models.Model):
 
         reference = reference.rjust(ocr_length - 1, '0')
         return reference + luhn.calc_check_digit(reference)
-
 
     def _get_invoice_reference_se_ocr2_invoice(self):
         self.ensure_one()


### PR DESCRIPTION
Follow the new legislation in Sweden: add delivery date on invoice: Delivery date in now by default next to due date.
If post without delivery date, take the invoice date

Task id: 6438985