### PR TITLE
[FIX] hr_holidays: fix bug where time-off type selection crashes

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -279,7 +279,7 @@ been taken for this time off type. Changing it now would affect existing employe
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented

--- a/addons/hr_holidays/tests/common.py
+++ b/addons/hr_holidays/tests/common.py
@@ -156,6 +156,16 @@ class TestHrHolidaysCommon(common.TransactionCase):
         })
         return leave
 
+    def _allocate_leave(self, employee, work_entry_type, num_days, valid_from, valid_to=False):
+        return self.env['hr.leave.allocation'].sudo().create({
+            'name': 'Alloc',
+            'employee_id': employee.id,
+            'work_entry_type_id': work_entry_type.id,
+            'number_of_days': num_days,
+            'date_from': valid_from,
+            'date_to': valid_to,
+        })
+
     def _create_form_test_accrual_allocation(self, work_entry_type, date_from, employee, accrual_plan, date_to=None, creator_user=None):
         allocation = self.env['hr.leave.allocation']
         if creator_user:

--- a/addons/hr_holidays/tests/test_hr_work_entry_type.py
+++ b/addons/hr_holidays/tests/test_hr_work_entry_type.py
@@ -232,3 +232,30 @@ class TestHrWorkEntryType(TestHrHolidaysCommon):
 
         with self.assertRaises(ValidationError):
             work_entry_type.count_days_as = 'working'
+
+    def _get_type(self, name, code):
+        return self.env['hr.work.entry.type'].sudo().create({
+            'name': name,
+            'code': code,
+            'requires_allocation': True,
+            'count_days_as': 'working',
+            'include_public_holidays_in_duration': False,
+        })
+
+    def test_search_virtual_remaining_leaves_works_with_gt(self):
+        self.env = self.env(user=self.employee_hruser.user_id)
+        emp = self.employee_hruser
+
+        type1 = self._get_type('Type 1', 'T1')
+        type2 = self._get_type('Type 2', 'T2')
+        type3 = self._get_type('Type 3', 'T3')
+
+        self._allocate_leave(emp, type1, 5, '2026-01-01').action_approve()
+        self._allocate_leave(emp, type2, 2, '2026-01-01').action_approve()
+        self._allocate_leave(emp, type3, 5, '2026-01-01').action_approve()
+
+        searchedLeaves = self.env["hr.work.entry.type"].search([("virtual_remaining_leaves", ">", 20)])
+
+        self.assertIn(type1, searchedLeaves)
+        self.assertNotIn(type2, searchedLeaves)
+        self.assertIn(type3, searchedLeaves)


### PR DESCRIPTION
Before this fix, going to a Create New Time Off form
and trying to select a time off type would result
in a server error.

This happens because when the select field is clicked,
in the background time off types with virtual_remaining_leaves
greater than 0 are searched, and in the search function,
a second parameter to the 'gt' function was forgotten.

I added the second parameter in the search function and
created a unit test to insure this function will hr_work_entry_type
properly in the future.

Task: 6446103