### PR TITLE
[FIX] account: allowed receipts to use Professional

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3495,7 +3495,7 @@ class AccountMove(models.Model):
         def has_non_deductible_lines(move):
             return (
                 move.state == 'draft'
-                and move.is_purchase_document()
+                and move.is_purchase_document(include_receipts=True)
                 and any(move.line_ids.filtered(lambda line: line.display_type == 'product' and line.deductible_amount < 100))
             )
 

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1610,7 +1610,7 @@ class AccountMoveLine(models.Model):
     @api.constrains('deductible_amount')
     def _constrains_deductible_amount(self):
         for line in self:
-            if not line.move_id.is_purchase_document() and float_compare(line.deductible_amount, 100, precision_digits=2):
+            if not line.move_id.is_purchase_document(include_receipts=True) and float_compare(line.deductible_amount, 100, precision_digits=2):
                 raise ValidationError(_("Only vendor bills allow for deductibility of product/services."))
             if line.deductible_amount < 0 or line.deductible_amount > 100:
                 raise ValidationError(_("The deductibility must be a value between 0 and 100."))

--- a/addons/account/tests/test_account_bill_deductibility.py
+++ b/addons/account/tests/test_account_bill_deductibility.py
@@ -492,3 +492,35 @@ class TestAccountBillPartialDeductibility(AccountTestInvoicingCommon):
             ],
             {}
         )
+
+    def test_simple_receipt_partial_deductibility(self):
+        receipt = self.env['account.move'].create({
+            'move_type': 'in_receipt',
+            'partner_id': self.partner_a.id,
+            'invoice_date': fields.Date.today(),
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'Partial item',
+                    'price_unit': 100,
+                    'quantity': 1,
+                    'deductible_amount': 75.00,
+                    'tax_ids': [Command.set(self.tax_purchase_a.ids)],
+                })
+            ]
+        })
+
+        self.assertInvoiceValues(
+            receipt,
+            [
+                {'display_type': 'product',                      'name': 'Partial item',         'balance': 100.0,  'tax_ids': [self.tax_purchase_a.id]},  # noqa: E241
+                {'display_type': 'non_deductible_product',       'name': 'Partial item',         'balance': -25.0,  'tax_ids': [self.tax_purchase_a.id]},  # noqa: E241
+                {'display_type': 'non_deductible_product_total', 'name': 'private part',         'balance': 25.0,   'tax_ids': []},  # noqa: E241
+                {'display_type': 'non_deductible_tax',           'name': 'private part (taxes)', 'balance': 3.75,   'tax_ids': []},  # noqa: E241
+                {'display_type': 'tax',                          'name': '15%',                  'balance': 11.25,  'tax_ids': []},  # noqa: E241
+                {'display_type': 'payment_term',                 'name': False,                  'balance': -115.0, 'tax_ids': []},  # noqa: E241
+            ],
+            {}
+        )
+
+        receipt.action_post()
+        self.assertEqual(receipt.state, 'posted')


### PR DESCRIPTION
It is actually a plausible accounting situation that we need to partially deduct a ticket/receipt. But curretntly the receipts where not counted as purchase documents, so a validation error is raised by the deductibility constraint.

task-6517924