### PR TITLE
[FIX] l10m_se: Add delivery date on invoice

### DIFF
--- a/addons/l10n_se/models/account_move.py
+++ b/addons/l10n_se/models/account_move.py
@@ -9,6 +9,26 @@ from stdnum import luhn
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.country_code == 'SE':
+                move.show_delivery_date = move.is_sale_document()
+
+    def _post(self, soft=True):
+        # EXTENDS 'account'
+        res = super()._post(soft)
+        for move in self:
+            if move.country_code == 'SE' and move.is_sale_document():
+                if not move.delivery_date:
+                    if not move.invoice_date:
+                        move.delivery_date = fields.Date.today()
+                    else:
+                        move.delivery_date = move.invoice_date
+        return res
+
     def _get_invoice_reference_se_ocr2(self, reference):
         self.ensure_one()
         return reference + luhn.calc_check_digit(reference)


### PR DESCRIPTION
Follow the new legislation in Sweden: add delivery date on invoice: Delivery date in now by default next to due date.
If post without delivery date, take the invoice date

Task id: 6438985