### PR TITLE
[IMP] account: make 0 credit/debit muted

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1426,11 +1426,13 @@
                                                sum="Total Debit"
                                                invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"
+                                               decoration-muted="debit == 0"
                                         />
                                         <field name="credit"
                                                sum="Total Credit"
                                                invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('line_section', 'line_note', 'product')"
+                                               decoration-muted="credit == 0"
                                         />
                                         <field name="balance" column_invisible="True"/>
                                         <field name="discount_date"


### PR DESCRIPTION
If the value of the credit or debit field
is 0 on a journal item, make the text a
lighter shade of grey to improve readability.

example:
<img width="219" height="255" alt="image" src="https://github.com/user-attachments/assets/eabbed49-631a-4e4e-8d6c-5f837ff05e36" />


task-6438911