### PR TITLE
[FIX] hr: New Contract Button Invisible

### DIFF
--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.js
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.js
@@ -70,6 +70,7 @@ export class ButtonNewContractWidget extends Component {
 
 export const buttonNewContractWidget = {
     component: ButtonNewContractWidget,
+    fieldDependencies: [{ name: "contract_date_start", type: "date" }],
 };
 
 registry.category("view_widgets").add("button_new_contract", buttonNewContractWidget);

--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
@@ -3,7 +3,7 @@
     <t t-name="hr.ButtonNewContract">
         <span class="w-100 d-flex justify-content-end">
             <button class="btn btn-link p-0 o_field_widget text-end w-auto text-nowrap" t-on-click="this.onClickNewContractBtn"
-                    t-ref="this.datetimePickerTargetRef" t-if="this.props.record.resId">New Contract</button>
+                    t-ref="this.datetimePickerTargetRef" t-if="this.props.record.resId and this.props.record.data.contract_date_start">New Contract</button>
         </span>
     </t>
 </template>


### PR DESCRIPTION
Fix: in employee form > payroll tab, the new contract button should only show if there is a start date to the contract

task-6519052