### PR TITLE
[IMP] hr_holidays: limit selection of month day based on selected month

### DIFF
--- a/addons/hr_holidays/static/src/components/month_selection/month_day_selection.js
+++ b/addons/hr_holidays/static/src/components/month_selection/month_day_selection.js
@@ -1,0 +1,49 @@
+import { t, useProps } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import {
+    SelectionField,
+    selectionField,
+    selectionFieldProps,
+} from "@web/views/fields/selection/selection_field";
+
+export class MonthDaySelectionField extends SelectionField {
+    props = useProps({
+        ...selectionFieldProps,
+        month_field: t.string().optional(),
+    });
+
+    get #top() {
+        const monthValue = this.props.record.data[this.props.month_field]
+        // 2024 is a leap year
+        return new Date(2024, parseInt(monthValue ?? 0), 0).getDate();
+    }
+
+    /**
+     * @override
+     */
+    get options() {
+        const options = super.options;
+        const top = this.#top;
+
+        return options.filter(option => Number(option[1]) <= top);
+    }
+}
+
+export const monthDaySelectionField = {
+    ...selectionField,
+    component: MonthDaySelectionField,
+    supportedOptions: [
+        {
+            label: "Month",
+            name: "month_field",
+            type: "string",
+        },
+    ],
+    extractProps({ options }) {
+        const props = selectionField.extractProps(...arguments);
+        props.month_field = options.month_field;
+        return props;
+    },
+};
+
+registry.category("fields").add("month_day_selection", monthDaySelectionField);

--- a/addons/hr_holidays/static/tests/tours/month_selection_for_february_tour.js
+++ b/addons/hr_holidays/static/tests/tours/month_selection_for_february_tour.js
@@ -1,0 +1,61 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_utils";
+
+registry.category("web_tour.tours").add("month_selection_for_february_tour", {
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Time Off App",
+            trigger: ".o_app[data-menu-xmlid='hr_holidays.menu_hr_holidays_root']",
+            run: "click",
+        },
+        {
+            content: "Open Configuration menu",
+            trigger: ".o-dropdown[data-menu-xmlid='hr_holidays.menu_hr_holidays_configuration']",
+            run: "click",
+        },
+        {
+            content: "Go to Accurals",
+            trigger: ".o-dropdown-item[data-menu-xmlid='hr_holidays.hr_holidays_accrual_menu_configuration']",
+            run: "click",
+        },
+        {
+            content: "Click 'New' Button",
+            trigger: ".o_list_button_add:contains('New')",
+            run: "click",
+        },
+        {
+            content: "Click select a carryover month",
+            trigger: ".o_input[id='carryover_month_0']",
+            run: "click",
+        },
+        {
+            content: "Click February",
+            trigger: ".o-dropdown-item[role='menuitem']:contains('February')",
+            run: "click",
+        },
+        {
+            content: "Click select a carryover day",
+            trigger: ".o_input[id='carryover_day_0']",
+            run: "click",
+        },
+        {
+            content: "Check if 29 is available",
+            trigger: ".o_select_menu_menu:has(.o_select_menu_item:contains(29))",
+        },
+        {
+            content: "Check if 30 is not available",
+            trigger: ".o_select_menu_menu:not(:has(.o_select_menu_item:contains(30)))",
+        },
+        {
+            content: "Select 29",
+            trigger: ".o_select_menu_menu:has(.o_select_menu_item:contains(29))",
+            run: "click",
+        },
+        {
+            content: "Discard the form",
+            trigger: ".o_form_button_cancel",
+            run: "click",
+        },
+    ]
+});

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -38,3 +38,4 @@ from . import test_work_entry_holidays
 from . import test_timeoff_overview_my_department_tour
 from . import test_hr_leave_report
 from . import test_member_of_department
+from . import test_month_selection_for_february_tour

--- a/addons/hr_holidays/tests/test_month_selection_for_february_tour.py
+++ b/addons/hr_holidays/tests/test_month_selection_for_february_tour.py
@@ -1,0 +1,8 @@
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestMonthSelectionForFebruaryTour(HttpCase):
+
+    def test_month_selection_for_february_tour(self):
+        self.start_tour("/odoo", "month_selection_for_february_tour", login="admin")

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,20 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'" 
+                                        widget="month_day_selection" options="{'month_field': 'first_month'}"/>
                                     of
                                     <field name="first_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"
+                                        widget="month_day_selection" options="{'month_field': 'second_month'}"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"
+                                        widget="month_day_selection" options="{'month_field': 'yearly_month'}"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_hr_narrow_field-5" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -205,7 +208,7 @@
                                         <span id="carryover_custom_date">
                                             : the
                                             <field name="carryover_day" placeholder="select a day"
-                                                   required="carryover_date == 'other'"/>
+                                                   required="carryover_date == 'other'" widget="month_day_selection" options="{'month_field': 'carryover_month'}"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"
                                                    required="carryover_date == 'other'"/>


### PR DESCRIPTION
In the accrual plan creation form, in the fields for selecting day of month
for a certain month, it was possible to select an invalid day, 31st of February
for example.

Additinally for month selection, a fields.Selection was used with options
(1, 1), ..., (31, 31) ; which is repetitve to do in every place where we needing
a month.

I created a seperate month selection component that goes with every field where a
month needs to be selected. This fixes the bug where 31st of February could be
selected and makes future month fields easier to implement.

Task: 6452125