### PR TITLE
[FIX] hr: hide "New Contract" button when employee contract date is missing

### DIFF
--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <template>
     <t t-name="hr.ButtonNewContract">
-        <span class="w-100 d-flex justify-content-end">
+        <span class="w-100 d-flex justify-content-end" t-if="this.props.record.data.contract_date_start">
             <button class="btn btn-link p-0 o_field_widget text-end w-auto text-nowrap" t-on-click="this.onClickNewContractBtn"
                     t-ref="this.datetimePickerTargetRef" t-if="this.props.record.resId">New Contract</button>
         </span>


### PR DESCRIPTION
Before this change, the "New Contract" button was always visible on the employee form (in payroll section), even when no contract date was present.

This fix adds a `t-if` condition in the button template to ensure the button is only displayed when the contract date is fulfilled.

Task: 6518971