### PR TITLE
[IMP] hr: make work permit fields versioned

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -222,13 +222,9 @@ class HrEmployee(models.Model):
     }
     """
 
-    permit_no = fields.Char('Work Permit No', groups="hr.group_hr_user", tracking=True)
     visa_no = fields.Char('Visa No', groups="hr.group_hr_user", tracking=True)
     visa_expire = fields.Date('Visa Expiration Date', groups="hr.group_hr_user", tracking=True)
-    work_permit_expiration_date = fields.Date('Work Permit Expiration Date', groups="hr.group_hr_user", tracking=True)
     has_work_permit = fields.Binary(string="Work Permit", groups="hr.group_hr_user")
-    work_permit_scheduled_activity = fields.Boolean(default=False, groups="hr.group_hr_user")
-    work_permit_name = fields.Char('work_permit_name', compute='_compute_work_permit_name', groups="hr.group_hr_user")
     certificate = fields.Selection(selection='_get_certificate_selection', string='Certificate Level', groups="hr.group_hr_user", tracking=True)
     study_field = fields.Char("Field of Study", groups="hr.group_hr_user", tracking=True)
     emergency_contact = fields.Char(groups="hr.group_hr_user", tracking=True)
@@ -1195,13 +1191,6 @@ class HrEmployee(models.Model):
                 employee.birthday_public_display_string = format_date(self.env, employee.birthday, date_format="MMMM dd")
             else:
                 employee.birthday_public_display_string = "hidden"
-
-    @api.depends('name', 'permit_no')
-    def _compute_work_permit_name(self):
-        for employee in self:
-            name = employee.name.replace(' ', '_') + '_' if employee.name else ''
-            permit_no = '_' + employee.permit_no if employee.permit_no else ''
-            employee.work_permit_name = "%swork_permit%s" % (name, permit_no)
 
     def _get_partner_count_depends(self):
         return ['user_id']

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -88,6 +88,11 @@ class HrVersion(models.Model):
         ('other', 'Other'),
     ], groups="hr.group_hr_user", tracking=1, help="This is the legal sex as recognized by the state, used for official and statutory purposes.")
 
+    permit_no = fields.Char('Work Permit No', groups="hr.group_hr_user")
+    work_permit_expiration_date = fields.Date('Work Permit Expiration Date', groups="hr.group_hr_user")
+    work_permit_scheduled_activity = fields.Boolean(default=False, groups="hr.group_hr_user")
+    work_permit_name = fields.Char('work_permit_name', compute='_compute_work_permit_name', groups="hr.group_hr_user")
+
     private_street = fields.Char(string="Private Street", groups="hr.group_hr_user", tracking=1)
     private_street2 = fields.Char(string="Private Street2", groups="hr.group_hr_user", tracking=1)
     private_city = fields.Char(string="Private City", groups="hr.group_hr_user", tracking=1)
@@ -242,6 +247,13 @@ class HrVersion(models.Model):
             states = self.env["res.country.state"].search([])
             for version in versions_without_countries:
                 version.allowed_country_state_ids = states
+
+    @api.depends('employee_id.name', 'permit_no')
+    def _compute_work_permit_name(self):
+        for version in self:
+            emp_name = version.employee_id.name.replace(' ', '_') + '_' if version.employee_id and version.employee_id.name else ''
+            permit_no = '_' + version.permit_no if version.permit_no else ''
+            version.work_permit_name = f"{emp_name}work_permit{permit_no}"
 
     @api.constrains('employee_id', 'contract_date_start', 'contract_date_end')
     def _check_dates(self):


### PR DESCRIPTION
Currently, the work permit information (such as `permit_no` and its associated fields) is stored directly on the `hr.employee` model.

This prevents keeping an accurate history of an employee's work permit details over time as their status evolves.

To address this, move `permit_no` and its related work permit fields (`work_permit_expiration_date`, `work_permit_name`, `work_permit_scheduled_activity`) from `hr.employee` to `hr.version`. The fields are now versioned on `hr.version` and accessed via delegation on `hr.employee`.

Task: 6448688