### PR TITLE
[IMP] hr: moved permit_no & expiration to parent class hr_version

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -222,13 +222,10 @@ class HrEmployee(models.Model):
     }
     """
 
-    permit_no = fields.Char('Work Permit No', groups="hr.group_hr_user", tracking=True)
     visa_no = fields.Char('Visa No', groups="hr.group_hr_user", tracking=True)
     visa_expire = fields.Date('Visa Expiration Date', groups="hr.group_hr_user", tracking=True)
-    work_permit_expiration_date = fields.Date('Work Permit Expiration Date', groups="hr.group_hr_user", tracking=True)
     has_work_permit = fields.Binary(string="Work Permit", groups="hr.group_hr_user")
     work_permit_scheduled_activity = fields.Boolean(default=False, groups="hr.group_hr_user")
-    work_permit_name = fields.Char('work_permit_name', compute='_compute_work_permit_name', groups="hr.group_hr_user")
     certificate = fields.Selection(selection='_get_certificate_selection', string='Certificate Level', groups="hr.group_hr_user", tracking=True)
     study_field = fields.Char("Field of Study", groups="hr.group_hr_user", tracking=True)
     emergency_contact = fields.Char(groups="hr.group_hr_user", tracking=True)
@@ -1195,13 +1192,6 @@ class HrEmployee(models.Model):
                 employee.birthday_public_display_string = format_date(self.env, employee.birthday, date_format="MMMM dd")
             else:
                 employee.birthday_public_display_string = "hidden"
-
-    @api.depends('name', 'permit_no')
-    def _compute_work_permit_name(self):
-        for employee in self:
-            name = employee.name.replace(' ', '_') + '_' if employee.name else ''
-            permit_no = '_' + employee.permit_no if employee.permit_no else ''
-            employee.work_permit_name = "%swork_permit%s" % (name, permit_no)
 
     def _get_partner_count_depends(self):
         return ['user_id']

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -100,6 +100,10 @@ class HrVersion(models.Model):
     private_country_id = fields.Many2one("res.country", string="Private Country", index='btree_not_null',
                                          groups="hr.group_hr_user", tracking=1, default=lambda self: self.env.company.country_id)
 
+    permit_no = fields.Char('Work Permit No', groups="hr.group_hr_user", tracking=True)
+    work_permit_expiration_date = fields.Date('Work Permit Expiration Date', groups="hr.group_hr_user", tracking=True)
+    work_permit_name = fields.Char('work_permit_name', compute='_compute_work_permit_name', groups="hr.group_hr_user")
+
     distance_home_work = fields.Integer(string="Home-Work Distance", groups="hr.group_hr_user", tracking=1)
     km_home_work = fields.Integer(string="Home-Work Distance in Km", groups="hr.group_hr_user",
                                   compute="_compute_km_home_work", inverse="_inverse_km_home_work", store=True, tracking=1)
@@ -242,6 +246,13 @@ class HrVersion(models.Model):
             states = self.env["res.country.state"].search([])
             for version in versions_without_countries:
                 version.allowed_country_state_ids = states
+
+    @api.depends('employee_id.name', 'permit_no')
+    def _compute_work_permit_name(self):
+        for version in self:
+            name = version.employee_id.name.replace(' ', '_') + '_' if version.employee_id.name else ''
+            permit_no = '_' + version.permit_no if version.permit_no else ''
+            version.work_permit_name = "%swork_permit%s" % (name, permit_no)
 
     @api.constrains('employee_id', 'contract_date_start', 'contract_date_end')
     def _check_dates(self):


### PR DESCRIPTION
The work permit number of an employee was not versioned, making it impossible to store 2 different values (in case of a renewal).

Solution: Move the permit_no field to parent class hr_version, along with linked field work_permit_expiration_date.

Task: 6446323