### PR TITLE
[FIX] hr: hide 'New Contract' button when no contract start date

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -383,7 +383,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite" widget="date_dynamic_min" options="{'min_date_field': 'contract_date_start'}"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start"/>
-                                            <widget name="button_new_contract"/>
+                                            <widget name="button_new_contract" invisible="not contract_date_start"/>
                                         </div>
                                         <field name="fixed_term" string="Fixed Term" invisible="1"/>
                                         <label for="wage"/>


### PR DESCRIPTION
Steps to reproduce:
- Open an employee record with no contract start date set.
- Observe the Contract section in the form view.
- The "New Contract" button is visible when it should not be.

Cause:
The `button_new_contract` widget declaration in `hr_employee_views.xml` lacked an `invisible` attribute checking for `contract_date_start`.

Solution:
Add `invisible="not contract_date_start"` to the `button_new_contract` widget in `hr_employee_views.xml` so that the button is hidden when no contract start date is present.

Task: 6443374