### PR TITLE
[FIX] hr_holidays: Fix error when creating a leave

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -279,7 +279,7 @@ been taken for this time off type. Changing it now would affect existing employe
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented

--- a/addons/hr_holidays/tests/test_hr_work_entry_type.py
+++ b/addons/hr_holidays/tests/test_hr_work_entry_type.py
@@ -232,3 +232,20 @@ class TestHrWorkEntryType(TestHrHolidaysCommon):
 
         with self.assertRaises(ValidationError):
             work_entry_type.count_days_as = 'working'
+
+    def test_search_virtual_remaining_leaves(self):
+        """
+        Test searching on the computed field 'virtual_remaining_leaves'
+        does not throw a TypeError missing the 'value' argument.
+        """
+        employee = self.env['hr.employee'].create({'name': 'Test Employee'})
+        result = self.env["hr.work.entry.type"].with_context(employee_id=employee.id).search(
+            [
+                ("virtual_remaining_leaves", ">", 0),
+            ],
+        )
+
+        self.assertTrue(
+            isinstance(result, type(self.env["hr.work.entry.type"])),
+            "The search should return a valid recordset without crashing.",
+        )


### PR DESCRIPTION
Fix a missing argument error when creating a leave and selecting work entry type.

Steps to reproduce:
1. Create a new leave type with:
    - `requires_allocation` checked.
    - `time_off_selectable` checked.
    - `allow_negative` unchecked.
2. Create a new allocation for this leave type with a positive number of days for an employee.
3. Create a new leave request with this leave type and the allocated employee.

Task: 6449776