### PR TITLE
[FIX] hr_holidays: fix search on virtual_remaining_leaves

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -279,7 +279,7 @@ been taken for this time off type. Changing it now would affect existing employe
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented

--- a/addons/hr_holidays/tests/test_hr_work_entry_type.py
+++ b/addons/hr_holidays/tests/test_hr_work_entry_type.py
@@ -232,3 +232,25 @@ class TestHrWorkEntryType(TestHrHolidaysCommon):
 
         with self.assertRaises(ValidationError):
             work_entry_type.count_days_as = 'working'
+
+    def test_time_off_type_dropdown_search(self):
+        """ Test that loading the time off types (hr.work.entry.type) dropdown list
+            does not raise any traceback during search or selection.
+        """
+        self.env['hr.work.entry.type'].create({
+            'name': 'Test Paid Time Off',
+            'code': 'TPTO',
+            'requires_allocation': True,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+        })
+
+        domain = [('virtual_remaining_leaves', '>', 0)]
+
+        res = self.env['hr.work.entry.type'].with_user(self.user_employee_id).name_search(
+            name='',
+            domain=domain,
+            operator='ilike',
+            limit=8,
+        )
+        self.assertIsNotNone(res)


### PR DESCRIPTION
Steps to reproduce:
- Configure a time off type with "Requires Allocation" set to True and "Allows Negative" set to False.
- Create a valid allocation for an employee on this type.
- Create a new time off request for the employee and click on the "Time Off Type" dropdown field.
- A RPC_ERROR occurs (`TypeError: gt expected 2 arguments, got 1`).

Cause:
In `hr_work_entry_type.py`, the `_search_virtual_remaining_leaves` method's internal `is_valid` function evaluates `op(work_entry_type.virtual_remaining_leaves)` with only one argument instead of passing the comparison value as the second argument.

Solution:
Pass `value` as the second argument to `op()` in `_search_virtual_remaining_leaves` (i.e. `op(work_entry_type.virtual_remaining_leaves, value)`).

Task: 6446513