### PR TITLE
[FIX] hr: change behavior of the new contract button for the payroll tab in employee

### DIFF
--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.js
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.js
@@ -70,6 +70,7 @@ export class ButtonNewContractWidget extends Component {
 
 export const buttonNewContractWidget = {
     component: ButtonNewContractWidget,
+    fieldDependencies: [{ name: "contract_date_start", type: "date" }],
 };
 
 registry.category("view_widgets").add("button_new_contract", buttonNewContractWidget);

--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
@@ -3,7 +3,7 @@
     <t t-name="hr.ButtonNewContract">
         <span class="w-100 d-flex justify-content-end">
             <button class="btn btn-link p-0 o_field_widget text-end w-auto text-nowrap" t-on-click="this.onClickNewContractBtn"
-                    t-ref="this.datetimePickerTargetRef" t-if="this.props.record.resId">New Contract</button>
+                    t-ref="this.datetimePickerTargetRef" t-if="this.props.record.resId &amp;&amp; !!this.props.record.data.contract_date_start">New Contract</button>
         </span>
     </t>
 </template>


### PR DESCRIPTION
The button to create new contract that was in the employee's payroll ta was appearing even when no contract dates were selected, which was incorrect behavior.

Is a problem because in order to create a contract you need both starting and closing dates.

To avoid code duplication the solution was to target the fix in the 'ButtonNewContract' custom widget that is only used in those views in all places (community, enterprise and addons). Now, it is dynamically verified if the ` 'contract_date_start' ` exists before rendering the button.

task-6519063