### PR TITLE
[IMP] hr_expense: added warning for same expense

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1278,6 +1278,12 @@ class HrExpense(models.Model):
             name=_("Expenses with a similar receipt to %(other_expense_name)s", other_expense_name=self.name),
         )
 
+    def action_show_duplicate_expense_ids(self):
+        self.ensure_one()
+        return (self.duplicate_expense_ids - self)._get_records_action(
+            name=self.env._("Expenses with similar details to %(other_expense_name)s", other_expense_name=self.name),
+        )
+
     @api.model
     def get_expense_dashboard(self):
         expense_state = {

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -145,6 +145,9 @@
                 <div class="alert alert-warning oe_edit_only" role="alert" name="warning_duplicate_receipt_expense" invisible="not same_receipt_expense_ids">
                     An <a type="object" name="action_show_same_receipt_expense_ids">expense</a> with the same receipt already exists.
                 </div>
+                <div class="alert alert-warning oe_edit_only" role="alert" name="warning_duplicate_expense" invisible="not duplicate_expense_ids">
+                    An <a type="object" name="action_show_duplicate_expense_ids">expense</a> with the same category, date, amount and employee already exists.
+                </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button name="action_open_split_expense"


### PR DESCRIPTION
Currently duplicate expenses are dedicated based on having the same receipts, but sometimes the duplicate expenses with different imgaes and documents and these goes undetected. A warning is now added to detect duplicates based on category, date, amount and employee

task-6517926