### PR TITLE
[FIX] hr_holidays: Selecting time off type no longer triggers an error when creating a time off request via management

### DIFF
--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -282,7 +282,7 @@ been taken for this time off type. Changing it now would affect existing employe
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(work_entry_type):
-            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves)
+            return not work_entry_type.requires_allocation or op(work_entry_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented

--- a/addons/hr_holidays/tests/test_hr_work_entry_type.py
+++ b/addons/hr_holidays/tests/test_hr_work_entry_type.py
@@ -232,3 +232,40 @@ class TestHrWorkEntryType(TestHrHolidaysCommon):
 
         with self.assertRaises(ValidationError):
             work_entry_type.count_days_as = 'working'
+
+    def test_search_virtual_remaining_leaves(self):
+        """Searching by virtual_remaining_leaves should not crash."""
+        leave_type = self.env['hr.work.entry.type'].create({
+            'name': 'Test Leave Virtual Remaining',
+            'code': 'Test Leave Virtual Remaining',
+            'requires_allocation': True,  # required to test the op call
+        })
+
+        # Should not raise
+        self.env['hr.work.entry.type'].search([
+            ('virtual_remaining_leaves', '>', 0),
+        ])
+
+        self.assertIn(
+            'Test Leave Virtual Remaining',
+            self.env['hr.work.entry.type'].search(
+                domain=[('virtual_remaining_leaves', '=', 0)]
+            ).mapped('name')
+        )
+
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Test Allocation',
+            'employee_id': self.employee_hruser_id,
+            'work_entry_type_id': leave_type.id,
+            'number_of_days': 5,
+            'state': 'confirm',
+        })
+
+        allocation.action_approve()
+
+        self.assertIn(
+            'Test Leave Virtual Remaining',
+            self.env['hr.work.entry.type'].with_context(employee_id=self.employee_hruser_id).search(
+                domain=[('virtual_remaining_leaves', '>', 0)]
+            ).mapped('name'),
+        )


### PR DESCRIPTION
Steps to reproduce: Time Off >> Configuration >> Time Off Types >> Open any type, navigate to the Smart button Time Off >> Click on New >> Time Off Type
Reason: Bug was due to the is_valid function calling the operator with only one value instead of two.
Solution: add value to op call


task-6522339