### PR TITLE
[FIX] account_peppol: don't recompute identifier of registered companies

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -231,12 +231,19 @@ class ResPartner(models.Model):
             res._update_peppol_state_per_company()
         return res
 
+    def _get_partners_to_skip_peppol_computation(self):
+        return self.env['res.company'].search([
+            ('account_peppol_proxy_state', 'in', self.env['account_edi_proxy_client.user']._get_can_send_domain()),
+        ]).mapped('partner_id')
+
     def _compute_peppol_endpoint(self):
-        partners_to_recompute = self.browse([partner.id for partner in self if partner._origin not in self])
+        partners_not_to_recompute = self._get_partners_to_skip_peppol_computation()
+        partners_to_recompute = self.browse([partner.id for partner in self if partner._origin not in partners_not_to_recompute])
         super(ResPartner, partners_to_recompute)._compute_peppol_endpoint()
 
     def _compute_peppol_eas(self):
-        partners_to_recompute = self.browse([partner.id for partner in self if partner._origin not in self])
+        partners_not_to_recompute = self._get_partners_to_skip_peppol_computation()
+        partners_to_recompute = self.browse([partner.id for partner in self if partner._origin not in partners_not_to_recompute])
         super(ResPartner, partners_to_recompute)._compute_peppol_eas()
 
     # -------------------------------------------------------------------------

--- a/addons/account_peppol/tests/__init__.py
+++ b/addons/account_peppol/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_peppol_identifier
 from . import test_peppol_kyc
 from . import test_account_journal
 from . import test_peppol_messages

--- a/addons/account_peppol/tests/test_peppol_identifier.py
+++ b/addons/account_peppol/tests/test_peppol_identifier.py
@@ -1,0 +1,32 @@
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestPeppolIdentifier(TransactionCase):
+
+    def test_no_recompute_when_registered(self):
+        """ The Peppol EAS/Endpoint of a company registered on Peppol must not
+            be recomputed when its VAT changes afterwards, as the registered
+            configuration would no longer match the one on the network.
+        """
+        company = self.env.company
+        company.partner_id.country_id = self.env.ref('base.be')
+        company.write({'peppol_eas': '0208', 'peppol_endpoint': '0239843188'})
+        company.account_peppol_proxy_state = 'receiver'
+
+        company.partner_id.vat = 'BE0477472701'
+
+        self.assertEqual(company.peppol_eas, '0208')
+        self.assertEqual(company.peppol_endpoint, '0239843188')
+
+    def test_recompute_when_not_registered(self):
+        """ A company not registered on Peppol keeps the standard behavior:
+            filling the VAT recomputes the endpoint. """
+        company = self.env.company
+        company.partner_id.country_id = self.env.ref('base.be')
+        company.write({'peppol_eas': '0106', 'peppol_endpoint': False})
+        self.assertEqual(company.account_peppol_proxy_state, 'not_registered')
+
+        company.partner_id.write({'peppol_eas': '9925', 'vat': 'BE0477472701'})
+
+        self.assertEqual(company.peppol_endpoint, 'BE0477472701')


### PR DESCRIPTION
When a company registers on Peppol, its EAS/endpoint identifier is committed on the network. If the user later fills or changes the company's VAT, the identifier fields were recomputed, so the configuration shown in Odoo no longer matched the one registered on the network, breaking the Peppol flows.

Skip the recomputation of peppol_eas/peppol_endpoint for partners corresponding to a company whose Peppol registration is active, and add a test covering both the registered and unregistered cases.

task-6517963