### PR TITLE
[FIX] hr_holidays: on yearly and bi-yearly frequencies, days are clamped to max day of the selected month

### DIFF
--- a/addons/hr_holidays/static/src/components/selection_day_in_month/selection_day_in_month.js
+++ b/addons/hr_holidays/static/src/components/selection_day_in_month/selection_day_in_month.js
@@ -1,0 +1,42 @@
+import { registry } from "@web/core/registry";
+import {
+    SelectionField,
+    selectionField,
+    selectionFieldProps,
+} from "@web/views/fields/selection/selection_field";
+import { useProps } from "@odoo/owl";
+
+function daysInMonth(month) {
+    return new Date(2024, month, 0).getDate();
+}
+
+export class SelectionDayInMonthField extends SelectionField {
+    props = useProps({
+        ...selectionFieldProps,
+        month_field: { type: String, optional: false },
+    });
+
+    get options() {
+        const month_field = this.props.month_field;
+        const month = this.props.record.data[month_field] ?? null;
+        const cap = daysInMonth(month) || 31;
+        const days = [];
+        for (let i = 1; i <= cap; i++) {
+            days.push([i.toString(), i.toString()]);
+        }
+        return days;
+    }
+}
+
+export const selectionDayInMonthField = {
+    ...selectionField,
+    component: SelectionDayInMonthField,
+    
+    extractProps({ options }) {
+        const props = selectionField.extractProps(...arguments);
+        props.month_field = options.month_field;
+        return props;
+    },
+};
+
+registry.category("fields").add("selection_day_in_month", selectionDayInMonthField);

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,29 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day"
+                                        class="o_hr_narrow_field-3" placeholder="select a day"
+                                        widget="selection_day_in_month"
+                                        options="{'month_field': 'first_month'}"
+                                        required="frequency == 'biyearly'"/>
                                     of
                                     <field name="first_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day"
+                                        class="o_hr_narrow_field-3" placeholder="select a day"
+                                        widget="selection_day_in_month"
+                                        options="{'month_field': 'second_month'}"
+                                        required="frequency == 'biyearly'"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day"
+                                        class="o_hr_narrow_field-3" placeholder="select a day"
+                                        widget="selection_day_in_month"
+                                        options="{'month_field': 'yearly_month'}"
+                                        required="frequency == 'yearly'"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_hr_narrow_field-5" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -204,8 +216,11 @@
                                                options="{'links': {'other': 'carryover_custom_date'}, 'observe': 'carryover'}"/>
                                         <span id="carryover_custom_date">
                                             : the
-                                            <field name="carryover_day" placeholder="select a day"
-                                                   required="carryover_date == 'other'"/>
+                                            <field name="carryover_day"
+                                                placeholder="select a day"
+                                                widget="selection_day_in_month"
+                                                options="{'month_field': 'carryover_month'}"
+                                                required="carryover_date == 'other'"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"
                                                    required="carryover_date == 'other'"/>


### PR DESCRIPTION
Steps to reproduce: Possible to have impossible dates like february31 if the day was chosen after the month on yearly and bi-yearly frequencies.
Also added a test to ensure date clamping stays
task-6522773