### PR TITLE
[IMP] l10n_se: always display delivery date on invoice

### DIFF
--- a/addons/l10n_se/models/account_move.py
+++ b/addons/l10n_se/models/account_move.py
@@ -9,6 +9,24 @@ from stdnum import luhn
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
+    def _post(self, soft=True):
+        # EXTENDS 'account'
+        posted = super()._post(soft)
+
+        for move in posted:
+            if move.country_code == 'SE' and move.is_sale_document() and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(move)
+
+        return posted
+
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.country_code == 'SE':
+                move.show_delivery_date = move.is_sale_document()
+
     def _get_invoice_reference_se_ocr2(self, reference):
         self.ensure_one()
         return reference + luhn.calc_check_digit(reference)


### PR DESCRIPTION
New legislation in Sweden requires the delivery date on invoices.

Currently the delivery date appears only in the Other Info tab, and only once it has a value, so Swedish users could post an invoice without setting a delivery date.
Also the fallback for the delivery date when posting should be the invoice date.

task-6517958