### PR TITLE
[IMP] hr_holiday: dynamically disable invalid date options in accrual plan levels.

### DIFF
--- a/addons/hr_holidays/static/src/components/disabled_selection_field/disabled_selection_field.js
+++ b/addons/hr_holidays/static/src/components/disabled_selection_field/disabled_selection_field.js
@@ -1,0 +1,78 @@
+import { registry } from "@web/core/registry";
+import { SelectionField, selectionField, selectionFieldProps } from "@web/views/fields/selection/selection_field";
+import { useProps, t } from "@odoo/owl";
+
+/**
+ * Custom SelectionField component that keeps all selection choices visible in the UI
+ * dropdown menu, but disables choices that are not present in the specified whitelist field.
+ */
+export class DisabledSelectionField extends SelectionField {
+    props = useProps({
+        ...selectionFieldProps,
+        selection_type: t.string(),
+        target_field: t.string(),
+    });
+
+    _getDaysInMonth(year, month) {
+      return new Date(year, month, 0).getDate();
+    }
+
+    _allowedDays(month_val) {
+        const month_int = parseInt(month_val || '1', 10);
+        const max_days = this._getDaysInMonth(2020, month_int);
+        return Array.from({ length: max_days }, (_, i) => String(i + 1));
+    }
+
+    _allowedMonths(day_val) {
+        const day_int = parseInt(day_val || '1', 10);
+        const fieldDef = this.props.record.fields[this.props.name];
+        const month_keys = fieldDef && fieldDef.selection ? fieldDef.selection.map((m) => m[0]) : [];
+
+        return month_keys.filter((m) => {
+            const max_days = this._getDaysInMonth(2020, parseInt(m, 10));
+            return max_days >= day_int;
+        });
+    }
+
+    get _lookup_whitelist_fn() {
+        return {
+            days: (month_value) => this._allowedDays(month_value),
+            months: (day_value) => this._allowedMonths(day_value)
+        }
+    }
+
+    get choices() {
+        const target_field = this.props.target_field;
+        const target_value = target_field ? this.props.record.data[target_field] : null;
+        const selection_type = this.props.selection_type;
+
+        const allowedValues = this._lookup_whitelist_fn[selection_type]?.(target_value) ?? null;
+
+        return this.options.map(([value, label]) => {
+            // check if the choice's value is in the whitelist array in order to enable/disable the selection item associated
+            const isEnabled = allowedValues !== null ? allowedValues.includes(String(value)) : true;
+
+            return {
+                value,
+                label,
+                enabled: isEnabled,
+            };
+        });
+    }
+
+}
+
+export const disabledSelectionField = {
+    ...selectionField,
+    component: DisabledSelectionField,
+
+    extractProps({ options }) {
+        const props = selectionField.extractProps(...arguments);
+        props.selection_type = options.selection_type;
+        props.target_field = options.target_field;
+
+        return props;
+    },
+};
+
+registry.category("fields").add("disabled_selection", disabledSelectionField);

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,19 +36,19 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" widget="disabled_selection" options="{'selection_type': 'days', 'target_field': 'first_month'}" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
-                                    <field name="first_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
+                                    <field name="first_month" widget="disabled_selection" options="{'selection_type': 'months', 'target_field': 'first_month_day'}" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" widget="disabled_selection" options="{'selection_type': 'days', 'target_field': 'second_month'}" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
                                     of
-                                    <field nolabel="1" name="second_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month" widget="disabled_selection" options="{'selection_type': 'months', 'target_field': 'second_month_day'}" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" widget="disabled_selection" options="{'selection_type': 'days', 'target_field': 'yearly_month'}" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
                                     of
-                                    <field nolabel="1" name="yearly_month" class="o_hr_narrow_field-5" required="frequency == 'yearly'" placeholder="select a month"/>
+                                    <field nolabel="1" name="yearly_month" widget="disabled_selection" options="{'selection_type': 'months', 'target_field': 'yearly_day'}" class="o_hr_narrow_field-5" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
                             </span>
                             <span name="yearly_gain" class="text-muted">
@@ -204,10 +204,10 @@
                                                options="{'links': {'other': 'carryover_custom_date'}, 'observe': 'carryover'}"/>
                                         <span id="carryover_custom_date">
                                             : the
-                                            <field name="carryover_day" placeholder="select a day"
+                                            <field name="carryover_day" widget="disabled_selection" options="{'selection_type': 'days', 'target_field': 'carryover_month'}" class="o_hr_narrow_field-3"  placeholder="select a day"
                                                    required="carryover_date == 'other'"/>
                                             of
-                                            <field name="carryover_month" placeholder="select a month"
+                                            <field name="carryover_month" widget="disabled_selection" options="{'selection_type': 'months', 'target_field': 'carryover_day'}" class="o_hr_narrow_field-5"  placeholder="select a month"
                                                    required="carryover_date == 'other'"/>
                                         </span>
                                     </span>


### PR DESCRIPTION
The purpose of this task is to prevent the selection of invalid dates (such as February 31st) in accrual plan levels by adding cross-validation for dependent selection fields.

UX Improvements:
- Add `disabled_selection` OWL widget extending native `SelectionField`. Instead of hiding invalid options, it keeps all choices visible in the UI dropdown while graying out non-allowed choices. The component handles two selection types:
  * Days: restricts available days based on the selected month via `target_field` option (e.g., selecting February grays out days 30 and 31).
  * Months: restricts available months based on the selected day via `target_field` option (e.g., selecting the 31st disables months with fewer days like Feb/Apr/Jun/Sep/Nov).

Task-ID: 6524484