### PR TITLE
[IMP] account: new filter for "In Payment" invoices

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1725,6 +1725,9 @@
                     <separator/>
                     <!-- not_paid & partial -->
                     <filter name="open" string="To pay" domain="[('state', '!=', 'cancel'), ('payment_state', 'in', ('not_paid', 'partial')), ('move_type', '!=', 'entry')]"/>
+                    <filter name="in_payment"
+                            string="In payment"
+                            domain="[('state', '=', 'posted'), ('payment_state', '=', 'in_payment')]"/>
                     <!-- overdue -->
                     <filter name="late" string="Overdue" domain="[
                         ('invoice_date_due', '&lt;', 'today'),


### PR DESCRIPTION
The quick filters of the invoices now lack an option to see items which are in-the-payment. We have one for pending payment, those which are overdue, but no for in–payment. So in that regard the filters are not complete in regard to invoice state. This commit fixes that by introducing in-payment filter.
    
tasks-6517870