### PR TITLE
[IMP] account: in l10n_se display delivery date and set its default value

### DIFF
--- a/addons/l10n_se/models/account_move.py
+++ b/addons/l10n_se/models/account_move.py
@@ -54,6 +54,23 @@ class AccountMove(models.Model):
         self.ensure_one()
         return self._get_invoice_reference_se_ocr4(self.partner_id.ref if str(self.partner_id.ref).isdecimal() else str(self.partner_id.id))
 
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        super()._compute_show_delivery_date()
+
+        for move in self:
+            if move.country_code == 'SE':
+                move.show_delivery_date = move.is_sale_document()
+
+    def _post(self, soft=True):
+        posted = super()._post(soft)
+
+        for move in posted:
+            if move.country_code == 'SE' and move.is_sale_document() and not move.delivery_date:
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
+
+        return posted
+
     @api.onchange('partner_id')
     def _onchange_partner_id(self):
         """ If Vendor Bill and Vendor OCR is set, add it. """


### PR DESCRIPTION
There was a new legislation in Sweden which requires adding delivery date on the invoice. And it needs to be displayed in the head section next to the due date. Thus this change was needed.

This patch mimics other country localizations (like Germany). The due date display is configurable via the `show_delivery_date` field which is used here instead of view change. The default value is also set when move is posted (via `_post` override) to comply with the legislation. As the default value fallback the invoice date is used, however if this is missing (no UI data change can lead to this) the current date is used instead.

tasks-6517880