### PR TITLE
[IMP] hr_expense: warn about similar expenses on the form

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1278,6 +1278,12 @@ class HrExpense(models.Model):
             name=_("Expenses with a similar receipt to %(other_expense_name)s", other_expense_name=self.name),
         )
 
+    def action_show_same_expenses_ids(self):
+        self.ensure_one()
+        return (self.duplicate_expense_ids - self)._get_records_action(
+            name=self.env._("Expenses similar to %(other_expense_name)s", other_expense_name=self.name),
+        )
+
     @api.model
     def get_expense_dashboard(self):
         expense_state = {

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -145,6 +145,9 @@
                 <div class="alert alert-warning oe_edit_only" role="alert" name="warning_duplicate_receipt_expense" invisible="not same_receipt_expense_ids">
                     An <a type="object" name="action_show_same_receipt_expense_ids">expense</a> with the same receipt already exists.
                 </div>
+                <div class="alert alert-warning oe_edit_only" role="alert" name="duplicate_expense_ids" invisible="not duplicate_expense_ids">
+                    A similar <a type="object" name="action_show_same_expenses_ids">expense</a> (same employee, category, date and amount) already exists.
+                </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button name="action_open_split_expense"


### PR DESCRIPTION
The duplicate detection (same employee, category, date and amount) only surfaced as a confirmation dialog when submitting the expense, while the same-receipt detection already shows a warning banner on the form.

task-6517969