### PR TITLE
[FIX] hr_holidays: improved ux when selecting a month in the accrual plan level view

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -10,6 +10,15 @@ def _get_selection_days(self):
     return [(str(i), str(i)) for i in range(1, 32)]
 
 
+def _get_contrained_selection_days(month):
+    """Obtain the list of days available for a given month."""
+    if month in ['2']:
+        return [str(i) for i in range(1, 29)]
+    if month in ['4', '6', '9', '11']:
+        return [str(i) for i in range(1, 31)]
+    return [str(i) for i in range(1, 32)]
+
+
 class HrLeaveAccrualLevel(models.Model):
     _name = 'hr.leave.accrual.level'
     _description = "Accrual Plan Level"

--- a/addons/hr_holidays/static/src/components/day_selector/day_selector.js
+++ b/addons/hr_holidays/static/src/components/day_selector/day_selector.js
@@ -1,0 +1,67 @@
+import { t, useProps } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import {
+    SelectionField,
+    selectionField,
+    selectionFieldProps,
+} from "@web/views/fields/selection/selection_field";
+
+export const daySelectorFieldProps = {
+    ...selectionFieldProps,
+    dependant: t.string()
+};
+
+export class DaySelector extends SelectionField {
+    props = useProps({
+        ...daySelectorFieldProps
+    });
+
+    getAvailableDays() {
+        const month = this.getMonth(this.props.dependant);
+
+        switch(month) {
+            case '2':
+                return [...Array(29).keys()].map(i => ([String(i + 1), String(i + 1)]));
+            case '4':
+            case '6':
+            case '9':
+            case '11':
+                return [...Array(30).keys()].map(i => ([String(i + 1), String(i + 1)]));
+            default:
+                return [...Array(31).keys()].map(i => ([String(i + 1), String(i + 1)]));
+        }
+    }
+
+    getMonth(variable) {
+        return this.props.record.data?.[variable] || "";
+    }
+
+    /**
+     * @override
+     */
+    get options() {
+        return this.getAvailableDays();
+    }
+}
+
+export const daySelectionField = {
+    ...selectionField,
+    component: DaySelector,
+    displayName: _t("Day Selection"),
+    supportedTypes: ["selection"],
+    supportedOptions: [
+        {
+            label: "Dependant Field",
+            name: "dependant",
+            type: "string",
+        },
+    ],
+    extractProps({ options }) {
+        const props = selectionField.extractProps(...arguments);
+        props.dependant = options.dependant;
+        return props;
+    },
+}
+
+registry.category("fields").add("day_selector", daySelectionField);

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -36,17 +36,17 @@
                                 </span>
                                 <span name="biyearly" invisible="frequency != 'biyearly'">
                                     on the
-                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="first_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'" widget="day_selector" options="{'dependant': 'first_month'}"/>
                                     of
                                     <field name="first_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                     and the
-                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'"/>
+                                    <field nolabel="1" name="second_month_day" class="o_hr_narrow_field-3" placeholder="select a day" required="frequency == 'biyearly'" widget="day_selector" options="{'dependant': 'second_month'}"/>
                                     of
                                     <field nolabel="1" name="second_month" class="o_hr_narrow_field-5" placeholder="select a month" required="frequency == 'biyearly'"/>
                                 </span>
                                 <span name="yearly" invisible="frequency != 'yearly'">
                                     on the
-                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day"/>
+                                    <field nolabel="1" name="yearly_day" class="o_hr_narrow_field-3" required="frequency == 'yearly'" placeholder="select a day" widget="day_selector" options="{'dependant': 'yearly_month'}"/>
                                     of
                                     <field nolabel="1" name="yearly_month" class="o_hr_narrow_field-5" required="frequency == 'yearly'" placeholder="select a month"/>
                                 </span>
@@ -205,7 +205,10 @@
                                         <span id="carryover_custom_date">
                                             : the
                                             <field name="carryover_day" placeholder="select a day"
-                                                   required="carryover_date == 'other'"/>
+                                                    class="o_hr_narrow_field-5"
+                                                    required="carryover_date == 'other'"
+                                                    widget="day_selector"
+                                                    options="{'dependant': 'carryover_month'}"/>
                                             of
                                             <field name="carryover_month" placeholder="select a month"
                                                    required="carryover_date == 'other'"/>


### PR DESCRIPTION
Error was found when both a new accrual plan and its level were being created and selected any option that made it possible to select a month and its day. The error allowed the user to chose dates like '31st of February', '31 of November', etc.

In order to reproduce it, anytime creating/editing a new Accrual Plan and adding or editing a Milestone you could see the inputs presenting the issue based on the 'frequency' in the first line of the 'Accrual Level Options'. Also, in the Primary view of the Accrual Plan, the issue was present on the 'Custom Date' option.

The fix focused on creating a new JS component that registered a new field 'day_selector' that depending on another field containing the month, updates the list of available days to select. If a selected day is out of range for a new selected month, then the last available day in the list is selected

task-6528269