### PR TITLE
[IMP] hr: made the certificate and study_field fields versioned

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -232,8 +232,8 @@ class HrEmployee(models.Model):
     has_work_permit = fields.Binary(string="Work Permit", groups="hr.group_hr_user")
     work_permit_scheduled_activity = fields.Boolean(default=False, groups="hr.group_hr_user")
     work_permit_name = fields.Char('work_permit_name', compute='_compute_work_permit_name', groups="hr.group_hr_user")
-    certificate = fields.Selection(selection='_get_certificate_selection', string='Certificate Level', groups="hr.group_hr_user", tracking=True)
-    study_field = fields.Char("Field of Study", groups="hr.group_hr_user", tracking=True)
+    certificate = fields.Selection(readonly=False, related="version_id.certificate", inherited=True, groups="hr.group_hr_user")
+    study_field = fields.Char(readonly=False, related="version_id.study_field", inherited=True, groups="hr.group_hr_user")
     emergency_contact = fields.Char(groups="hr.group_hr_user", tracking=True)
     emergency_phone = fields.Char(groups="hr.group_hr_user", tracking=True)
     # HR-only companions for the phone widget; computed apart from work/mobile
@@ -594,16 +594,6 @@ class HrEmployee(models.Model):
     def _compute_age(self):
         for employee in self:
             employee.age = employee._get_age()
-
-    @api.model
-    def _get_certificate_selection(self):
-        return [
-            ('graduate', self.env._('Graduate')),
-            ('bachelor', self.env._('Bachelor')),
-            ('master', self.env._('Master')),
-            ('doctor', self.env._('Doctor')),
-            ('other', self.env._('Other')),
-        ]
 
     @api.depends('version_ids.contract_date_start')
     def _compute_first_contract_date(self):

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -118,6 +118,8 @@ class HrVersion(models.Model):
     spouse_complete_name = fields.Char(string="Spouse Legal Name", groups="hr.group_hr_user", tracking=1)
     spouse_birthdate = fields.Date(string="Spouse Birthdate", groups="hr.group_hr_user", tracking=1)
     children = fields.Integer(string='Dependent Children', groups="hr.group_hr_user", tracking=1)
+    certificate = fields.Selection(selection='_get_certificate_selection', string='Certificate Level', groups="hr.group_hr_user", tracking=True)
+    study_field = fields.Char("Field of Study", groups="hr.group_hr_user", tracking=True)
 
     # Work Information
     department_id = fields.Many2one('hr.department', check_company=True, tracking=1, index=True)
@@ -697,6 +699,16 @@ class HrVersion(models.Model):
                 ("contract_date_end", "=", False),
                 ("contract_date_end", ">=", today),
             ('employee_id', '!=', False),
+        ]
+
+    @api.model
+    def _get_certificate_selection(self):
+        return [
+            ('graduate', self.env._('Graduate')),
+            ('bachelor', self.env._('Bachelor')),
+            ('master', self.env._('Master')),
+            ('doctor', self.env._('Doctor')),
+            ('other', self.env._('Other')),
         ]
 
     def _inverse_resource_calendar_id(self):


### PR DESCRIPTION
In an Employee profile, on the 'Personal' tab there are many fields that are versioned, aka, they are linked to different contracts, so the values can changed or be updated through time. This wasn't the case for the fields 'certificate' and 'study_field', that could benefit from being versioned through different contracts.

To achieve that, the fields were added to the HR Version class/model, following the same patterns for other fields in the same category.

task-6522860
See odoo-dev/enterprise#1474