### PR TITLE
[IMP] account: add "In Payment" filter on invoices

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1725,6 +1725,8 @@
                     <separator/>
                     <!-- not_paid & partial -->
                     <filter name="open" string="To pay" domain="[('state', '!=', 'cancel'), ('payment_state', 'in', ('not_paid', 'partial')), ('move_type', '!=', 'entry')]"/>
+                    <!-- in_payment -->
+                    <filter name="in_payment" string="In payment" domain="[('state', '=', 'posted'), ('payment_state', '=', 'in_payment')]"/>
                     <!-- overdue -->
                     <filter name="late" string="Overdue" domain="[
                         ('invoice_date_due', '&lt;', 'today'),


### PR DESCRIPTION
The invoice list has filters for the other payment stages (To pay, Overdue, Paid) but none for invoices whose payment has been registered and is still waiting for the bank reconciliation.

task-6517948