### PR TITLE
[IMP] payment_paypal: add tokenization

### DIFF
--- a/addons/payment_paypal/const.py
+++ b/addons/payment_paypal/const.py
@@ -4,15 +4,12 @@ PAYMENT_COMPLETE_ORDER_ROUTE = "/payment/paypal/complete_order"
 PAYMENT_RETURN_ROUTE = "/payment/paypal/return"
 PAYMENT_CANCEL_ROUTE = "/payment/paypal/cancel"
 WEBHOOK_ROUTE = "/payment/paypal/webhook/"
-
-
 OAUTH_INIT_ROUTE = "/payment/paypal/oauth/init"
 OAUTH_FINALIZE_ROUTE = "/payment/paypal/oauth/finalize"
 
 # ISO 4217 codes of currencies supported by PayPal
 # See https://developer.paypal.com/docs/reports/reference/paypal-supported-currencies/.
 # Last seen on: 04 November 2025.
-
 # CNY removed as it requires in-country PayPal accounts but China mostly uses WeChat and Alipay.
 SUPPORTED_CURRENCIES = (
     "AUD",
@@ -68,10 +65,14 @@ CHECKOUT_WEBHOOK_EVENTS = [
     "CHECKOUT.PAYMENT-APPROVAL.REVERSED",
 ]
 CAPTURE_WEBHOOK_EVENTS = ["PAYMENT.CAPTURE.COMPLETED", "PAYMENT.CAPTURE.DENIED"]
+VAULT_WEBHOOK_EVENTS = ["VAULT.PAYMENT-TOKEN.CREATED"]
 MERCHANT_WEBHOOK_EVENTS = ["CUSTOMER.MERCHANT-INTEGRATION.SELLER-EMAIL-CONFIRMED"]
+
+# The merchant capability required to vault PayPal wallets
+VAULTING_CAPABILITY = "PAYPAL_WALLET_VAULTING_ADVANCED"
 
 # Odoo's public identifiers as a PayPal Partner for OAuth
 OAUTH_ODOO_PARTNER_ID = "QHZVTLZNWGSEW"
 OAUTH_ODOO_CLIENT_ID = (
-    "AUssUsouGEwQ-elJwte7-ullwiRUY3eQyYlWU-1T6iI7-zVw7bveLzjm8ue53fhVFBojRE6RNQZiecp"  # noqa: E501
+    "AUssUsouGEwQ-elJwte7-ullwiRUY3eQyYlWU-1T6iI7-zVw7bveLzjm8ue53fhVFBojRE6RNQZiecp"
 )

--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -5,12 +5,12 @@ import pprint
 from werkzeug.exceptions import Forbidden
 
 from odoo import http
-from odoo.exceptions import ValidationError
 from odoo.http import request
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_paypal import const
+from odoo.addons.payment_paypal import utils as paypal_utils
 
 _logger = get_payment_logger(__name__)
 
@@ -19,6 +19,8 @@ class PaypalController(http.Controller):
     @http.route(const.PAYMENT_COMPLETE_ORDER_ROUTE, type="jsonrpc", methods=["POST"], auth="public")
     def paypal_complete_order(self, reference):
         """Make a capture request and process the payment data.
+
+        This is used by the Card, Venmo, and PayPal Pay Later payment methods.
 
         :param str reference: The reference of the transaction whose order must be captured
         :return: None
@@ -30,12 +32,16 @@ class PaypalController(http.Controller):
             ._search_by_reference("paypal", {"reference_id": reference})
         )
         if tx_sudo:
-            self._paypal_capture_order(tx_sudo)
+            if tx_sudo.operation == "validation":
+                tx_sudo._record(self._paypal_exchange_setup_token(tx_sudo))
+            else:
+                self._paypal_capture_order(tx_sudo)
 
     @http.route(const.PAYMENT_RETURN_ROUTE, type="http", methods=["GET"], auth="public")
     def paypal_return_from_checkout(self, **data):
-        """Process the payment data sent by PayPal after redirection from an alternative payment
-        method checkout.
+        """Process the payment data sent by PayPal after redirection.
+
+        This is used by the PayPal payment method and alternative payment methods.
 
         :param dict data: The transaction reference embedded in the return URL, together with the
                           payment data appended by PayPal
@@ -47,7 +53,9 @@ class PaypalController(http.Controller):
     @http.route(const.PAYMENT_CANCEL_ROUTE, type="http", methods=["GET"], auth="public")
     def paypal_cancel_payment(self, **data):
         """Process the payment cancellation initiated by the customer sent by PayPal after
-        redirection from an alternative payment method checkout.
+        redirection.
+
+        This is used by the PayPal payment method and alternative payment methods.
 
         :param dict data: The transaction reference embedded in the return URL, together with the
                           payment data appended by PayPal
@@ -74,15 +82,49 @@ class PaypalController(http.Controller):
         if not tx_sudo:
             return
 
-        if tx_sudo.payment_method_code in {"paypal", "card"}:
+        if tx_sudo.operation == "validation":
+            if is_canceled:
+                normalized_data = {"id": tx_sudo.paypal_setup_token_ref}
+            else:
+                normalized_data = self._paypal_exchange_setup_token(tx_sudo)
+            tx_sudo._record(normalized_data)
+        elif tx_sudo.payment_method_code in {"paypal", "card"}:
             self._paypal_capture_order(tx_sudo)
         else:
             order_id = tx_sudo.provider_reference
             order_details = tx_sudo._send_api_request("GET", f"/v2/checkout/orders/{order_id}")
-            normalized_data = self._normalize_paypal_data(order_details)
+            normalized_data = paypal_utils.normalize_payment_data(order_details)
             if is_canceled:
                 normalized_data["status"] = "CANCELED"
             tx_sudo._record(normalized_data)
+
+    def _paypal_exchange_setup_token(self, tx_sudo):
+        """Exchange the approved setup token for a payment token .
+
+        See https://developer.paypal.com/api/payment-tokens/v3/#payment-tokens_create.
+
+        :return: The vault data
+        :rtype: dict
+        """
+        vault = tx_sudo._send_api_request(
+            "POST",
+            "/v3/vault/payment-tokens",
+            json={
+                "payment_source": {
+                    "token": {"id": tx_sudo.paypal_setup_token_ref, "type": "SETUP_TOKEN"}
+                }
+            },
+            idempotency_key=payment_utils.generate_idempotency_key(
+                tx_sudo, scope="exchange_setup_token_request"
+            ),
+        )
+        return {
+            "id": vault["id"],
+            "status": "COMPLETED",
+            "payment_source": paypal_utils.format_vault_payment_source(
+                vault, tx_sudo.payment_method_code
+            ),
+        }
 
     def _paypal_capture_order(self, tx_sudo):
         """Capture the order of the transaction and record the resulting payment data on it.
@@ -97,13 +139,14 @@ class PaypalController(http.Controller):
             card_info = order_details.get("payment_source", {}).get("card", {})
             auth_result = card_info.get("authentication_result", {})
             if auth_result and auth_result.get("liability_shift") != "POSSIBLE":
-                raise ValidationError(self.env._("3D Secure authentication failed."))
+                tx_sudo._set_error(self.env._("3D Secure authentication failed."))
+                return
 
         idempotency_key = payment_utils.generate_idempotency_key(tx_sudo, scope="capture_order")
         response = tx_sudo._send_api_request(
             "POST", f"/v2/checkout/orders/{order_id}/capture", idempotency_key=idempotency_key
         )
-        tx_sudo._record(self._normalize_paypal_data(response, is_capture_request=True))
+        tx_sudo._record(paypal_utils.normalize_payment_data(response, has_capture_data=True))
 
     @http.route(const.WEBHOOK_ROUTE, type="http", methods=["POST"], auth="public", csrf=False)
     def paypal_webhook(self):
@@ -121,6 +164,8 @@ class PaypalController(http.Controller):
             self._handle_checkout_notification(data)
         elif event_type in const.CAPTURE_WEBHOOK_EVENTS:
             self._handle_capture_notification(data)
+        elif event_type in const.VAULT_WEBHOOK_EVENTS:
+            self._handle_vault_notification(data)
         elif event_type in const.MERCHANT_WEBHOOK_EVENTS:
             self._handle_merchant_notification(data)
         return request.make_json_response("")
@@ -131,7 +176,7 @@ class PaypalController(http.Controller):
         :param dict data: The notification data sent by PayPal
         :return: None
         """
-        normalized_data = self._normalize_paypal_data(data.get("resource"))
+        normalized_data = paypal_utils.normalize_payment_data(data.get("resource"))
         tx_sudo = (
             self.env["payment.transaction"].sudo()._search_by_reference("paypal", normalized_data)
         )
@@ -139,19 +184,14 @@ class PaypalController(http.Controller):
             return
 
         # Check the origin and integrity of the notification
-        try:
-            self._verify_notification_origin(data, tx_sudo.provider_id)
-        except ValidationError:
-            tx_sudo.with_context(
-                # The verification request is idempotent; the handler is safe to replay
-                payment_safe_write=True
-            )._set_error(self.env._("Unable to verify the payment data"))
-        else:
-            if data.get("event_type") == "CHECKOUT.ORDER.DECLINED":
-                normalized_data["status"] = "DECLINED"
-                if errors := normalized_data.get("most_recent_errors"):
-                    normalized_data["state_message"] = errors[0].get("description")
-            tx_sudo._record(normalized_data)
+        self._verify_notification_origin(data, tx_sudo.provider_id)
+
+        # Normalize and process the notification data
+        if data.get("event_type") == "CHECKOUT.ORDER.DECLINED":
+            normalized_data["status"] = "DECLINED"
+            if errors := normalized_data.get("most_recent_errors"):
+                normalized_data["state_message"] = errors[0].get("description")
+        tx_sudo._record(normalized_data)
 
     def _handle_capture_notification(self, data):
         """Process a payment capture notification and record the payment on the transaction.
@@ -160,32 +200,35 @@ class PaypalController(http.Controller):
         :return: None
         """
         resource = data.get("resource", {})
-        tx_sudo = self.env["payment.transaction"].sudo()
         provider_reference = (
             resource.get("supplementary_data", {}).get("related_ids", {}).get("order_id")
         )
-        if provider_reference:
-            tx_sudo = tx_sudo.search(
+        if not provider_reference:
+            return
+
+        tx_sudo = (
+            self
+            .env["payment.transaction"]
+            .sudo()
+            .search(
                 [("provider_code", "=", "paypal"), ("provider_reference", "=", provider_reference)],
                 limit=1,
-            )  # Instead of searching with provider reference possible to get order from PayPal.
+            )
+        )
         if not tx_sudo:
             return
-        try:
-            self._verify_notification_origin(data, tx_sudo.provider_id)
-        except ValidationError:
-            tx_sudo.with_context(
-                # The verification request is idempotent; the handler is safe to replay.
-                payment_safe_write=True
-            )._set_error(self.env._("Unable to verify the payment data"))
-        else:
-            normalized_data = {
-                "reference_id": tx_sudo.reference,
-                "id": resource.get("id"),
-                "status": resource.get("status"),
-                "amount": resource.get("amount"),
-            }
-            tx_sudo._record(normalized_data)
+
+        # Check the origin and integrity of the notification
+        self._verify_notification_origin(data, tx_sudo.provider_id)
+
+        # Normalize and process the notification data
+        normalized_data = {
+            "reference_id": tx_sudo.reference,
+            "id": resource.get("id"),
+            "status": resource.get("status"),
+            "amount": resource.get("amount"),
+        }
+        tx_sudo._record(normalized_data)
 
     def _handle_merchant_notification(self, data):
         """Handle a merchant webhook onboarding notification and update the provider accordingly.
@@ -198,7 +241,7 @@ class PaypalController(http.Controller):
         if not merchant_id:
             return
         provider_sudo = (
-            request
+            self
             .env["payment.provider"]
             .sudo()
             .search([("code", "=", "paypal"), ("paypal_account_id", "=", merchant_id)], limit=1)
@@ -212,35 +255,41 @@ class PaypalController(http.Controller):
         # The only handled merchant event is the confirmation of the merchant's email address
         provider_sudo.paypal_email_confirmed = True
 
-    def _normalize_paypal_data(self, data, is_capture_request=False):
-        """Normalize the payment data received from PayPal.
+    def _handle_vault_notification(self, data):
+        """Create a token from a `VAULT.PAYMENT-TOKEN.CREATED` webhook notification.
 
-        The payment data received from PayPal has a different format depending on whether the data
-        come from the payment request response (order creation or capture), or from the webhook.
+        See https://developer.paypal.com/api/rest/webhooks/event-names/#vault.
 
-        :param dict data: The data to normalize
-        :param bool is_capture_request: Whether the data came from a capture API call
-        :return: The normalized data
-        :rtype: dict
+        :param dict data: The full notification payload
+        :rtype: None
         """
-        purchase_unit = data["purchase_units"][0]
-        result = {
-            "payment_source": data.get("payment_source"),
-            "reference_id": purchase_unit.get("reference_id"),
-            "purchase_units": data.get("purchase_units"),
-        }
-        if not is_capture_request:
-            result.update({
-                **purchase_unit,
-                "txn_type": data.get("intent"),
-                "id": data.get("id"),
-                "status": data.get("status"),
-            })
-        elif captured := purchase_unit.get("payments", {}).get("captures"):
-            result.update({**captured[0], "txn_type": "CAPTURE"})
-        else:
-            _logger.warning("Invalid response format; can't normalize.")
-        return result
+        resource = data.get("resource", {})
+        provider_reference = resource.get("metadata", {}).get("order_id")
+        if not provider_reference:
+            return
+
+        tx_sudo = (
+            self
+            .env["payment.transaction"]
+            .sudo()
+            .search(
+                [("provider_code", "=", "paypal"), ("provider_reference", "=", provider_reference)],
+                limit=1,
+            )
+        )
+        if not tx_sudo or tx_sudo.token_id:
+            return
+
+        # Check the origin and integrity of the notification
+        self._verify_notification_origin(data, tx_sudo.provider_id)
+
+        # Normalize and process the notification data
+        normalized_data = paypal_utils.normalize_payment_data(
+            resource,
+            event_type=data.get("event_type"),
+            payment_method_code=tx_sudo.payment_method_code,
+        )
+        tx_sudo._record(normalized_data)
 
     def _verify_notification_origin(self, payment_data, provider_sudo):
         """Check that the notification was sent by PayPal.

--- a/addons/payment_paypal/data/payment_method_data.xml
+++ b/addons/payment_paypal/data/payment_method_data.xml
@@ -9,6 +9,7 @@
         <field name="sequence">10</field>
         <field name="provider_id" ref="payment.payment_provider_paypal"/>
         <field name="image" type="bytes" file="payment/static/img/paypal.png"/>
+        <field name="support_tokenization">True</field>
     </record>
 
     <record id="payment_method_bancontact" model="payment.method">

--- a/addons/payment_paypal/data/payment_provider_data.xml
+++ b/addons/payment_paypal/data/payment_provider_data.xml
@@ -5,6 +5,7 @@
         <field name="code">paypal</field>
         <field name="inline_form_view_id" ref="inline_form"/>
         <field name="redirect_form_view_id" ref="payment.generic_redirect_form"/>
+        <field name="allow_tokenization">True</field>
     </record>
 
 </odoo>

--- a/addons/payment_paypal/models/__init__.py
+++ b/addons/payment_paypal/models/__init__.py
@@ -1,3 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import payment_provider, payment_transaction
+from . import payment_provider, payment_token, payment_transaction

--- a/addons/payment_paypal/models/payment_provider.py
+++ b/addons/payment_paypal/models/payment_provider.py
@@ -63,6 +63,11 @@ class PaymentProvider(models.Model):
             )
         return supported_currencies
 
+    def _compute_feature_support_fields(self):
+        """Override of `payment` to enable additional features."""
+        super()._compute_feature_support_fields()
+        self.filtered(lambda p: p.code == "paypal").update({"support_tokenization": True})
+
     # === CONSTRAINT METHODS === #
 
     @api.constrains("is_published")
@@ -164,6 +169,7 @@ class PaymentProvider(models.Model):
         webhook_events = (
             const.CHECKOUT_WEBHOOK_EVENTS
             + const.CAPTURE_WEBHOOK_EVENTS
+            + const.VAULT_WEBHOOK_EVENTS
             + const.MERCHANT_WEBHOOK_EVENTS
         )
         data = {
@@ -201,21 +207,30 @@ class PaymentProvider(models.Model):
             "paypal_email_account": response_content.get("primary_email"),
             "paypal_payments_receivable": response_content.get("payments_receivable"),
             "paypal_email_confirmed": response_content.get("primary_email_confirmed"),
+            "allow_tokenization": any(
+                capability.get("name") == const.VAULTING_CAPABILITY
+                and capability.get("status") == "ACTIVE"
+                for capability in response_content.get("capabilities", [])
+            ),
         })
 
         return response_content
 
-    def _paypal_get_inline_form_values(self, currency=None, partner_id=None):
+    def _paypal_get_inline_form_values(self, currency=None, partner_id=None, payment_method=None):
         """Return a serialized JSON of the required values to render the inline form.
 
         Note: `self.ensure_one()`
 
         :param res.currency currency: The transaction currency.
-        :param int partner_id: The partner of the transaction, as a `res.partner` id.
-        :return: The JSON serial of the required values to render the inline form.
+        :param int partner_id: The partner making the payment, as a `res.partner` id
+        :param payment.method payment_method: The payment method the form is rendered for
+        :return: The JSON serial of the required values to render the inline form
         :rtype: str
         """
         partner = self.env["res.partner"].browse(partner_id).exists()
+        currency = (
+            currency or self.with_context(validation_pm=payment_method)._get_validation_currency()
+        )  # The SDK requires a currency; find the default one if we're in a validation operation
         inline_form_values = {
             "provider_id": self.id,
             "client_id": self.paypal_client_id,

--- a/addons/payment_paypal/models/payment_token.py
+++ b/addons/payment_paypal/models/payment_token.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class PaymentToken(models.Model):
+    _inherit = "payment.token"
+
+    # === BUSINESS METHODS === #
+
+    def _build_display_name(self, *args, should_pad=True, **kwargs):
+        """Override of `payment` to only pad the display name of card tokens.
+
+        The payment details of PayPal wallet tokens are not card digits, so they must not be padded.
+        """
+        if self.provider_code != "paypal" or self.payment_method_code == "card":
+            return super()._build_display_name(*args, should_pad=should_pad, **kwargs)
+        return super()._build_display_name(*args, should_pad=False, **kwargs)

--- a/addons/payment_paypal/models/payment_transaction.py
+++ b/addons/payment_paypal/models/payment_transaction.py
@@ -17,12 +17,16 @@ _logger = get_payment_logger(__name__)
 class PaymentTransaction(models.Model):
     _inherit = "payment.transaction"
 
+    paypal_setup_token_ref = fields.Char(string="PayPal Setup Token ID")
+
     # See https://developer.paypal.com/docs/api-basics/notifications/ipn/IPNandPDTVariables/
     # this field has no use in Odoo except for debugging
     paypal_type = fields.Char(string="PayPal Transaction Type")
 
     def _get_specific_processing_values(self, processing_values):
         """Override of `payment` to return the Paypal-specific processing values.
+
+        This is used by the Card, Venmo, and PayPal Pay Later payment methods.
 
         Note: self.ensure_one() from `_get_processing_values`
 
@@ -31,10 +35,18 @@ class PaymentTransaction(models.Model):
         :return: The dict of provider-specific processing values
         :rtype: dict
         """
-        if self.provider_code != "paypal" or self.operation != "online_direct":
+        is_card_validation = self.operation == "validation" and self.payment_method_code == "card"
+        if self.provider_code != "paypal" or (
+            self.operation != "online_direct" and not is_card_validation
+        ):
             return super()._get_specific_processing_values(processing_values)
 
         try:
+            if is_card_validation:
+                setup_token_data = self._paypal_create_setup_token()
+                self.paypal_setup_token_ref = setup_token_data["id"]
+                return {"setup_token_id": self.paypal_setup_token_ref}
+
             order_data = self._paypal_create_order()
         except ValidationError as e:
             self._set_error(str(e))
@@ -46,6 +58,8 @@ class PaymentTransaction(models.Model):
     def _get_specific_rendering_values(self, processing_values):
         """Override of `payment` to return the PayPal-specific rendering values.
 
+        This is used by the PayPal payment method and alternative payment methods.
+
         Note: self.ensure_one() from `_get_processing_values`.
 
         :param dict processing_values: The generic and specific processing values of the
@@ -53,28 +67,93 @@ class PaymentTransaction(models.Model):
         :return: The dict of provider-specific rendering values
         :rtype: dict
         """
-        if self.provider_code != "paypal":
+        is_validation = self.operation == "validation"
+        if self.provider_code != "paypal" or (is_validation and self.payment_method_code == "card"):
             return super()._get_specific_rendering_values(processing_values)
 
-        if self.payment_method_code == "paypal":
-            payload = self._paypal_prepare_order_payload()
-        else:
-            payload = self._paypal_prepare_apm_order_payload()
         try:
-            order_data = self._paypal_create_order(payload=payload)
+            if is_validation:
+                setup_token_data = self._paypal_create_setup_token()
+                self.paypal_setup_token_ref = setup_token_data["id"]
+                candidate_api_url_data = setup_token_data["links"]
+            else:
+                if self.payment_method_code == "paypal":
+                    payload = self._paypal_prepare_order_payload()
+                else:
+                    payload = self._paypal_prepare_apm_order_payload()
+                order_data = self._paypal_create_order(payload=payload)
+                self.provider_reference = order_data["id"]
+                candidate_api_url_data = order_data["links"]
         except ValidationError as e:
             self._set_error(str(e))
             return {}
 
-        self.provider_reference = order_data["id"]
+        action_rel = "approve" if is_validation else "payer-action"
         payer_action_url = next(
-            link["href"] for link in order_data["links"] if link["rel"] == "payer-action"
+            link["href"] for link in candidate_api_url_data if link["rel"] == action_rel
         )
         return {
             "api_url": payer_action_url,
             "http_method": "get",
             "url_params": payment_utils.extract_url_params(payer_action_url),
         }
+
+    def _paypal_create_setup_token(self):
+        """Create a PayPal setup token to save a payment method without a payment.
+
+        The setup token is temporary; it must be approved by the customer, then exchanged for a
+        payment token in`_paypal_exchange_setup_token`.
+
+        See https://developer.paypal.com/api/payment-tokens/v3/#setup-tokens_create.
+
+        :return: The API response of the setup token creation
+        :rtype: dict
+        """
+        return_url, cancel_url = self._paypal_build_return_urls(self.reference)
+        experience_context = {
+            "brand_name": self.provider_id.company_id.name,
+            "return_url": return_url,
+            "cancel_url": cancel_url,
+        }
+        if self.payment_method_code == "card":
+            payload = {
+                "payment_source": {
+                    "card": {
+                        "verification_method": "SCA_WHEN_REQUIRED",
+                        "experience_context": experience_context,
+                    }
+                }
+            }
+        else:
+            payload = {
+                "payment_source": {
+                    "paypal": {
+                        "usage_type": "MERCHANT",
+                        "customer_type": "CONSUMER",
+                        "experience_context": {
+                            **experience_context,
+                            "payment_method_preference": "IMMEDIATE_PAYMENT_REQUIRED",
+                            "shipping_preference": "NO_SHIPPING",
+                        },
+                    }
+                }
+            }
+        return self._send_api_request(
+            "POST",
+            "/v3/vault/setup-tokens",
+            json=payload,
+            idempotency_key=payment_utils.generate_idempotency_key(
+                self, scope="setup_token_request"
+            ),
+        )
+
+    def _send_payment_request(self):
+        """Override of `payment` to charge a saved PayPal wallet or card by token."""
+        if self.provider_code != "paypal":
+            return super()._send_payment_request()
+
+        response_content = self._paypal_create_order()
+        self._record(paypal_utils.normalize_payment_data(response_content, has_capture_data=True))
 
     def _paypal_create_order(self, payload=None):
         """Create a PayPal order for the transaction and return the API response.
@@ -151,15 +230,13 @@ class PaymentTransaction(models.Model):
         return_url, cancel_url = self._paypal_build_return_urls(self.reference)
         if self.payment_method_code == "card":
             return {
-                "card": {
-                    "name": self.partner_name,
-                    "billing_address": invoice_address_vals.get("address", {}),
-                    "attributes": {"verification": {"method": "SCA_WHEN_REQUIRED"}},
-                    "experience_context": {"return_url": return_url, "cancel_url": cancel_url},
-                }
+                "card": self._paypal_prepare_card_payment_source_payload(
+                    return_url, cancel_url, invoice_address_vals
+                )
             }
         partner_first_name, partner_last_name = payment_utils.split_partner_name(self.partner_name)
-        return {
+
+        payment_source = {
             "paypal": {
                 "experience_context": {
                     "payment_method_preference": "IMMEDIATE_PAYMENT_REQUIRED",
@@ -175,6 +252,66 @@ class PaymentTransaction(models.Model):
                 **invoice_address_vals,
             }
         }
+        if self.token_id:
+            payment_source["paypal"]["vault_id"] = self.token_id.provider_ref
+            if self.operation == "offline":
+                payment_source["paypal"]["stored_credential"] = {
+                    "payment_initiator": "MERCHANT",
+                    "usage": "SUBSEQUENT",
+                }
+        elif self.tokenize:
+            payment_source["paypal"]["attributes"] = {
+                "vault": {
+                    "store_in_vault": "ON_SUCCESS",
+                    "usage_type": "MERCHANT",
+                    "customer_type": "CONSUMER",
+                }
+            }
+
+        return payment_source
+
+    def _paypal_prepare_card_payment_source_payload(
+        self, return_url, cancel_url, invoice_address_vals
+    ):
+        """Prepare the card payment source of the create order request payload.
+
+        :param str return_url: The URL to redirect the customer to after the payment
+        :param str cancel_url: The URL to redirect the customer to after canceling the payment
+        :param dict invoice_address_vals: The formatted invoice address
+        :return: The card payment source payload
+        :rtype: dict
+        """
+        card_data = {"experience_context": {"return_url": return_url, "cancel_url": cancel_url}}
+
+        if self.token_id:
+            card_data["vault_id"] = self.token_id.provider_ref
+            card_data["stored_credential"] = {"usage": "SUBSEQUENT"}
+            if self.operation == "offline":
+                card_data["stored_credential"].update({
+                    "payment_initiator": "MERCHANT",
+                    "payment_type": "UNSCHEDULED",
+                })
+            else:
+                card_data["attributes"] = {"verification": {"method": "SCA_WHEN_REQUIRED"}}
+                card_data["stored_credential"].update({
+                    "payment_initiator": "CUSTOMER",
+                    "payment_type": "ONE_TIME",
+                })
+            return card_data
+
+        card_data["name"] = self.partner_name
+        card_data["billing_address"] = invoice_address_vals.get("address", {})
+        card_data["attributes"] = {"verification": {"method": "SCA_WHEN_REQUIRED"}}
+
+        if self.tokenize:
+            card_data["stored_credential"] = {
+                "payment_initiator": "CUSTOMER",
+                "payment_type": "ONE_TIME",
+                "usage": "FIRST",
+            }
+            card_data["attributes"]["vault"] = {"store_in_vault": "ON_SUCCESS"}
+
+        return card_data
 
     def _paypal_prepare_apm_order_payload(self):
         """Prepare the payload of the create order request for an alternative payment method.
@@ -233,18 +370,12 @@ class PaymentTransaction(models.Model):
             self._set_canceled(state_message=self.env._("The customer left the payment page."))
             return
 
+        if payment_data.get("event_type") in const.VAULT_WEBHOOK_EVENTS:
+            return  # Vault notifications carry no payment state; only the token is created
+
         # Update the provider reference.
         txn_id = payment_data.get("id")
         txn_type = payment_data.get("txn_type")
-        if not all((txn_id, txn_type)):
-            self._set_error(
-                self.env._(
-                    "Missing value for txn_id (%(txn_id)s) or txn_type (%(txn_type)s).",
-                    txn_id=txn_id,
-                    txn_type=txn_type,
-                )
-            )
-            return
 
         self.provider_reference = txn_id
         self.paypal_type = txn_type
@@ -281,7 +412,43 @@ class PaymentTransaction(models.Model):
         if self.provider_code != "paypal":
             return super()._extract_amount_data(payment_data)
 
+        if payment_data.get("event_type") in const.VAULT_WEBHOOK_EVENTS:
+            return None  # Vault notifications carry no payment state; only the token is created
+
         amount_data = payment_data.get("amount", {})
         amount = amount_data.get("value")
         currency_code = amount_data.get("currency_code")
         return {"amount": float(amount), "currency_code": currency_code}
+
+    def _extract_token_values(self, payment_data):
+        """Override of `payment` to extract the token values from the payment data."""
+        if self.provider_code != "paypal":
+            return super()._extract_token_values(payment_data)
+
+        vault_data = (
+            payment_data
+            .get("payment_source", {})
+            .get(self.payment_method_code, {})
+            .get("attributes", {})
+            .get("vault", {})
+        )
+        if vault_data.get("status") == "APPROVED":
+            _logger.info(
+                "Deferred vaulting of the payment source for transaction %s.", self.reference
+            )
+            return {}
+
+        vault_id = vault_data.get("id")
+        if not vault_id:
+            _logger.warning("Tried to tokenize with missing vault_id: %s", vault_id)
+            return {}
+
+        payment_source = payment_data.get("payment_source", {}).get(self.payment_method_code, {})
+        return {
+            "provider_ref": vault_id,
+            "payment_details": (
+                payment_source.get("last_digits")
+                or payment_source.get("name", {}).get("given_name")
+                or payment_source.get("email_address")
+            ),
+        }

--- a/addons/payment_paypal/static/src/interactions/payment_form.js
+++ b/addons/payment_paypal/static/src/interactions/payment_form.js
@@ -173,13 +173,17 @@ patch(PaymentForm.prototype, {
 
             if (isCard && paypal.CardFields !== undefined) {
                 // Render the card inputs
-                const cardFields = paypal.CardFields({
+                const paypalData = this.paypalData[paymentOptionId];
+                const cardFieldsOptions = {
                     style: CARD_INPUT_STYLE,
-                    createOrder: () => {
-                        return this.paypalData[paymentOptionId].paypalOrderId;
-                    },
                     onApprove: this._paypalOnApprove.bind(this),
-                });
+                };
+                if (this.paymentContext['mode'] === 'validation') {
+                    cardFieldsOptions.createVaultSetupToken = () => paypalData.paypalSetupTokenId;
+                } else {
+                    cardFieldsOptions.createOrder = () => paypalData.paypalOrderId;
+                }
+                const cardFields = paypal.CardFields(cardFieldsOptions);
                 this.paypalData[paymentOptionId].cardFields = cardFields;
                 cardFields
                   .NameField({ placeholder: "" })
@@ -222,6 +226,7 @@ patch(PaymentForm.prototype, {
                         .forEach(domButton => {
                             const enabledButton = paypal.Buttons({
                                 fundingSource: activeConfig.fundingSource,
+                                enableVenmoSandbox: !this._getProviderIsLive(radio),
                                 // https://developer.paypal.com/sdk/js/reference/#link-style
                                 style: {
                                     layout: 'vertical',
@@ -307,6 +312,7 @@ patch(PaymentForm.prototype, {
             return;
         }
         this.paypalData[paymentOptionId].paypalOrderId = processingValues['order_id'];
+        this.paypalData[paymentOptionId].paypalSetupTokenId = processingValues['setup_token_id'];
         this.paypalData[paymentOptionId].paypalTxRef = processingValues['reference'];
 
         // Submit the card fields to report invalid inputs

--- a/addons/payment_paypal/tests/test_paypal.py
+++ b/addons/payment_paypal/tests/test_paypal.py
@@ -9,6 +9,7 @@ from odoo.tools import mute_logger
 
 from odoo.addons.payment.tests.http_common import PaymentHttpCommon
 from odoo.addons.payment_paypal import const
+from odoo.addons.payment_paypal import utils as paypal_utils
 from odoo.addons.payment_paypal.controllers.main import PaypalController
 from odoo.addons.payment_paypal.tests.common import PaypalCommon
 
@@ -54,17 +55,15 @@ class PaypalTest(PaypalCommon, PaymentHttpCommon):
     def test_complete_order_confirms_transaction(self):
         """Test the processing of a webhook notification."""
         tx = self._create_transaction("direct")
-        normalized_data = PaypalController._normalize_paypal_data(
-            self, self.completed_order, is_capture_request=True
+        normalized_data = paypal_utils.normalize_payment_data(
+            self.completed_order, has_capture_data=True
         )
         tx.with_context(payment_safe_write=True)._process(normalized_data)
         self.assertEqual(tx.state, "done")
         self.assertEqual(tx.provider_reference, normalized_data["id"])
 
     def test_feedback_processing(self):
-        normalized_data = PaypalController._normalize_paypal_data(
-            self, self.payment_data.get("resource")
-        )
+        normalized_data = paypal_utils.normalize_payment_data(self.payment_data.get("resource"))
 
         # Confirmed transaction
         tx = self._create_transaction("direct")
@@ -164,6 +163,105 @@ class PaypalTest(PaypalCommon, PaymentHttpCommon):
         ):
             self._make_json_request(url, data=self.payment_data)
             self.assertEqual(record_mock.call_count, 0)
+
+    @mute_logger("odoo.addons.payment_paypal.controllers.main")
+    def test_deferred_vaulting_creates_token_from_webhook(self):
+        """A wallet vaulted asynchronously (vault.status APPROVED, no vault id) is tokenized from
+        the VAULT.PAYMENT-TOKEN.CREATED webhook, correlated through the order id."""
+        paypal_pm = self.env.ref("payment_paypal.payment_method_paypal").id
+        tx = self._create_transaction("direct", payment_method_id=paypal_pm, tokenize=True)
+        customer_id = "CUSTOMER123"
+        vault_id = "VAULT456"
+        approved_capture = {
+            "status": "COMPLETED",
+            "id": self.order_id,
+            "txn_type": "CAPTURE",
+            "reference_id": self.reference,
+            "amount": {"currency_code": self.currency.name, "value": str(self.amount)},
+            "payment_source": {
+                "paypal": {
+                    "attributes": {"vault": {"status": "APPROVED", "customer": {"id": customer_id}}}
+                }
+            },
+        }
+        tx.with_context(payment_safe_write=True)._process(approved_capture)
+        self.assertEqual(tx.state, "done")
+        self.assertEqual(tx.paypal_customer_id, customer_id)
+        self.assertFalse(tx.token_id, "No token should be created before the vault webhook.")
+
+        notification = {
+            "event_type": "VAULT.PAYMENT-TOKEN.CREATED",
+            "resource": {
+                "id": vault_id,
+                "customer": {"id": customer_id},
+                "metadata": {"order_id": self.order_id},
+                "payment_source": {"paypal": {"email_address": "buyer@example.com"}},
+            },
+        }
+        url = self._build_url(PaypalController._webhook_url)
+        with patch(
+            "odoo.addons.payment_paypal.controllers.main.PaypalController"
+            "._verify_notification_origin"
+        ):
+            self._make_json_request(url, data=notification)
+        self._run_processing()
+        tx.invalidate_recordset()
+        self.assertTrue(tx.token_id, "The vault webhook should create the token.")
+        self.assertEqual(tx.token_id.provider_ref, vault_id)
+        self.assertEqual(tx.token_id.paypal_customer_id, customer_id)
+        self.assertEqual(tx.token_id.payment_details, "buyer@example.com")
+        self.assertFalse(tx.tokenize)
+
+    @mute_logger("odoo.addons.payment_paypal.controllers.main")
+    def test_paypal_token_payment(self):
+        """A customer-present token payment is charged through `_send_payment_request` and recorded
+        without any payer action."""
+        paypal_pm = self.env.ref("payment_paypal.payment_method_paypal").id
+        token = self._create_token(payment_method_id=paypal_pm, provider_ref="VAULT-TOKEN-1")
+        tx = self._create_transaction("token", payment_method_id=paypal_pm, token_id=token.id)
+        # PayPal returns a minimal representation of the completed order: the amount and the final
+        # status live on the capture, not on the purchase unit.
+        capture_id = "CAPTURE-1"
+        completed_order = {
+            "id": self.order_id,
+            "status": "COMPLETED",
+            "payment_source": {"paypal": {"account_id": "59XDVNACRAZZJ"}},
+            "purchase_units": [
+                {
+                    "reference_id": self.reference,
+                    "payments": {
+                        "captures": [
+                            {
+                                "id": capture_id,
+                                "status": "COMPLETED",
+                                "amount": {
+                                    "currency_code": self.currency.name,
+                                    "value": str(self.amount),
+                                },
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+        with patch(
+            "odoo.addons.payment.models.payment_provider.PaymentProvider._send_api_request",
+            return_value=completed_order,
+        ):
+            tx._charge_with_token()
+        payment_data = self.env["payment.data"].search([("transaction_id", "=", tx.id)])
+        self.assertTrue(payment_data)
+        self.assertEqual(
+            payment_data.payload["amount"],
+            {"currency_code": self.currency.name, "value": str(self.amount)},
+            "The amount should be normalized from the capture embedded in the order.",
+        )
+
+        tx.with_context(payment_safe_write=True)._process(payment_data.payload)
+        self.assertEqual(tx.state, "done")
+        self.assertEqual(tx.provider_reference, capture_id)
+        payment_source = tx._paypal_prepare_order_payload()["payment_source"]["paypal"]
+        self.assertNotIn("stored_credential", payment_source)
 
     def test_provide_shipping_address(self):
         if "sale.order" not in self.env:

--- a/addons/payment_paypal/utils.py
+++ b/addons/payment_paypal/utils.py
@@ -1,5 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.addons.payment.logging import get_payment_logger
+from odoo.addons.payment_paypal import const
+
+_logger = get_payment_logger(__name__)
+
 
 def format_partner_address(partner):
     """Format the partner address values to PayPal address values. When provided, PayPal requires
@@ -55,3 +60,60 @@ def format_shipping_address(tx_sudo):
     ):
         address_vals["shipping"] = format_partner_address(partner_shipping)
     return address_vals
+
+
+def format_vault_payment_source(vault_data, payment_method_code):
+    """Format the vault data to the payment source of the normalized payment data.
+
+    :param dict vault_data: The resource of the vault webhook notification
+    :param str payment_method_code: The code of the payment method of the transaction
+    :return: The payment source of the normalized payment data
+    :rtype: dict
+    """
+    return {
+        payment_method_code: {
+            **vault_data.get("payment_source", {}).get(payment_method_code, {}),
+            "attributes": {
+                "vault": {"id": vault_data.get("id"), "customer": vault_data.get("customer", {})}
+            },
+        }
+    }
+
+
+def normalize_payment_data(data, has_capture_data=False, event_type=None, payment_method_code=None):
+    """Normalize the payment data received from PayPal.
+
+    The payment data received from PayPal has a different format depending on whether the data
+    come from the payment request response (order creation or capture), or from the webhook.
+
+    :param dict data: The data to normalize
+    :param bool has_capture_data: Whether the data has the `captures` dict
+    :param str event_type: The event type of the webhook notification the data came from
+    :param str payment_method_code: The code of the payment method of the transaction
+    :return: The normalized data
+    :rtype: dict
+    """
+    if event_type in const.VAULT_WEBHOOK_EVENTS:
+        return {
+            "event_type": event_type,
+            "payment_source": format_vault_payment_source(data, payment_method_code),
+        }
+
+    purchase_unit = data["purchase_units"][0]
+    result = {
+        "payment_source": data["payment_source"],
+        "reference_id": purchase_unit.get("reference_id"),
+        "purchase_units": data["purchase_units"],
+    }
+    if not has_capture_data:
+        result.update({
+            **purchase_unit,
+            "txn_type": data.get("intent"),
+            "id": data.get("id"),
+            "status": data.get("status"),
+        })
+    elif captured := purchase_unit.get("payments", {}).get("captures"):
+        result.update({**captured[0], "txn_type": "CAPTURE"})
+    else:
+        _logger.warning("Invalid response format; can't normalize.")
+    return result

--- a/addons/payment_paypal/views/payment_form_templates.xml
+++ b/addons/payment_paypal/views/payment_form_templates.xml
@@ -4,7 +4,7 @@
     <template id="payment_paypal.method_form" inherit_id="payment.method_form">
         <input name="o_payment_radio" position="attributes">
             <attribute name="t-att-data-paypal-inline-form-values">
-                provider_sudo._paypal_get_inline_form_values(currency, partner_id)
+                provider_sudo._paypal_get_inline_form_values(currency, partner_id, pm_sudo)
             </attribute>
             <attribute name="t-att-data-paypal-color">
                 "blue"


### PR DESCRIPTION
In recent commits, we integrated various payment methods provided by PayPal, including Advanced Credit and Debit Cards. We also migrated the PayPal Wallet integration from the JS SDK to the Orders API to standardize the appearance of payment methods across different providers.

Before this commit, customers had to re-enter their payment details for every PayPal transaction, and merchants could not charge them offline (e.g., for subscriptions or invoice follow-ups).

This commit introduces the ability to tokenize PayPal Wallet and PayPal-provided cards. Tokenization is available if the merchant's account has the advanced vaulting capability enabled. We also handle the case where PayPal creates the vault asynchronously, generating the token via a webhook rather than the immediate checkout response.

task-6095033