### PR TITLE
[IMP] hr: hide 'New Contract' button in Employee > Payroll view when contract start and end dates are not set

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -383,7 +383,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite" widget="date_dynamic_min" options="{'min_date_field': 'contract_date_start'}"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <field name="fixed_term" string="Fixed Term" invisible="1"/>
                                         <label for="wage"/>


### PR DESCRIPTION
Hides the 'New Contract' button in the Payroll notebook in the employee view. This is because a new contract cannot be created if there is no existing one (no contract_date_start) and if no ending date is set to the last one (no contract_date_end).

Task: 6445358