### PR TITLE
[FIX] hr_holidays: Time Type domain search crash when opening dropdow…

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -279,7 +279,7 @@ been taken for this time off type. Changing it now would affect existing employe
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented

--- a/addons/hr_holidays/tests/test_hr_work_entry_type.py
+++ b/addons/hr_holidays/tests/test_hr_work_entry_type.py
@@ -232,3 +232,33 @@ class TestHrWorkEntryType(TestHrHolidaysCommon):
 
         with self.assertRaises(ValidationError):
             work_entry_type.count_days_as = 'working'
+
+    def test_search_virtual_remaining_leaves(self):
+        work_entry_type = self.env['hr.work.entry.type'].create({
+            'name': 'Test Time Off',
+            'code': 'Test Time Off 5',
+            'requires_allocation': True,
+            'allows_negative': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+        })
+
+        self.env['hr.leave.allocation'].create({
+            'name': 'Regular allocation',
+            'date_from': '2026-08-01',
+            'employee_id': self.employee_emp_id,
+            'work_entry_type_id': work_entry_type.id,
+            'number_of_days': 6,
+        }).action_approve()
+
+        domain = [
+            ('id', '=', work_entry_type.id),
+            ('virtual_remaining_leaves', '>', 0),
+        ]
+
+        # Test _search_virtual_remaining_leaves method
+        work_entry_type_ids = self.env['hr.work.entry.type'].with_context(
+            employee_id=self.employee_emp_id,
+        ).search(domain)
+
+        self.assertEqual(work_entry_type_ids.virtual_remaining_leaves, 6)


### PR DESCRIPTION
Steps to reproduce the error:

Prerequisite:
- Have a Time off type (test_timeoff) with
  - "Requires allocation" ticked (= True)
  - "Allow Negative" not ticked (= False)
- Create a regular allocation (Time Off > Management > Allocations > New)
to an employee (test_employee) with
  - Time Type = test_timeoff
  - Allocation > 0
- Validate the allocation

Bug error:
- Navigate to Time Off > Time Types > Select any time type > Select smart
button `Time off` > New
- Select Employee = test_employee
- Press Time Type -> ERROR

Reason: The search method for virtual_remaining_leaves has a bug.
The comparison function in _search_virtual_remaining_leaves accepts only one argument,
when two are required.

Solution:
- Add the missing argument.
- Add a unit test.

Task: 6449756