### PR TITLE
[ADD] hr_expense: add similar expense detection

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1278,6 +1278,12 @@ class HrExpense(models.Model):
             name=_("Expenses with a similar receipt to %(other_expense_name)s", other_expense_name=self.name),
         )
 
+    def action_show_duplicate_expense_ids(self):
+        self.ensure_one()
+        return self.duplicate_expense_ids._get_records_action(
+            name=self.env._("Duplicate Expenses to %(other_expense_name)s", other_expense_name=self.name),
+        )
+
     @api.model
     def get_expense_dashboard(self):
         expense_state = {

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -145,6 +145,9 @@
                 <div class="alert alert-warning oe_edit_only" role="alert" name="warning_duplicate_receipt_expense" invisible="not same_receipt_expense_ids">
                     An <a type="object" name="action_show_same_receipt_expense_ids">expense</a> with the same receipt already exists.
                 </div>
+                <div class="alert alert-warning oe_edit_only" role="alert" name="warning_duplicate_expense" invisible="not duplicate_expense_ids">
+                    A duplicate <a type="object" name="action_show_duplicate_expense_ids">expense</a> already exists.
+                </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button name="action_open_split_expense"


### PR DESCRIPTION
Add a new warning message in the expense form view to alert the user when a similar expense already exists. The similarity is determined by matching the product, date, total amount, and employee.

Task id: 6438999