### PR TITLE
[ADD] skills: odoo-guidelines, odoo-review, odoo-security

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,29 @@
+# Odoo's Skill Library
+
+This directory contains a set of useful Skills for agentic development with Odoo.
+
+Skills are structured documentation that can help AI agents achieve some tasks faster
+and more reliably, with less guesswork. Odoo's Skill library includes skills that
+help agents review code, audit it for security, and write it right in the first place.
+
+More about the skill format: https://agentskills.io
+
+## Installation
+
+The installation of the skills consists of copying the content of this directory
+into the correct place, which will depend on which harness you use (claude code,
+copilot-cli, codex, opencode, etc.) and where you launch it from.
+
+The usual location is `.agents/skills/` or `.claude/skills/` at the root of
+the directory where you launch your agent for Odoo development. It is also
+possible to install those skills globally in your agent harness; for that,
+see your harness's own documentation.
+
+Note that all the skills provided must be installed together as they
+reference each other.
+
+## Usage
+
+Once installed, restart your agent session and it should be able to use the
+skills on its own. If you ask it _'Please review this code'_ the agent will
+read the content of the `odoo-review` skill and apply its guidance.

--- a/skills/odoo-guidelines/AUTHORING.md
+++ b/skills/odoo-guidelines/AUTHORING.md
@@ -1,0 +1,51 @@
+# Adding a guideline
+
+## Files
+
+- Guidelines live in `guidelines/`, one file per domain: `orm.md`, `xml.md`, `tests.md`,
+  and a new file the day a domain has guidelines of its own.
+- Inside a file, one guideline per `#` section. The title states the rule: "Batch ORM
+  calls", not "Loops".
+- Order inside a file means nothing. No rule outranks another.
+
+## Two kinds of guideline: conventions and rules
+
+- A **convention** is a choice that fits in one line and can be followed as stated.
+  - Examples: `_id` suffix on a `Many2one`, one model class per file.
+  - Needs no explanation.
+  - Written as a bullet.
+  - Conventions are grouped by topic, one section per topic.
+- A **rule** needs an explanation to be applied correctly.
+  - Written as its own section: the rule, then why it exists, then the cases where it
+    does not apply.
+  - A few sentences is the normal size. Sub-headings and code blocks are allowed, not
+    required.
+- Promote a convention to a rule when it keeps being violated even though the
+  convention was loaded. That shows it needs the explanation.
+
+## Writing the rule itself
+
+- State the rule as something a reviewer can check against code with a yes or no.
+  - Good: "no `create` call inside a loop".
+  - Bad: "write efficient code".
+- The why and the exceptions come after the rule. They do not replace a clear rule.
+- Name the alternative. A rule that forbids something says what to write instead.
+
+## Examples
+
+- An example is optional. Add one when the rule is hard to state without it, and keep
+  it schematic: the smallest tree or snippet that carries the concept.
+- Show the same code both ways when seeing it break the rule is what makes the rule
+  clear.
+- Do not copy real code. Use schematic model names such as `library.book`, never a
+  real one: a real name makes the guideline show up in every grep for that model.
+- Do not point at real files or directories. Nothing checks them, and a stale
+  reference is worse than none.
+
+## Registering the guideline
+
+- Add a row to the table in `SKILL.md`.
+- The "Read it when" cell names the files or the activity that should trigger reading
+  the guideline. Not every edit of every file.
+- The link points at the section title. Renaming a title changes the anchor, so update
+  the row with it.

--- a/skills/odoo-guidelines/SKILL.md
+++ b/skills/odoo-guidelines/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: odoo-guidelines
+description: >-
+  House rules for Odoo addon code: module structure, manifest, Python/ORM,
+  fields, controllers, XML views and data, QWeb reports, access rights and
+  record rules, performance, tests. Use when writing or reviewing any file in
+  an Odoo addon outside static/ (for the JavaScript, Owl templates and SCSS
+  under static/, see odoo-web-guidelines).
+---
+
+# Odoo addon guidelines
+
+House rules for code in Odoo addons (`addons/*` and `odoo/addons/*`).
+Everything an addon ships under `static/` has its own skill:
+`odoo-web-guidelines`.
+
+Guidelines are grouped by domain, one file per domain in `guidelines/`, one section per
+guideline. No rule outranks another. Read the sections that match the files you are
+touching instead of loading whole files.
+
+| Guideline | Read it when |
+| --- | --- |
+| [Module structure and file naming](guidelines/module_structure.md#module-structure-and-file-naming) | creating or moving files in an addon, or adding a module |
+| [Manifest](guidelines/manifest.md#manifest) | touching `__manifest__.py` |
+| [Imports](guidelines/python.md#imports) | writing Python anywhere in an addon |
+| [Naming and model layout](guidelines/python.md#naming-and-model-layout) | naming a model, field, method or variable; laying out a model class |
+| [Translate only static literals](guidelines/python.md#translate-only-static-literals) | user-facing strings in Python |
+| [Recordsets, domains and context](guidelines/orm.md#recordsets-domains-and-context) | reading records, building domains, passing context |
+| [Computes, onchange and constraints](guidelines/orm.md#computes-onchange-and-constraints) | computes, onchange, constraints, indexes, `create` overrides |
+| [Methods and extension points](guidelines/orm.md#methods-and-extension-points) | adding a model method, or one another module will override |
+| [Transactions and exceptions](guidelines/orm.md#transactions-and-exceptions) | cursors, commits, savepoints, `try`/`except` |
+| [Fields](guidelines/fields.md#fields) | declaring or modifying field definitions |
+| [Controllers](guidelines/controllers.md#controllers) | touching `controllers/` or `@route` |
+| [Views, actions and data records](guidelines/xml.md#views-actions-and-data-records) | touching `views/`, `data/`, or any XML records |
+| [Anchor view inheritance on names, never on position](guidelines/xml.md#anchor-view-inheritance-on-names-never-on-position) | extending or overriding an existing view |
+| [QWeb PDF reports](guidelines/reports.md#qweb-pdf-reports) | report templates or `_get_report_values` |
+| [Access rights](guidelines/security.md#access-rights) | touching `security/` (`ir.access.csv`, groups) |
+| [Batch ORM calls](guidelines/performance.md#batch-orm-calls) | ORM calls (`create`/`search*`/aggregates) inside a loop |
+| [Performance conventions](guidelines/performance.md#performance-conventions) | code that loops over records or filters query results |
+| [Tests](guidelines/tests.md#tests) | touching `tests/` |
+| [Changes in a stable version](guidelines/stable.md#changes-in-a-stable-version) | any change targeting a released branch rather than master |
+
+To add or restructure a guideline, follow [AUTHORING.md](AUTHORING.md).

--- a/skills/odoo-guidelines/guidelines/controllers.md
+++ b/skills/odoo-guidelines/guidelines/controllers.md
@@ -1,0 +1,14 @@
+# Controllers
+
+- Routes are methods decorated with `@route` on a `http.Controller` subclass.
+  Always re-decorate an **override** with `@route` (an undecorated override
+  still works — the framework auto-decorates it and logs a warning). An empty
+  `@route()` keeps the parent's arguments and any argument overrides the
+  parent's — except `type`, which an override can never change (ignored with
+  a warning; loosening `readonly` is likewise reverted).
+- Set the right `auth` on each route (`user`, `bearer`, `public`, or `none`):
+  a `public` route must not expose internal data or perform privileged writes
+  (see the `odoo-security` skill). `auth='bearer'` requires `bearer_scope`
+  (which is only valid there).
+- Route `type` is `'http'`, `'jsonrpc'`, or `'json2'` — `type='json'` is a
+  deprecated 19.0 alias of `'jsonrpc'`.

--- a/skills/odoo-guidelines/guidelines/fields.md
+++ b/skills/odoo-guidelines/guidelines/fields.md
@@ -1,0 +1,27 @@
+# Fields
+
+- Relational suffixes: `Many2one` → `_id`, `One2many`/`Many2many` → `_ids`.
+- `index=True` on fields that are both searched and selective (many distinct
+  values). An index on a low-cardinality field — a boolean, a state — is wasted
+  space and slows every write. `index` also accepts
+  a type (`'btree_not_null'`, `'trigram'` for `like` searches); multi-column or
+  custom indexes are model attributes (`_x_idx = models.Index("(a, b)")`,
+  `models.UniqueIndex`; the attribute name must start with `_`).
+- Restrict sensitive fields with the `groups` attribute (comma-separated external
+  ids); restricted fields are dropped from views and `fields_get`, and raise on
+  direct read/write.
+- Check relational definitions: correct `comodel_name`, sensible `ondelete`,
+  `required`, and a currency companion for monetary fields.
+- Use **reserved** fields for their built-in behavior rather than reinventing
+  them: `active` for archiving (via `action_archive`, not a custom boolean),
+  `state` for lifecycle, `parent_id` + `parent_path` (`index=True`, with
+  `_parent_store`) for trees, `company_id` for multi-company (consistency via
+  `_check_company`). Keep `_log_access` enabled on a `TransientModel`.
+- A field and a method can't share a name (same namespace) — flag collisions.
+- `related` fields can't chain `One2many`/`Many2many` in the dependency path —
+  the ORM does not reject it, it *silently truncates each x2many hop to its
+  first record* and returns wrong data; reach the target through a `Many2one`
+  (ending the chain on an x2many is fine). Reusing one compute for several
+  fields is fine; reusing one **inverse** is discouraged — while the inverse
+  runs, every field sharing it is protected and reads as `False` when not
+  cached, so the method sees wrong sibling values.

--- a/skills/odoo-guidelines/guidelines/manifest.md
+++ b/skills/odoo-guidelines/guidelines/manifest.md
@@ -1,0 +1,17 @@
+# Manifest
+
+- `name` is required; `version` should follow semantic versioning.
+- `depends` lists every module whose features or resources are used, direct
+  dependencies only. Don't list `base`: a manifest without `depends` gets
+  `['base']` injected, and upgrading `base` upgrades every installed module
+  whether or not it lists it.
+- `data` files are always installed/updated; `demo` files load only in demo
+  mode. Keep load order correct (a record's dependencies first).
+- `license` defaults to `LGPL-3`; set it deliberately and correctly.
+- `auto_install` is only for "link" modules (installed automatically when their
+  dependencies are); it can also be a *subset* of `depends` that triggers the
+  auto-install (an empty list: always installed).
+- `application` is `True` only for full apps, not technical modules.
+- Declare non-Odoo requirements in `external_dependencies` (`python`/`bin`).
+- `assets` declares how static files load into bundles (don't register assets
+  ad-hoc elsewhere).

--- a/skills/odoo-guidelines/guidelines/module_structure.md
+++ b/skills/odoo-guidelines/guidelines/module_structure.md
@@ -1,0 +1,23 @@
+# Module structure and file naming
+
+- Standard directories: `models/`, `views/`, `controllers/`, `data/`,
+  `security/`, `static/`, and optional `wizard/`, `report/`, `tests/`,
+  `populate/`.
+- One model class per file, named after the model with dots as underscores
+  (`res_partner.py`), whether the class defines a new model or extends an
+  existing one with `_inherit`.
+- Suffix conventions: backend views `*_views.xml`, portal/QWeb pages
+  `*_templates.xml`, menus optional `*_menus.xml`, data `*_data.xml`, demo
+  `*_demo.xml`, wizards `<transient>.py` + `<transient>_views.xml`.
+- Security files: access rows in `security/ir.access.csv`; groups and other
+  security records in `security/<module>_security.xml`.
+- Controllers: feature-named files, or `<inherited_module>.py` when extending
+  another module's controller (e.g. `portal.py`); `main.py` is legacy (still
+  widespread in core).
+- Reports: a statistics (SQL-view) report is `<model>_report.py` +
+  `<model>_report_views.xml`; a printable report splits `<model>_reports.xml`
+  (report actions, paperformat) from `<model>_templates.xml` (QWeb templates).
+- `populate/` holds `populate.blueprint` XML records (`populate_demo.xml`,
+  `benchmarks.xml`); an `__init__.py` makes it an importable package for
+  custom populate generators.
+- File and directory names are Python identifiers: lowercase, `[a-z0-9_]`.

--- a/skills/odoo-guidelines/guidelines/orm.md
+++ b/skills/odoo-guidelines/guidelines/orm.md
@@ -1,0 +1,51 @@
+# Recordsets, domains and context
+
+- Use recordset methods (`filtered`, `grouped`, `mapped`, `sorted`) where they
+  read better than a loop.
+- Recordsets/collections are booleans: write `if records:` / `if some_list:`,
+  not `if len(...)`.
+- Don't read a non-relational field on a multi-record set (it raises) — iterate
+  or `mapped`. Conversely, guard single-record assumptions with `ensure_one()`.
+- Combine domains with `odoo.fields.Domain`: the `&`, `|`, `~` operators for
+  domains written inline, `Domain.AND`/`Domain.OR` for a list of domains you
+  already hold. Never hand-build `'&'`/`'|'` prefix-notation lists.
+- Propagate context with `with_context(...)` (it's a frozendict, immutable);
+  name custom context keys carefully and prefix module-specific ones (a stray
+  `default_<field>` in context leaks into unrelated `create` calls).
+- Delegation inheritance (`_inherits`) inherits fields but **not** methods; avoid
+  it where you can (chained `_inherits` is unsupported).
+
+# Computes, onchange and constraints
+
+- `create` must accept a list of vals (`@api.model_create_multi`); don't call
+  `create` per record in a loop (see [Batch ORM calls](performance.md#batch-orm-calls)).
+- `@api.depends` must list **every** field the compute reads; stored computes
+  need correct dependencies and no side effects.
+- `@api.onchange` is UI-only — never rely on it for data integrity; enforce
+  invariants with `@api.constrains` or SQL constraints declared as model
+  attributes (`_x_check = models.Constraint("CHECK (...)", "msg")`; the
+  attribute name must start with `_`). Indexes are declared the same way
+  (`_x_index = models.Index(...)`, `models.UniqueIndex(...)`). Flag
+  `_sql_constraints`: on master it is **ignored** with a log warning, the
+  constraint is never created.
+
+# Methods and extension points
+
+- Methods are private (`_` prefix) by default. A public name is an RPC entry
+  point: make one only when it must be callable from outside, and decorate
+  with `@api.private` a public name that must not be exposed.
+- Logic that another module actually overrides goes in its own small method
+  (`self._get_partner_domain()`); other modules extend methods, not lines.
+  Don't pre-split for extension points that don't exist yet.
+- Don't use `odoo.http.request` in models: it is absent in crons, RPC, tests
+  and the shell. Pass what the model needs in from the controller.
+
+# Transactions and exceptions
+
+- **Never** call `cr.commit()` / `cr.rollback()` unless you opened your own
+  cursor; the framework owns the transaction. Any unavoidable commit needs an
+  explicit comment justifying it.
+- Catch **specific** exceptions over the smallest possible block; let unexpected
+  ones propagate to the framework. To recover from framework exceptions, wrap the
+  work in `with self.env.cr.savepoint():` (note: >64 savepoints per transaction
+  degrades PostgreSQL — bound batch sizes).

--- a/skills/odoo-guidelines/guidelines/performance.md
+++ b/skills/odoo-guidelines/guidelines/performance.md
@@ -1,0 +1,56 @@
+# Batch ORM calls
+
+Make **one** ORM call for the whole collection; an ORM call inside a
+`for` loop over records or vals is a query per iteration. This covers
+`search`, `search_count`, `_read_group` and `create` alike.
+
+```python
+# bad — one INSERT round-trip per record
+for vals in vals_list:
+    self.env['library.book'].create(vals)
+
+# good — one batched create (and decorate overrides with @api.model_create_multi)
+self.env['library.book'].create(vals_list)
+```
+
+```python
+# bad — one aggregate query per author
+for author in authors:
+    author.book_count = Book.search_count([('author_id', '=', author.id)])
+
+# good — one grouped query, then a dict lookup
+counts = {
+    author.id: count
+    for author, count in Book._read_group(
+        [('author_id', 'in', authors.ids)], ['author_id'], ['__count'],
+    )
+}
+for author in authors:
+    author.book_count = counts.get(author.id, 0)
+```
+
+## Why
+
+- Each call is a full round-trip (Python → SQL → Python); a loop turns O(1)
+  queries into O(n) and dominates response time on real data volumes.
+- Reading fields batches too: iterate a recordset (or `browse` all ids
+  first) and the ORM prefetches each field for the whole set in one query —
+  a record-by-record `browse(id)` loop defeats the prefetch.
+
+## Exceptions
+
+- A loop that only computes in memory on already-read fields is fine — the
+  rule is about calls that hit the database.
+- When a per-record call is truly unavoidable (e.g. an external API per
+  record), bound the batch size.
+
+# Performance conventions
+
+- Put conditions in the search domain, not in `filtered()` on the result:
+  `filtered` runs in Python on records already fetched. Reserve it for
+  predicates a domain cannot express.
+- **Reduce complexity.** Pre-map results into a dict (`{r['id']: r}`) instead of
+  nested loops; cast membership-test collections to `set` (or use recordset
+  arithmetic like `self - invalid`) to avoid O(n²).
+- Index searched fields (`index=True`) — selectively, per
+  [Fields](fields.md#fields).

--- a/skills/odoo-guidelines/guidelines/python.md
+++ b/skills/odoo-guidelines/guidelines/python.md
@@ -1,0 +1,76 @@
+# Imports
+
+PEP 8 applies; the `ruff.toml` at the repository root is the reference for what
+is enforced.
+
+- Four groups, each alphabetically sorted (the ruff isort order):
+  1. stdlib
+  2. third-party libs
+  3. `odoo` submodules (`from odoo import Command, api, fields, models`)
+  4. `odoo.addons.*` (rarely, only if necessary)
+
+# Naming and model layout
+
+- Model `_name`: dotted, prefixed by module, **singular** (`sale.order`, not
+  `sale.orders`). Transient/wizard: `<base_model>.<action>` (avoiding the word
+  "wizard" is a soft preference — core ships many `.wizard` names). SQL-view report model: `<base_model>.report.<action>`.
+- A variable holding a model class is PascalCase (`Partner =
+  self.env['res.partner']`). Suffix a var holding a record id / list of ids
+  with `_id` / `_ids` (don't name a `res.partner` record `partner_id`).
+- Method-name patterns: compute `_compute_<field>`, search `_search_<field>`,
+  default `_default_<field>`, selection `_selection_<field>`, onchange
+  `_onchange_<field>`, constraint `_check_<name>`, object action `action_*`
+  (acts on one record — start it with `self.ensure_one()`).
+- Model body order: private attrs (`_name`, `_description`, `_inherit`) → default
+  methods → field declarations → `models.Constraint`/`models.Index` attributes
+  (core also places these right after the private attrs) → compute/inverse/search
+  (field order) → selection methods → `@api.constrains`/`@api.onchange` → CRUD
+  overrides → action methods → other business methods.
+
+# Translate only static literals
+
+Translate only **static literals**, passing interpolation values as
+arguments; in model code the current API is `self.env._(...)`.
+
+```python
+# good
+raise UserError(self.env._("Record %s cannot be modified", record.display_name))
+
+# good — several variables: name them so translators keep them straight
+msg = self.env._("%(count)s records imported by %(user)s", count=len(records), user=user.name)
+
+# good — a list argument is formatted per language ("a, b and c")
+raise UserError(self.env._("Missing fields: %s", missing_names))
+
+# bad — formats before the lookup: the dynamic string matches no exported term
+raise UserError(self.env._("Record %s cannot be modified" % record.display_name))
+
+# bad — formats after the lookup: bypasses placeholder validation and reordering
+raise UserError(self.env._("Record %s cannot be modified") % record.display_name)
+
+# bad — manual join ignores the user's language and its list rules
+raise UserError(self.env._("Missing fields: %s", ", ".join(missing_names)))
+```
+
+## Why
+
+- Translations are keyed on the exact source literal, at export (building the
+  `.pot`) and at runtime lookup. Concatenation, f-strings, or `%`-formatting
+  inside `_()` produce strings that exist in neither.
+- Named placeholders let translators reorder words per language; passing them
+  as `_()` arguments lets the framework validate them per translation and
+  apply Markup-aware escaping (post-lookup `%` formatting loses that safety).
+
+## Exceptions and notes
+
+- Bare `_` (imported from `odoo`) is the backward-compatible API: it locates
+  the environment by inspecting the caller's frame; in plain functions and
+  comprehensions it silently returns the untranslated (or wrong-language)
+  string with only a logged warning — prefer `self.env._`.
+- Never call `_()` at module or class level — it runs at import time with no
+  user language and silently doesn't translate. Translate inside the method
+  when you can; if a module-level constant is unavoidable, make it lazy
+  (`_lt = LazyTranslate(__name__)`; `LABEL = _lt("...")`) and resolve it where
+  the language is known, by passing it through `self.env._(LABEL)`.
+- Field *values* are translated via the field's `translate` flag, never `_()`.
+- Prefer `%`-style placeholders over `.format()`.

--- a/skills/odoo-guidelines/guidelines/reports.md
+++ b/skills/odoo-guidelines/guidelines/reports.md
@@ -1,0 +1,10 @@
+# QWeb PDF reports
+
+- A custom report's `_get_report_values` must add the default `docs` / `doc_ids`
+  / `doc_model` itself if the template needs them — they are not auto-included.
+- For translated reports use `t-lang` — it is only valid on a node that also
+  carries `t-call` (anywhere else QWeb raises a `SyntaxError` at template
+  compile time); to translate part of a report,
+  extract that part into its own template and `t-call` it with `t-lang`. Only
+  re-browse records in the target language when the template reads
+  translatable fields (otherwise it is a needless performance cost).

--- a/skills/odoo-guidelines/guidelines/security.md
+++ b/skills/odoo-guidelines/guidelines/security.md
@@ -1,0 +1,25 @@
+# Access rights
+
+Master unifies the old `ir.model.access` ACLs and `ir.rule` record rules into
+a single `ir.access` model, declared in `security/ir.access.csv` with columns
+`id,name,model_id,group_id/id,operation,domain`.
+
+- `operation` is required: a subset of `crud` letters (`r`, `cru`, `crud`, …);
+  a row applies to exactly the operations it lists. The optional `domain`
+  restricts the row to matching records (what record rules used to do).
+- Rows **with** a group are *permissions*: OR-ed together (union over the
+  user's groups); a row's domain limits only what that row grants. Rows
+  **without** a group are *restrictions*: AND-ed onto **every** user — they
+  never grant anything, and non-overlapping restrictions can lock everyone
+  out.
+- Default deny: a model with no permission row is inaccessible. Granting to
+  everyone (portal/public included) is done via `base.group_everyone` — flag
+  any `c`/`u`/`d` granted to `base.group_everyone`, `base.group_portal`, or
+  `base.group_public`.
+- Multi-company models need a group-less restriction row with a company
+  domain — `"[('company_id', 'in', company_ids)]"` (`company_ids` evaluates to
+  the user's allowed companies; append `+ [False]` when the company is
+  optional).
+
+For auditing beyond the data files (`sudo()`, SQL, public methods, …), use the
+`odoo-security` skill.

--- a/skills/odoo-guidelines/guidelines/stable.md
+++ b/skills/odoo-guidelines/guidelines/stable.md
@@ -1,0 +1,26 @@
+# Changes in a stable version
+
+A stable version is any released branch (`17.0`, `18.0`, ...): only bug fixes and
+localizations go there; improvements and features go to master, and an LTS fix is
+forward-ported by the maintainers, never re-submitted per branch.
+
+- Value over risk: keep the change minimal and strictly about the bug. If the risk is
+  high or the value low, it belongs in master, not in stable.
+- No improvements, technical or functional, and no purely cosmetic changes
+  (formatting, PEP 8, restyling). Match the surrounding code's style.
+- Public model methods (no `_` prefix) are API for integrators: never change their
+  signature. Avoid changing private signatures too, extension modules override them.
+- No data-model change: stored columns are never added, removed, or changed to an
+  incompatible type. Compatible tweaks (`ondelete`, `size`) are allowed when needed;
+  a non-stored computed field may be added if really necessary.
+- Keep XML ids of existing data, and don't delete data records that user data may
+  reference, unless essential and the records were `noupdate` from the start.
+- Change XML (views, menus, default data) only when inevitable, and then the Python
+  code must not depend on the change: a database that has not been updated must
+  keep working.
+- A fix may need an explicit module update as long as users who don't run it are
+  safe. A critical security fix must work with a pull and restart alone.
+- Don't modify existing translatable source terms, even for a typo; that breaks
+  existing translations. Correct a term in master, or add an English-to-English
+  translation in stable. Adding or deleting terms is fine; don't ship `.pot`
+  updates, they are exported and synced automatically.

--- a/skills/odoo-guidelines/guidelines/tests.md
+++ b/skills/odoo-guidelines/guidelines/tests.md
@@ -1,0 +1,29 @@
+# Tests
+
+- Use `TransactionCase` (or `HttpCase` for web); start new business tests from
+  `odoo.addons.base.tests.common.BaseCommon` (independent non-admin user and
+  company, mail side effects disabled), or
+  `TransactionCaseWithUserDemo`/`HttpCaseWithUserDemo` when demo data is
+  needed (it is not guaranteed present). Assert behavior, not implementation.
+- Tests are tagged `standard` and `post_install` by default (fully-loaded
+  registry); set exactly one of `at_install`/`post_install` — the check is
+  only a log warning, and *both* tags makes the class run twice while
+  *neither* makes it never run. Opt into
+  `@tagged('at_install', '-post_install')` only when the test must run before
+  other modules load, with a comment justifying it — `at_install` prevents
+  runbot parallelization, and an `HttpCase` must stay `post_install`. Tests
+  run only for installed modules.
+- Silent skips: a test file must be named `test_*.py` **and** imported from
+  `tests/__init__.py`; the test class must be *defined* in that file (a class
+  merely imported into it is skipped); and inherited `test_*` methods are not
+  collected — a subclass defining no tests of its own runs nothing unless it
+  sets `allow_inherited_tests_method = True`.
+- `assertQueryCount` only when strictly necessary, and never inside a business
+  test: it breaks on any unrelated ORM change. Keep it to dedicated
+  performance tests, paired with `@warmup` (and `@users`); only *exceeding*
+  the budget fails — a lower count merely logs, so keep budgets exact.
+- Wrap expected-error and warning logs in `mute_logger(...)` so the expected
+  ERROR or WARNING never reaches the runbot log.
+- Tours: a step that triggers a page unload must set `expectUnloadPage: true`,
+  and the last step must leave the client in a stable state (no pending edits
+  or in-flight requests) to avoid teardown race conditions.

--- a/skills/odoo-guidelines/guidelines/xml.md
+++ b/skills/odoo-guidelines/guidelines/xml.md
@@ -1,0 +1,67 @@
+# Views, actions and data records
+
+- Record format: put `id` before `model`; inside a `field`, `name` first, then
+  the value (tag body or `eval`), then other attributes by importance. Group
+  records by model.
+- Prefer the syntactic-sugar tags `<menuitem>`, `<template>`, and `<asset>`
+  over raw `<record>`. Trap: an `active` attribute on `<template>`/`<asset>`
+  is applied at record creation and module *install/re-install* (`-i`) only —
+  a module **update** (`-u`) updates the arch but never changes `active`, so
+  it can't deactivate an already-installed record.
+- `<data noupdate="1">` only for non-updatable data; if the whole file is
+  noupdate, set `noupdate="1"` on `<odoo>` and drop `<data>`.
+- XML id patterns: view `<model>_view_<type>` (`form`/`list`/`kanban`/`search`),
+  action `<model>_action[_<detail>]`, window-action view
+  `<model>_action_view_<type>`, menu `<model>_menu[_<do_stuff>]`, group
+  `<module>_group_<name>`, rule `<model>_rule_<group>`. The record `name` mirrors
+  the id with dots instead of underscores; actions get a real display name.
+- CSS classes in views and templates: prefix with `o_<module>` (`o_` alone is
+  reserved for the web client), never style through ids, and keep names flat
+  (`o_element_entry`) rather than mirroring the DOM nesting.
+- Inheriting a view: see
+  [Anchor view inheritance on names, never on position](#anchor-view-inheritance-on-names-never-on-position).
+
+# Anchor view inheritance on names, never on position
+
+Anchor a view inheritance on a **stable, identifying attribute** — an
+element's `name` — never on document position.
+
+```xml
+<!-- good — the shorthand: a field locator matches by name alone -->
+<field name="partner_id" position="after">
+    <field name="delivery_instructions"/>
+</field>
+
+<!-- good — xpath when the shorthand can't express the match -->
+<xpath expr="//page[@name='other_information']//field[@name='user_id']" position="attributes">
+    <attribute name="readonly">1</attribute>
+</xpath>
+
+<!-- bad — breaks as soon as the parent view inserts or reorders anything -->
+<xpath expr="//group[2]/field[3]" position="after">
+    <field name="delivery_instructions"/>
+</xpath>
+```
+
+Shorthand matching is asymmetric: a `field` element matches the first field
+with the same `name` — in document order at **any** depth (use xpath when the
+name recurs in an embedded subview), other locator attributes ignored. Any
+**other** tag matches the first node with the same tag carrying all the
+locator's attributes with equal values (`position` excepted); extra attributes
+on the target are fine.
+
+## Why
+
+- The parent view belongs to another module that changes it freely; a
+  positional match silently lands the change on the wrong element or raises
+  at install on every parent reorganization.
+- The shorthand form reads as "this element, changed", and fails loudly if
+  the anchor disappears.
+
+## Record conventions
+
+- An inheriting view reuses the **same xml id** as the original record; its
+  `name` carries an `.inherit.<details>` suffix.
+- A new **primary** view (a variant, not an extension) sets `mode="primary"`
+  and needs no inherit suffix.
+- Don't re-add fields the parent view already renders.

--- a/skills/odoo-review/SKILL.md
+++ b/skills/odoo-review/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: odoo-review
+description: >-
+  Review Odoo addon code against the house rules, dispatching each changed
+  file to the matching odoo-guidelines, odoo-web-guidelines, and
+  odoo-security material. Use when reviewing a diff, commit, PR, or module.
+---
+
+# Reviewing Odoo code
+
+Review against Odoo's framework conventions, not generic Python style alone.
+Flag issues with file/line and a concrete fix; do not auto-fix anything
+ambiguous.
+
+## Process
+
+- Read the module's `__manifest__.py` first to understand scope and `depends`.
+- For each changed file, read the guidelines that match it and apply every
+  rule that fits:
+  - [`odoo-guidelines`](../odoo-guidelines/SKILL.md) — module structure,
+    manifest, Python/ORM, fields, controllers, XML, access rights,
+    performance, tests; its table maps file types to guideline sections.
+  - [`odoo-web-guidelines`](../odoo-web-guidelines/SKILL.md) — everything
+    under `static/`: JavaScript, Owl templates, SCSS.
+- If the diff touches controllers, access rules (`ir.access` records), `sudo()`, raw SQL,
+  `eval`, or public/RPC-callable methods, also apply the
+  [`odoo-security`](../odoo-security/SKILL.md) skill.
+- **Stable vs master.** In a *stable* version, the existing file style
+  supersedes the guidelines — never restyle existing code; keep the diff
+  minimal, and check the change against
+  [Changes in a stable version](../odoo-guidelines/guidelines/stable.md#changes-in-a-stable-version). In *master*,
+  apply guidelines to new code, or to existing code only when a file is under
+  major change (do a separate *move* commit first).
+- **Version traps.** Odoo's ORM and view/template syntax change between major
+  versions (`attrs=`, `<tree>`, `name_get`, `read_group` are all gone from
+  recent versions). Before flagging — or writing — an API or attribute,
+  confirm it exists in this checkout (`git grep` the ORM source or a current
+  usage); don't trust a remembered API.
+
+## Code the diff never shows
+
+Odoo modules extend each other: any method can be overridden by another module,
+and any field, XML id, or view element can be referenced by one, including
+modules outside this repository (enterprise, customer addons). A change in
+behaviour, signature, or name can therefore break code that is not in the diff.
+
+- For each changed method, `git grep "def <name>("` across every addons path
+  available, and read the overrides: do they still call `super()` with valid
+  arguments, and does the new behaviour hold with their additions?
+- For each renamed or removed field, XML id, or method, grep for its name in
+  Python, XML, and JavaScript; a stale reference in a view or a domain fails
+  only at runtime.
+- In a stable version, treat a signature change as a bug on its own (see
+  [Changes in a stable version](../odoo-guidelines/guidelines/stable.md#changes-in-a-stable-version)).
+
+Checking the guidelines and the code around the diff is the floor of a review,
+not the end of it. Then review the change on its merits as you would any code.

--- a/skills/odoo-security/SKILL.md
+++ b/skills/odoo-security/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: odoo-security
+description: >-
+  Security audit of Odoo addon code: access control (ir.access, field groups,
+  sudo), injection (SQL, domain, eval, XSS via Markup/markup()), untrusted
+  public methods/RPC,
+  controller auth/CSRF, file access, deserialization, returning complex
+  objects, getattr/setattr, timing attacks. Use when auditing an addon, or
+  judging whether a specific construct (a sudo, raw SQL, a route, …) is safe.
+---
+
+# Security audit of Odoo code
+
+Audit Odoo addons for the framework-specific ways access control and injection
+go wrong. When a feature needs more access than the rules give, it gets the
+minimum, in the narrowest scope, with a comment saying why; a silent widening
+(a bare `sudo()`, a loosened access row) is a finding.
+
+## Process
+
+- Review the `security/` data files against [Access control](#access-control).
+- Sweep the addon for every pattern in the table below; judge each hit against
+  its section. A hit is not a finding by itself — the sections say what makes
+  it one.
+- Report each finding with severity, exact file/line, and a minimal fix.
+
+The audit is complete when every pattern has been swept and every hit judged.
+
+| Sweep for | Judge against |
+| --- | --- |
+| `sudo(`, `with_user(`, `with_company(` | [Don't over-sudo](#dont-over-sudo) |
+| `cr.execute`, `SQL(`, `.format`/`%`/f-string near SQL | [Use the ORM; parameterize SQL](#use-the-orm-parameterize-sql) |
+| domain built from request, RPC, or stored field values | [Domain injection](#domain-injection) |
+| public (non-`_`) model methods | [Default to private methods](#default-to-private-methods) |
+| `@http.route(`, bare `@route(` | [Routes: auth, POST, CSRF](#routes-auth-post-csrf) |
+| `innerHTML`, `insertAdjacentHTML`, `markup(` (JS), `Markup(` (Python), `t-raw` (dead code) | [Prevent XSS](#prevent-xss-escape-on-the-way-into-the-dom) |
+| password/token/secret fields | [Field-level access](#field-level-access) |
+| `related=` crossing models (sudo-computed by default) | [Field-level access](#field-level-access) |
+| `open(` | [Open files with `file_open`](#open-files-with-file_open-not-open) |
+| `eval(`, `exec(`, `safe_eval` | [`eval` is evil](#eval-is-evil) |
+| `pickle` | [Never `pickle`](#never-pickle) |
+| `getattr(`, `setattr(` on records | [`getattr`/`setattr`](#getattrsetattr-are-not-your-friends) |
+| `==` comparing a secret/token | [Timing attacks](#timing-attacks) |
+| `def f(..., x=[])` / `x={}` | [Mutable default arguments](#mutable-default-arguments) |
+| methods returning rich objects | [Don't return complex objects](#dont-return-complex-objects-from-model-methods) |
+
+## Access control
+
+Mechanics of `ir.access` rows and field `groups` are in the `odoo-guidelines`
+skill ([Access rights](../odoo-guidelines/guidelines/security.md#access-rights),
+[Fields](../odoo-guidelines/guidelines/fields.md#fields)); audit `security/` with
+the attacker's reading:
+
+- Flag any `c`/`u`/`d` operation granted to `base.group_everyone`,
+  `base.group_portal`, or `base.group_public`; scrutinize even `r` on models
+  holding personal or business-sensitive data.
+- A permission row's `operation` set is what it grants; a *restriction*
+  (group-less) row covering only some operations leaves the others governed by
+  the permission rows alone — if any permission grants `write`, an attacker
+  can alter records the read restriction hides (`write` checks write access
+  only, never read). Cover **all** CRUD operations that need restricting.
+- Multi-company models need a company restriction row; sensitive models need
+  domain restrictions, not just group permissions.
+
+## Field-level access
+
+- A field's `groups` attribute removes it from views and `fields_get` and
+  raises on explicit read/write. Use it for sensitive fields instead of
+  relying on the UI to hide them.
+- **Passwords and API tokens**: restrict them with `groups="base.group_system"`,
+  or `groups=fields.NO_ACCESS` to hide the field from everyone, admins
+  included. A token field on a model with a permissive access row is readable
+  by any user via `search_read`.
+- **`related` fields are sudo-computed by default** (`related_sudo=True`): a
+  related field reaching sensitive data through a user-writable `Many2one`
+  lets the user point the M2o at an arbitrary record and read the related
+  value with elevated rights — set `related_sudo=False` on sensitive chains.
+  (`readonly=False` write-through is a separate concern: it runs in the
+  user's environment and is access-checked.)
+
+## Default to private methods
+
+- **Any public method is callable via RPC** with attacker-chosen arguments;
+  the records in `self` and the parameters **cannot be trusted** (access
+  control is only enforced on CRUD, not method calls). More public methods =
+  bigger attack surface. **Prefix methods with `_` by default**; drop the `_`
+  only when the method is genuinely meant to be called externally — and then
+  validate inputs. (Privacy alone isn't a control: a `_`-method fed untrusted
+  data is still dangerous.)
+- The RPC guard (`get_public_method`) blocks `_`-prefixed names,
+  classmethods/staticmethods, and anything decorated `@api.private` anywhere
+  in the MRO — check that before flagging a public-named method as exposed;
+  `@api.private` is the sanctioned fix when renaming would break callers.
+
+## Use the ORM; parameterize SQL
+
+- Never use the cursor directly when the ORM can do it: raw SQL bypasses
+  access control, translations, field invalidation, and `active` handling.
+  Prefer `search`/`_read_group` and direct field access (not `read()`). For
+  custom SQL over ORM-filtered rows, build the query with `_search(...)` and
+  `Query.select(SQL(...))`: access rules and `active` handling stay in force.
+- When you must write SQL, **never** interpolate with `+`/`%`/`.format`. Pass
+  values as **parameters** (psycopg2 formats them, including a tuple for
+  `IN %s`), or use the `odoo.tools.SQL` wrapper. For dynamic **identifiers**
+  (table/column names, which can't be parameters) use `SQL.identifier(name)`,
+  which validates the name (via `assert`, so a `-O` deployment skips the
+  check — still never feed it raw user input).
+
+## Domain injection
+
+- Build/extend domains with `fields.Domain` (`domain &= Domain(...)`), never
+  by concatenating a user-provided list onto a security domain (a user could
+  inject `['|', ...]` to widen access).
+
+## Don't over-sudo
+
+- `sudo()` is the top risk — review every use twice, especially in controllers
+  and public methods, never use it to mask an access error. For each `sudo()`,
+  confirm there is no attacker-controlled:
+  - **read**: arbitrary model / record / field;
+  - **create**: arbitrary model / values;
+  - **write**: arbitrary model / record / values;
+  - **search**: arbitrary model / domain / injection.
+- Controllers: never `record.sudo().write(post)` with raw request params —
+  whitelist keys (`{k: post[k] for k in ('name', 'email') if post.get(k)}`).
+- Under `sudo()`, x2many `Command` payloads in `vals` execute with sudo **on
+  the comodel** (unless it sets `_allow_sudo_commands = False`) — a sudo
+  write with raw request values pivots the privilege into other models, so
+  whitelist command lists too.
+- Avoid sudo-computed `related` fields onto `ir.attachment` (arbitrary
+  `attachment_id` → arbitrary file read). Prefer a plain `fields.Binary`, or
+  create/search `ir.attachment` records so the ORM enforces its access rights.
+- `with_user` / `with_company` switches must be intentional, not
+  attacker-driven.
+
+## Routes: auth, POST, CSRF
+
+- Match `auth` to the route's exposure: a `public`/`none` route must not
+  expose internal data or perform privileged writes.
+- A route that writes must use `methods=['POST']`; on a `type='http'` route
+  keep CSRF on (never `csrf=False`, except dedicated webhooks) —
+  `jsonrpc`/`json2` routes have no token check by design, their protection is
+  the JSON content type. State-changing logic on a **GET** route is a CSRF
+  hole: an attacker can auto-submit a hidden form / crafted
+  link and perform the action as the logged-in victim.
+- Templates that POST must include `<input type="hidden" name="csrf_token"
+  t-att-value="request.csrf_token()"/>`.
+
+## Prevent XSS (escape on the way into the DOM)
+
+- Reflected (script in URL/params) and stored (script saved by a
+  low-privileged user) both execute with the victim's session — far more than
+  `alert()`.
+- Server/QWeb: render with `t-out` (escapes by default). `t-raw` no longer
+  exists in either server QWeb or OWL — flag any occurrence as broken legacy
+  code; the raw-HTML vector today is a `Markup`/`markup()` value reaching
+  `t-out`. Build HTML by wrapping **literals** in `markupsafe.Markup` and
+  formatting user content in (Markup auto-escapes; `escape()`/`html_escape`
+  turns `str` into escaped `Markup`). f-strings defeat escaping
+  (`Markup(f"<p>{x}</p>")`) — use `Markup("<p>{x}</p>").format(x=...)`.
+  `_()` escapes when any argument is `Markup`, so keep HTML out of the
+  literal. (`t-esc`: deprecated-but-escaping alias in OWL; server QWeb
+  ignores it and renders nothing — a bug to flag, though not an XSS.)
+- JS: the sinks are `el.innerHTML = …`, `insertAdjacentHTML`, and owl
+  `markup()` on a non-literal — never feed them user/low-privilege strings.
+  Escape with `htmlEscape` (`@odoo/owl`) or use the tagged-template form
+  ``markup`<td>${name}</td>` `` (placeholders auto-escape; plain
+  `markup(str)` marks raw HTML), use the `@web/core/utils/html` helpers
+  (`setInnerHtml`, `htmlJoin`), or render through OWL `t-out`.
+- **Escaping vs sanitizing**: escaping (TEXT→CODE) is always mandatory when
+  mixing data with code, even for trusted data. Sanitizing (CODE→safer CODE)
+  is only for **untrusted** CODE and only works **after** escaping (sanitizing
+  raw TEXT corrupts it). `fields.Html`/`html_sanitize` options
+  (e.g. `strip_classes`) tune the level.
+
+## Open files with `file_open`, not `open`
+
+- Never use the builtin `open()` on a path that can be influenced — it can
+  read *or write* arbitrary files on the host (config, ssh keys, executable
+  Python → RCE). Use `odoo.tools.file_open()`, which confines access to the
+  addons paths, the Odoo root, and registered temporary directories. It
+  refuses to *create* files but will open an existing one in write mode — it
+  is a path confinement, not a write protection.
+
+## `eval` is evil
+
+- Never `eval`/`exec`. To parse data use `json.loads()` or
+  `ast.literal_eval()`; only at worst `odoo.tools.safe_eval.safe_eval` with a
+  constrained namespace, and only for trusted privileged users (it still
+  gives broad capabilities, and plain `eval` allows
+  `__import__('os').popen(...)` RCE; master's extra `--unsafe-policy`
+  whitelist sandbox is observe-only by default).
+
+## Don't return complex objects from model methods
+
+- A public model method that **returns** a rich object (a crypto key, a
+  backend handle) is exploitable from `safe_eval`'d code — server actions,
+  automation rules: the evaluated code calls it and walks single-underscore
+  internals (`._backend._ffi`) to read files or run code. (Dunders are
+  blocked there, and over RPC the return dies in marshalling — safe_eval is
+  the live vector.) Don't factor such logic into a model method if not
+  needed; use a standalone module-level function, or dunder-prefix the
+  method name — dunder names are unreachable from safe_eval, `_`-names over
+  RPC.
+
+## `getattr`/`setattr` are not your friends
+
+- Don't access record fields by dynamic name with `getattr`/`setattr` — it
+  exposes private attributes and methods (`__class__` → `__globals__` →
+  `__import__` → RCE). Use `record[name]` (safe `__getitem__`); still
+  validate the record id and field name, otherwise restrict.
+
+## Never `pickle`
+
+- Builtin `pickle` executes arbitrary code on load (via `__reduce__`). Never
+  unpickle untrusted data; store/exchange with `json` (the framework no
+  longer ships a restricted pickle wrapper).
+
+## Timing attacks
+
+- Compare secrets/tokens in constant time with `odoo.tools.consteq`, not `==`
+  (which short-circuits and leaks length/content via timing). Better, look
+  the token up in the database (`search([('access_token', '=', token)])`).
+
+## Mutable default arguments
+
+- Don't use mutable default parameters (`def f(x, vals=[])`); they persist
+  across calls and can leak/accumulate data.

--- a/skills/odoo-web-guidelines/SKILL.md
+++ b/skills/odoo-web-guidelines/SKILL.md
@@ -24,5 +24,7 @@ touching instead of loading whole files.
 | [Organize files by feature](guidelines/javascript.md#organize-files-by-feature-not-by-type) | creating a file, or deciding where new code lives |
 | [Avoid getters](guidelines/javascript.md#avoid-getters) | adding a computed value to a class or a component |
 | [Avoid patching JavaScript code](guidelines/javascript.md#avoid-patching-javascript-code) | extending or overriding behaviour that already exists |
+| [SCSS and CSS](guidelines/scss.md#scss-and-css) | touching `*.scss` |
+| [Assets](guidelines/assets.md#assets) | adding an image, font, or library |
 
 To add a guideline, follow [AUTHORING.md](AUTHORING.md).

--- a/skills/odoo-web-guidelines/guidelines/assets.md
+++ b/skills/odoo-web-guidelines/guidelines/assets.md
@@ -1,0 +1,5 @@
+# Assets
+
+- Every resource a page needs ships in the codebase: copy images, fonts and libraries
+  into the addon instead of linking them by URL.
+- Third-party libraries go in `static/lib/`, unminified, so they can be read and diffed.

--- a/skills/odoo-web-guidelines/guidelines/scss.md
+++ b/skills/odoo-web-guidelines/guidelines/scss.md
@@ -1,0 +1,20 @@
+# SCSS and CSS
+
+- Formatting: 4-space indent (no tabs), ~80-column lines, opening brace on the
+  selector line, closing brace on its own line, one declaration per line.
+- Order properties from the outside in (start at `position`, end with decorative
+  rules like `font`/`filter`); put scoped SCSS and CSS variables at the top,
+  separated by a blank line.
+- Class naming: avoid `id` selectors; prefix classes with `o_<module>` (just
+  `o_` for the webclient). Use the flat "grandchild" approach
+  (`o_element_entry`), not hyper-specific nested names. Classes use
+  underscores (`o_`); SCSS variables, mixins and functions below use hyphens
+  (`o-`).
+- Variable conventions: SCSS `$o-[root]-[element]-[property]-[modifier]`, scoped
+  SCSS `$-[name]`, mixins/functions `o-[name]` (imperative verbs) with
+  optional arguments named in scoped form (`@mixin o-avatar($-size: 1.5em)`), CSS variables
+  in BEM `--[root]__[element]-[property]--[modifier]`. Don't define CSS variables
+  on `:root` (use SCSS for global design; core's few `:root` definitions are
+  deliberate utility APIs); CSS variables are for contextual DOM adaptation.
+  The variable conventions bind *new* code — much of core (plain mixin
+  arguments, `--ComponentName-property` CSS variables) predates them.


### PR DESCRIPTION
Stacked on odoo/odoo#285015 (targets its branch so only these commits show; rebase to master once it merges).

Adds three agent skills to `skills/`, following the structure introduced there:

- **odoo-guidelines** — the house rules for addon code, one numbered file per domain (module structure, manifest, Python/ORM, fields, controllers, XML, QWeb reports, access rights, SCSS, performance, tests), dispatched by a routing table keyed on the files being touched. Trap-shaped rules (translations interpolation, view inheritance, batch ORM calls) get the full treatment with examples; the rest stay one-line bullets. Authoring conventions in `AUTHORING.md`.
- **odoo-review** — a thin review-process skill: per-changed-file dispatch to the matching guidelines (including `odoo-js-guidelines`), stable-vs-master policy, version-trap warning, explicit completion criterion.
- **odoo-security** — a security-audit skill routed by a sweep table (16 grep patterns → pitfall sections): access control (`ir.access`), sudo, SQL/domain injection, XSS, CSRF, eval, file access, and friends.

All content was verified in two passes against today's master: first against the documentation, then against the source itself. The source pass overruled the docs in several places (`ir.access` unification, `t-raw` and the restricted pickle no longer existing, CSRF being http-type-only, test-tag defaults) — a list of the documentation bugs found along the way is being forwarded to the docs team separately.