### PR TITLE
[IMP] hr_holidays: Accrual UX - Day in month range

### DIFF
--- a/addons/hr_holidays/static/src/components/dynamic_selection_day_with_month_filter/dynamic_selection_day_with_month_filter.js
+++ b/addons/hr_holidays/static/src/components/dynamic_selection_day_with_month_filter/dynamic_selection_day_with_month_filter.js
@@ -1,0 +1,52 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { SelectionField, selectionField } from "@web/views/fields/selection/selection_field";
+
+
+// Automatic fallback mapping if XML options are omitted
+const DEFAULT_MONTH_MAPPING = {
+    first_day: "first_month",
+    first_month_day: "first_month",
+    second_month_day: "second_month",
+    yearly_day: "yearly_month",
+    carryover_day: "carryover_month",
+};
+
+export class HrHolidaysDaySelectionWithMonthFilter extends SelectionField {
+    static props = {
+        ...SelectionField.props,
+        monthField: { type: String, optional: true},
+    };
+
+    get options() {
+        const { record, name } = this.props;
+        const allOptions = super.options;
+
+        const monthFieldName = this.props.monthField || DEFAULT_MONTH_MAPPING[name];
+        const monthValue = monthFieldName ? record.data[monthFieldName]: null;
+
+        if (!monthValue) {
+            return allOptions;
+        }
+        const month = parseInt(monthValue, 10);
+
+        // 2020 is a leap year, so luxon.DateTime.local(2020, 2) will return 29
+        const maxDays = luxon.DateTime.local(2020, month).daysInMonth;
+        return allOptions.filter(([value]) => parseInt(value, 10) <= maxDays);
+    }
+}
+
+export const hrHolidaysDaySelectionWithMonthFilter = {
+    ...selectionField,
+    component: HrHolidaysDaySelectionWithMonthFilter,
+    displayName: _t("Selection With Month Filter"),
+    extractProps: (fieldInfo, dynamicInfo) => {
+        const props = selectionField.extractProps(fieldInfo, dynamicInfo);
+        props.monthField = fieldInfo.options.month_field;
+        return props;
+    }, 
+};
+
+registry
+    .category("fields")
+    .add("dynamic_selection_day_with_month_filter", hrHolidaysDaySelectionWithMonthFilter);

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,20 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"
+                                        widget="dynamic_selection_day_with_month_filter" options="{'month_field': 'first_month'}"/>
                                     of
                                     <field name="first_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"
+                                        widget="dynamic_selection_day_with_month_filter" options="{'month_field': 'second_month'}"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"
+                                        widget="dynamic_selection_day_with_month_filter" options="{'month_field': 'yearly_month'}"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_hr_narrow_field-5" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -205,7 +208,9 @@
                                         <span id="carryover_custom_date">
                                             : the
                                             <field name="carryover_day" placeholder="select a day"
-                                                   required="carryover_date == 'other'"/>
+                                                    class="o_hr_narrow_field-3 d-inline-block" 
+                                                    required="carryover_date == 'other'" 
+                                                    widget="dynamic_selection_day_with_month_filter" options="{'month_field': 'carryover_month'}"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"
                                                    required="carryover_date == 'other'"/>


### PR DESCRIPTION
In Time Off > Configuration > Accrual Plans > New, When selecting a day-month combination in the configuration section or the milestone section, the dropdown selection field for the day has a default range from 1 to 31, no matter the accociated month.

The backend checks the range, but to improve UX experience, a dynamic custom selection widget is implemented to filter on the month. E.g, the month of September should display a range from 1 to 30.

Worth noting that for February, the range is 1-29 (included). As mention in the task, and what the backend accepts.

task: 6455797