### PR TITLE
[IMP] l10n_se: add delivery date to invoice

### DIFF
--- a/addons/l10n_se/models/account_move.py
+++ b/addons/l10n_se/models/account_move.py
@@ -75,3 +75,12 @@ class AccountMove(models.Model):
                     luhn.validate(invoice.payment_reference)
                 except Exception:
                     raise ValidationError(_("Vendor require OCR Number as payment reference. Payment reference isn't a valid OCR Number."))
+
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.country_code == 'SE':
+                move.show_delivery_date = move.is_sale_document()
+

--- a/addons/l10n_se/models/account_move.py
+++ b/addons/l10n_se/models/account_move.py
@@ -84,3 +84,9 @@ class AccountMove(models.Model):
             if move.country_code == 'SE':
                 move.show_delivery_date = move.is_sale_document()
 
+    
+    def _post(self, soft=True):
+        for move in self:
+            if move.country_code == 'SE' and move.is_sale_document() and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
+        return super()._post(soft)


### PR DESCRIPTION
Show delivery date on the invoice for the Swedish localisation.

If the invoice is pushed with no delivery date set, automatically set the delivery date to the invoice date instead.
If the invoice date is also not set, fall back to the current date.

task-6438916