### PR TITLE
[ADD] skills: odoo-git

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,29 @@
+# Odoo's Skill Library
+
+This directory contains a set of useful Skills for agentic development with Odoo.
+
+Skills are structured documentation that can help AI agents achieve some tasks faster
+and more reliably, with less guesswork. Odoo's Skill library includes skills that
+help agents review code, audit it for security, and write it right in the first place.
+
+More about the skill format: https://agentskills.io
+
+## Installation
+
+The installation of the skills consists of copying the content of this directory
+into the correct place, which will depend on which harness you use (claude code,
+copilot-cli, codex, opencode, etc.) and where you launch it from.
+
+The usual location is `.agents/skills/` or `.claude/skills/` at the root of
+the directory where you launch your agent for Odoo development. It is also
+possible to install those skills globally in your agent harness; for that,
+see your harness's own documentation.
+
+Note that all the skills provided must be installed together as they
+reference each other.
+
+## Usage
+
+Once installed, restart your agent session and it should be able to use the
+skills on its own. If you ask it _'Please review this code'_ the agent will
+read the content of the `odoo-review` skill and apply its guidance.

--- a/skills/odoo-git/SKILL.md
+++ b/skills/odoo-git/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: odoo-git
+description: >-
+  Odoo's git conventions: commit message format ([TAG] module: header, a
+  why-first body, reference trailers), which branch a change targets, branch
+  naming, and pull request hygiene. Use when writing or amending a commit
+  message, choosing the branch a fix or feature goes to, or opening or
+  updating a pull request on an Odoo repository.
+---
+
+# Odoo git conventions
+
+These conventions apply to every commit and pull request on an Odoo repository
+(community, enterprise, and their forks). They are house rules, not general git
+advice.
+
+## Commit message
+
+A commit message is a header `[TAG] module: summary`, a blank line, a body that
+says **why** the change is made, and reference trailers last, one per line.
+
+```
+[FIX] library: keep loans visible after a book is archived
+
+Before this commit, archiving a book hid its open loans from the member's
+portal page, because the loan list was searched through the book with the
+default active filter. Members lost track of what they still had to return.
+
+After this commit, the loan list searches loans directly, with
+active_test disabled on the book relation, so an archived book still shows
+its open loans until they are returned.
+
+task-1234
+opw-5678
+```
+
+```
+[IMP] library, *: bugfix and improvements
+
+Fixed the loan list and improved the portal page. Also updated the tests.
+```
+
+The second message fails on every part: the tag does not match the content, the
+header is not a sentence, the body says what instead of why, and nothing links
+it to a task.
+
+### Header
+
+- `[TAG]`, a space, the module's technical name, a colon, a space, then the
+  summary. Several modules: `[FIX] library, portal:`. Many modules: the main
+  one then `*` (`[REF] library, *:`), or `*` alone for a transversal change.
+- The summary completes the sentence "if applied, this commit will ...": an
+  imperative verb, no trailing period, about 50 characters and never past 70.
+  "bugfix", "improvements", "changes" are not summaries.
+- Tags:
+
+  | Tag | Use |
+  | --- | --- |
+  | `[FIX]` | bug fix, in stable or in master |
+  | `[IMP]` | incremental improvement, the default in master |
+  | `[REF]` | refactoring, a feature heavily rewritten |
+  | `[ADD]` | new module |
+  | `[REM]` | removed resources: dead code, views, modules |
+  | `[MOV]` | files or code moved without content change, so history follows |
+  | `[REV]` | revert of an earlier commit |
+  | `[PERF]` | performance |
+  | `[CLN]` | cleanup |
+  | `[LINT]` | lint pass |
+  | `[I18N]` | translation files |
+  | `[REL]` | release |
+  | `[MERGE]` | merge commit |
+  | `[CLA]` | signing the contributor license agreement |
+
+### Body
+
+- Why first: the purpose of the change, what was wrong for whom. The diff
+  already shows what changed; describe the what only for a technical choice,
+  and then say why that choice. "The PO team asked for it" is not a why.
+- "Before this commit, ... After this commit, ..." is a common shape for the
+  why and the outcome; use it when it fits.
+- Wrap at about 72 characters. Be complete rather than short: for most readers
+  the message is the whole change.
+
+### Trailers
+
+- One per line, after the body: `task-123` (task), `opw-123` (support
+  ticket), `runbot-123` (runbot error), `Fixes #123` (a GitHub issue this
+  closes), `Co-authored-by: Name <email>`.
+- Leave the rest to the bots: `closes odoo/odoo#123`, `Signed-off-by`,
+  `Related: odoo/enterprise#123` are added at merge; `X-original-commit`,
+  `Forward-port-of`, `Part-of` by the forward-port bot. Merge, release, and
+  forward-port commits are written by the tooling; keep them as generated.
+
+## Branches and pull requests
+
+- Target: a bug fix goes to the oldest supported stable version that has the
+  bug, never to master; a feature or any unstable change goes to master; a
+  localization goes to either. A fix merged in a stable version is
+  forward-ported to the newer versions by the bots.
+- One pull request per patch: never open the same patch against several
+  branches. If the forward-port needs manual help, do it in the forward-port
+  PR the bot opened.
+- Branch name: `<target>-<topic>-<trigram>` (`19.0-loan-archive-fix-abc`,
+  `master-library-portal-abc`); the bots suffix their forward-ports with
+  `-fw`.
+- One logical change per commit, and one module per commit unless the change
+  is inseparable; a move is its own `[MOV]` commit before the `[REF]` that
+  edits the moved code.
+- Rebase on the target branch before submitting and whenever it conflicts;
+  squash fixups into the commit they fix. A PR carries only the commits that
+  should land, never "address review" commits or merge commits.
+- A change to a stable version follows
+  [0016](../odoo-guidelines/guidelines/0016_stable_changes.md) of
+  odoo-guidelines; a PR description explains why, as the commit message does,
+  and links the task or ticket.
+- A bug fix comes with a test that reproduces it when one is possible.
+- An external contributor signs the CLA in the PR, once.

--- a/skills/odoo-guidelines/AUTHORING.md
+++ b/skills/odoo-guidelines/AUTHORING.md
@@ -1,0 +1,22 @@
+# Adding a guideline
+
+- One numbered file per rule or per domain of conventions, named
+  `guidelines/NNNN_snake_case_title.md`. `NNNN` is the next free number and
+  is never reused, even if a guideline is deleted. It is an identifier, not a
+  priority: the order of the numbers means nothing.
+- Say each rule so that following it is checkable, then why it exists, then
+  the exceptions.
+- Two kinds of file. A convention is a choice that can be stated in one line
+  and followed as stated: 4-space indent, `o_<module>` class prefix.
+  Conventions are bullets, grouped in one file per domain (one kind of file
+  or one topic). A rule needs an explanation to be applied correctly: a why,
+  an example, exceptions. A rule gets its own file: the rule, code that
+  follows it, the same code breaking it, why, then the cases where it does
+  not apply. A convention that keeps being violated despite being loaded has
+  shown it needs the explanation; promote it to a rule file.
+- Examples are schematic: the smallest tree or snippet that carries the
+  concept. Do not copy real code or point at real files or directories;
+  nothing checks them, and a stale reference is worse than none.
+- Add a row to the table in `SKILL.md`. The "Read it when" cell names the
+  files or the activity that should trigger reading the guideline, not every
+  edit of every file.

--- a/skills/odoo-guidelines/SKILL.md
+++ b/skills/odoo-guidelines/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: odoo-guidelines
+description: >-
+  House rules for Odoo addon code: module structure, manifest, Python/ORM,
+  fields, controllers, XML views and data, QWeb reports, access rights and
+  record rules, performance, tests. Use when writing or reviewing any file in
+  an Odoo addon outside static/ (for the JavaScript, Owl templates and SCSS
+  under static/, see odoo-web-guidelines).
+---
+
+# Odoo addon guidelines
+
+House rules for code in Odoo addons (`addons/*` and `odoo/addons/*`).
+Everything an addon ships under `static/` has its own skill:
+`odoo-web-guidelines`.
+
+Each domain lives in its own numbered file in `guidelines/`. The number is
+an identifier, not a priority: no guideline outranks another. Read the ones
+that match the files you are touching.
+
+| Guideline | Read it when |
+| --- | --- |
+| [0001 Module structure & file naming](guidelines/0001_module_structure.md) | creating or moving files in an addon, or adding a module |
+| [0002 Manifest](guidelines/0002_manifest.md) | touching `__manifest__.py` |
+| [0003 Python imports, naming, layout](guidelines/0003_python_conventions.md) | writing Python anywhere in an addon |
+| [0004 ORM idioms & correctness](guidelines/0004_orm.md) | reading/writing records, computes, onchange, constraints, cursors |
+| [0005 Translations](guidelines/0005_translations.md) | user-facing strings in Python |
+| [0006 Fields](guidelines/0006_fields.md) | declaring or modifying field definitions |
+| [0007 Controllers](guidelines/0007_controllers.md) | touching `controllers/` or `@route` |
+| [0008 XML views, actions, data](guidelines/0008_xml_views_data.md) | touching `views/`, `data/`, or any XML records |
+| [0009 QWeb PDF reports](guidelines/0009_qweb_reports.md) | report templates or `_get_report_values` |
+| [0010 Access rights (`ir.access`)](guidelines/0010_security_data.md) | touching `security/` (`ir.access.csv`, groups) |
+| [0012 Performance](guidelines/0012_performance.md) | code that loops over records or queries in a loop |
+| [0013 Tests](guidelines/0013_tests.md) | touching `tests/` |
+| [0014 Inheriting views](guidelines/0014_view_inheritance.md) | extending or overriding an existing view |
+| [0015 Batch ORM calls](guidelines/0015_batch_orm_calls.md) | ORM calls (`create`/`search*`/aggregates) inside a loop |
+| [0016 Changes in a stable version](guidelines/0016_stable_changes.md) | any change targeting a released branch rather than master |
+
+To add or restructure a guideline, follow [AUTHORING.md](AUTHORING.md).

--- a/skills/odoo-guidelines/guidelines/0001_module_structure.md
+++ b/skills/odoo-guidelines/guidelines/0001_module_structure.md
@@ -1,0 +1,23 @@
+# Module structure & file naming
+
+- Standard directories: `models/`, `views/`, `controllers/`, `data/`,
+  `security/`, `static/`, and optional `wizard/`, `report/`, `tests/`,
+  `populate/`.
+- One model class per file, named after the model with dots as underscores
+  (`res_partner.py`), whether the class defines a new model or extends an
+  existing one with `_inherit`.
+- Suffix conventions: backend views `*_views.xml`, portal/QWeb pages
+  `*_templates.xml`, menus optional `*_menus.xml`, data `*_data.xml`, demo
+  `*_demo.xml`, wizards `<transient>.py` + `<transient>_views.xml`.
+- Security files: access rows in `security/ir.access.csv`; groups and other
+  security records in `security/<module>_security.xml`.
+- Controllers: feature-named files, or `<inherited_module>.py` when extending
+  another module's controller (e.g. `portal.py`); `main.py` is legacy (still
+  widespread in core).
+- Reports: a statistics (SQL-view) report is `<model>_report.py` +
+  `<model>_report_views.xml`; a printable report splits `<model>_reports.xml`
+  (report actions, paperformat) from `<model>_templates.xml` (QWeb templates).
+- `populate/` holds `populate.blueprint` XML records (`populate_demo.xml`,
+  `benchmarks.xml`); an `__init__.py` makes it an importable package for
+  custom populate generators.
+- File and directory names are Python identifiers: lowercase, `[a-z0-9_]`.

--- a/skills/odoo-guidelines/guidelines/0002_manifest.md
+++ b/skills/odoo-guidelines/guidelines/0002_manifest.md
@@ -1,0 +1,17 @@
+# Manifest (`__manifest__.py`)
+
+- `name` is required; `version` should follow semantic versioning.
+- `depends` lists every module whose features or resources are used, direct
+  dependencies only. Don't list `base`: a manifest without `depends` gets
+  `['base']` injected, and upgrading `base` upgrades every installed module
+  whether or not it lists it.
+- `data` files are always installed/updated; `demo` files load only in demo
+  mode. Keep load order correct (a record's dependencies first).
+- `license` defaults to `LGPL-3`; set it deliberately and correctly.
+- `auto_install` is only for "link" modules (installed automatically when their
+  dependencies are); it can also be a *subset* of `depends` that triggers the
+  auto-install (an empty list: always installed).
+- `application` is `True` only for full apps, not technical modules.
+- Declare non-Odoo requirements in `external_dependencies` (`python`/`bin`).
+- `assets` declares how static files load into bundles (don't register assets
+  ad-hoc elsewhere).

--- a/skills/odoo-guidelines/guidelines/0003_python_conventions.md
+++ b/skills/odoo-guidelines/guidelines/0003_python_conventions.md
@@ -1,0 +1,30 @@
+# Python imports, naming, and model layout
+
+PEP 8 applies; the `ruff.toml` at the repository root is the reference for what
+is enforced.
+
+## Imports
+
+- Four groups, each alphabetically sorted (the ruff isort order):
+  1. stdlib
+  2. third-party libs
+  3. `odoo` submodules (`from odoo import Command, api, fields, models`)
+  4. `odoo.addons.*` (rarely, only if necessary)
+
+## Naming & method conventions
+
+- Model `_name`: dotted, prefixed by module, **singular** (`sale.order`, not
+  `sale.orders`). Transient/wizard: `<base_model>.<action>` (avoiding the word
+  "wizard" is a soft preference — core ships many `.wizard` names). SQL-view report model: `<base_model>.report.<action>`.
+- A variable holding a model class is PascalCase (`Partner =
+  self.env['res.partner']`). Suffix a var holding a record id / list of ids
+  with `_id` / `_ids` (don't name a `res.partner` record `partner_id`).
+- Method-name patterns: compute `_compute_<field>`, search `_search_<field>`,
+  default `_default_<field>`, selection `_selection_<field>`, onchange
+  `_onchange_<field>`, constraint `_check_<name>`, object action `action_*`
+  (acts on one record — start it with `self.ensure_one()`).
+- Model body order: private attrs (`_name`, `_description`, `_inherit`) → default
+  methods → field declarations → `models.Constraint`/`models.Index` attributes
+  (core also places these right after the private attrs) → compute/inverse/search
+  (field order) → selection methods → `@api.constrains`/`@api.onchange` → CRUD
+  overrides → action methods → other business methods.

--- a/skills/odoo-guidelines/guidelines/0004_orm.md
+++ b/skills/odoo-guidelines/guidelines/0004_orm.md
@@ -1,0 +1,42 @@
+# ORM idioms & correctness
+
+- Use recordset methods (`filtered`, `grouped`, `mapped`, `sorted`) where they
+  read better than a loop.
+- Recordsets/collections are booleans: write `if records:` / `if some_list:`,
+  not `if len(...)`.
+- `create` must accept a list of vals (`@api.model_create_multi`); don't call
+  `create` per record in a loop (see [0015](0015_batch_orm_calls.md)).
+- `@api.depends` must list **every** field the compute reads; stored computes
+  need correct dependencies and no side effects.
+- `@api.onchange` is UI-only — never rely on it for data integrity; enforce
+  invariants with `@api.constrains` or SQL constraints declared as model
+  attributes (`_x_check = models.Constraint("CHECK (...)", "msg")`; the
+  attribute name must start with `_`). Indexes are declared the same way
+  (`_x_index = models.Index(...)`, `models.UniqueIndex(...)`). Flag
+  `_sql_constraints`: on master it is **ignored** with a log warning, the
+  constraint is never created.
+- Methods are private (`_` prefix) by default. A public name is an RPC entry
+  point: make one only when it must be callable from outside, and decorate
+  with `@api.private` a public name that must not be exposed.
+- Combine domains with `odoo.fields.Domain`: the `&`, `|`, `~` operators for
+  domains written inline, `Domain.AND`/`Domain.OR` for a list of domains you
+  already hold. Never hand-build `'&'`/`'|'` prefix-notation lists.
+- Propagate context with `with_context(...)` (it's a frozendict, immutable);
+  name custom context keys carefully and prefix module-specific ones (a stray
+  `default_<field>` in context leaks into unrelated `create` calls).
+- Logic that another module actually overrides goes in its own small method
+  (`self._get_partner_domain()`); other modules extend methods, not lines.
+  Don't pre-split for extension points that don't exist yet.
+- Don't read a non-relational field on a multi-record set (it raises) — iterate
+  or `mapped`. Conversely, guard single-record assumptions with `ensure_one()`.
+- Delegation inheritance (`_inherits`) inherits fields but **not** methods; avoid
+  it where you can (chained `_inherits` is unsupported).
+- Don't use `odoo.http.request` in models: it is absent in crons, RPC, tests
+  and the shell. Pass what the model needs in from the controller.
+- **Never** call `cr.commit()` / `cr.rollback()` unless you opened your own
+  cursor; the framework owns the transaction. Any unavoidable commit needs an
+  explicit comment justifying it.
+- Catch **specific** exceptions over the smallest possible block; let unexpected
+  ones propagate to the framework. To recover from framework exceptions, wrap the
+  work in `with self.env.cr.savepoint():` (note: >64 savepoints per transaction
+  degrades PostgreSQL — bound batch sizes).

--- a/skills/odoo-guidelines/guidelines/0005_translations.md
+++ b/skills/odoo-guidelines/guidelines/0005_translations.md
@@ -1,0 +1,47 @@
+# Translations with `_()`
+
+Translate only **static literals**, passing interpolation values as
+arguments; in model code the current API is `self.env._(...)`.
+
+```python
+# good
+raise UserError(self.env._("Record %s cannot be modified", record.display_name))
+
+# good — several variables: name them so translators keep them straight
+msg = self.env._("%(count)s records imported by %(user)s", count=len(records), user=user.name)
+
+# good — a list argument is formatted per language ("a, b and c")
+raise UserError(self.env._("Missing fields: %s", missing_names))
+
+# bad — formats before the lookup: the dynamic string matches no exported term
+raise UserError(self.env._("Record %s cannot be modified" % record.display_name))
+
+# bad — formats after the lookup: bypasses placeholder validation and reordering
+raise UserError(self.env._("Record %s cannot be modified") % record.display_name)
+
+# bad — manual join ignores the user's language and its list rules
+raise UserError(self.env._("Missing fields: %s", ", ".join(missing_names)))
+```
+
+## Why
+
+- Translations are keyed on the exact source literal, at export (building the
+  `.pot`) and at runtime lookup. Concatenation, f-strings, or `%`-formatting
+  inside `_()` produce strings that exist in neither.
+- Named placeholders let translators reorder words per language; passing them
+  as `_()` arguments lets the framework validate them per translation and
+  apply Markup-aware escaping (post-lookup `%` formatting loses that safety).
+
+## Exceptions & notes
+
+- Bare `_` (imported from `odoo`) is the backward-compatible API: it locates
+  the environment by inspecting the caller's frame; in plain functions and
+  comprehensions it silently returns the untranslated (or wrong-language)
+  string with only a logged warning — prefer `self.env._`.
+- Never call `_()` at module or class level — it runs at import time with no
+  user language and silently doesn't translate. Translate inside the method
+  when you can; if a module-level constant is unavoidable, make it lazy
+  (`_lt = LazyTranslate(__name__)`; `LABEL = _lt("...")`) and resolve it where
+  the language is known, by passing it through `self.env._(LABEL)`.
+- Field *values* are translated via the field's `translate` flag, never `_()`.
+- Prefer `%`-style placeholders over `.format()`.

--- a/skills/odoo-guidelines/guidelines/0006_fields.md
+++ b/skills/odoo-guidelines/guidelines/0006_fields.md
@@ -1,0 +1,27 @@
+# Fields
+
+- Relational suffixes: `Many2one` → `_id`, `One2many`/`Many2many` → `_ids`.
+- `index=True` on fields that are both searched and selective (many distinct
+  values). An index on a low-cardinality field — a boolean, a state — is wasted
+  space and slows every write. `index` also accepts
+  a type (`'btree_not_null'`, `'trigram'` for `like` searches); multi-column or
+  custom indexes are model attributes (`_x_idx = models.Index("(a, b)")`,
+  `models.UniqueIndex`; the attribute name must start with `_`).
+- Restrict sensitive fields with the `groups` attribute (comma-separated external
+  ids); restricted fields are dropped from views and `fields_get`, and raise on
+  direct read/write.
+- Check relational definitions: correct `comodel_name`, sensible `ondelete`,
+  `required`, and a currency companion for monetary fields.
+- Use **reserved** fields for their built-in behavior rather than reinventing
+  them: `active` for archiving (via `action_archive`, not a custom boolean),
+  `state` for lifecycle, `parent_id` + `parent_path` (`index=True`, with
+  `_parent_store`) for trees, `company_id` for multi-company (consistency via
+  `_check_company`). Keep `_log_access` enabled on a `TransientModel`.
+- A field and a method can't share a name (same namespace) — flag collisions.
+- `related` fields can't chain `One2many`/`Many2many` in the dependency path —
+  the ORM does not reject it, it *silently truncates each x2many hop to its
+  first record* and returns wrong data; reach the target through a `Many2one`
+  (ending the chain on an x2many is fine). Reusing one compute for several
+  fields is fine; reusing one **inverse** is discouraged — while the inverse
+  runs, every field sharing it is protected and reads as `False` when not
+  cached, so the method sees wrong sibling values.

--- a/skills/odoo-guidelines/guidelines/0007_controllers.md
+++ b/skills/odoo-guidelines/guidelines/0007_controllers.md
@@ -1,0 +1,14 @@
+# Controllers (HTTP routes)
+
+- Routes are methods decorated with `@route` on a `http.Controller` subclass.
+  Always re-decorate an **override** with `@route` (an undecorated override
+  still works — the framework auto-decorates it and logs a warning). An empty
+  `@route()` keeps the parent's arguments and any argument overrides the
+  parent's — except `type`, which an override can never change (ignored with
+  a warning; loosening `readonly` is likewise reverted).
+- Set the right `auth` on each route (`user`, `bearer`, `public`, or `none`):
+  a `public` route must not expose internal data or perform privileged writes
+  (see the `odoo-security` skill). `auth='bearer'` requires `bearer_scope`
+  (which is only valid there).
+- Route `type` is `'http'`, `'jsonrpc'`, or `'json2'` — `type='json'` is a
+  deprecated 19.0 alias of `'jsonrpc'`.

--- a/skills/odoo-guidelines/guidelines/0008_xml_views_data.md
+++ b/skills/odoo-guidelines/guidelines/0008_xml_views_data.md
@@ -1,0 +1,21 @@
+# XML — views, actions, data
+
+- Record format: put `id` before `model`; inside a `field`, `name` first, then
+  the value (tag body or `eval`), then other attributes by importance. Group
+  records by model.
+- Prefer the syntactic-sugar tags `<menuitem>`, `<template>`, and `<asset>`
+  over raw `<record>`. Trap: an `active` attribute on `<template>`/`<asset>`
+  is applied at record creation and module *install/re-install* (`-i`) only —
+  a module **update** (`-u`) updates the arch but never changes `active`, so
+  it can't deactivate an already-installed record.
+- `<data noupdate="1">` only for non-updatable data; if the whole file is
+  noupdate, set `noupdate="1"` on `<odoo>` and drop `<data>`.
+- XML id patterns: view `<model>_view_<type>` (`form`/`list`/`kanban`/`search`),
+  action `<model>_action[_<detail>]`, window-action view
+  `<model>_action_view_<type>`, menu `<model>_menu[_<do_stuff>]`, group
+  `<module>_group_<name>`, rule `<model>_rule_<group>`. The record `name` mirrors
+  the id with dots instead of underscores; actions get a real display name.
+- CSS classes in views and templates: prefix with `o_<module>` (`o_` alone is
+  reserved for the web client), never style through ids, and keep names flat
+  (`o_element_entry`) rather than mirroring the DOM nesting.
+- Inheriting a view: see [0014](0014_view_inheritance.md).

--- a/skills/odoo-guidelines/guidelines/0009_qweb_reports.md
+++ b/skills/odoo-guidelines/guidelines/0009_qweb_reports.md
@@ -1,0 +1,10 @@
+# QWeb reports (PDF)
+
+- A custom report's `_get_report_values` must add the default `docs` / `doc_ids`
+  / `doc_model` itself if the template needs them — they are not auto-included.
+- For translated reports use `t-lang` — it is only valid on a node that also
+  carries `t-call` (anywhere else QWeb raises a `SyntaxError` at template
+  compile time); to translate part of a report,
+  extract that part into its own template and `t-call` it with `t-lang`. Only
+  re-browse records in the target language when the template reads
+  translatable fields (otherwise it is a needless performance cost).

--- a/skills/odoo-guidelines/guidelines/0010_security_data.md
+++ b/skills/odoo-guidelines/guidelines/0010_security_data.md
@@ -1,0 +1,25 @@
+# Access rights (`ir.access`)
+
+Master unifies the old `ir.model.access` ACLs and `ir.rule` record rules into
+a single `ir.access` model, declared in `security/ir.access.csv` with columns
+`id,name,model_id,group_id/id,operation,domain`.
+
+- `operation` is required: a subset of `crud` letters (`r`, `cru`, `crud`, …);
+  a row applies to exactly the operations it lists. The optional `domain`
+  restricts the row to matching records (what record rules used to do).
+- Rows **with** a group are *permissions*: OR-ed together (union over the
+  user's groups); a row's domain limits only what that row grants. Rows
+  **without** a group are *restrictions*: AND-ed onto **every** user — they
+  never grant anything, and non-overlapping restrictions can lock everyone
+  out.
+- Default deny: a model with no permission row is inaccessible. Granting to
+  everyone (portal/public included) is done via `base.group_everyone` — flag
+  any `c`/`u`/`d` granted to `base.group_everyone`, `base.group_portal`, or
+  `base.group_public`.
+- Multi-company models need a group-less restriction row with a company
+  domain — `"[('company_id', 'in', company_ids)]"` (`company_ids` evaluates to
+  the user's allowed companies; append `+ [False]` when the company is
+  optional).
+
+For auditing beyond the data files (`sudo()`, SQL, public methods, …), use the
+`odoo-security` skill.

--- a/skills/odoo-guidelines/guidelines/0012_performance.md
+++ b/skills/odoo-guidelines/guidelines/0012_performance.md
@@ -1,0 +1,13 @@
+# Performance
+
+- **Batch, don't loop queries.** Don't call `search`, `search_count`,
+  `_read_group` or `create` inside a loop — each one is a query. Batch before
+  the loop and look results up in a dict; see [0015](0015_batch_orm_calls.md).
+- Put conditions in the search domain, not in `filtered()` on the result:
+  `filtered` runs in Python on records already fetched. Reserve it for
+  predicates a domain cannot express.
+- **Reduce complexity.** Pre-map results into a dict (`{r['id']: r}`) instead of
+  nested loops; cast membership-test collections to `set` (or use recordset
+  arithmetic like `self - invalid`) to avoid O(n²).
+- Index searched fields (`index=True`) — selectively, per
+  [0006](0006_fields.md).

--- a/skills/odoo-guidelines/guidelines/0013_tests.md
+++ b/skills/odoo-guidelines/guidelines/0013_tests.md
@@ -1,0 +1,29 @@
+# Tests
+
+- Use `TransactionCase` (or `HttpCase` for web); start new business tests from
+  `odoo.addons.base.tests.common.BaseCommon` (independent non-admin user and
+  company, mail side effects disabled), or
+  `TransactionCaseWithUserDemo`/`HttpCaseWithUserDemo` when demo data is
+  needed (it is not guaranteed present). Assert behavior, not implementation.
+- Tests are tagged `standard` and `post_install` by default (fully-loaded
+  registry); set exactly one of `at_install`/`post_install` — the check is
+  only a log warning, and *both* tags makes the class run twice while
+  *neither* makes it never run. Opt into
+  `@tagged('at_install', '-post_install')` only when the test must run before
+  other modules load, with a comment justifying it — `at_install` prevents
+  runbot parallelization, and an `HttpCase` must stay `post_install`. Tests
+  run only for installed modules.
+- Silent skips: a test file must be named `test_*.py` **and** imported from
+  `tests/__init__.py`; the test class must be *defined* in that file (a class
+  merely imported into it is skipped); and inherited `test_*` methods are not
+  collected — a subclass defining no tests of its own runs nothing unless it
+  sets `allow_inherited_tests_method = True`.
+- `assertQueryCount` only when strictly necessary, and never inside a business
+  test: it breaks on any unrelated ORM change. Keep it to dedicated
+  performance tests, paired with `@warmup` (and `@users`); only *exceeding*
+  the budget fails — a lower count merely logs, so keep budgets exact.
+- Wrap expected-error and warning logs in `mute_logger(...)` so the expected
+  ERROR or WARNING never reaches the runbot log.
+- Tours: a step that triggers a page unload must set `expectUnloadPage: true`,
+  and the last step must leave the client in a stable state (no pending edits
+  or in-flight requests) to avoid teardown race conditions.

--- a/skills/odoo-guidelines/guidelines/0014_view_inheritance.md
+++ b/skills/odoo-guidelines/guidelines/0014_view_inheritance.md
@@ -1,0 +1,44 @@
+# Inheriting views
+
+Anchor a view inheritance on a **stable, identifying attribute** — an
+element's `name` — never on document position.
+
+```xml
+<!-- good — the shorthand: a field locator matches by name alone -->
+<field name="partner_id" position="after">
+    <field name="delivery_instructions"/>
+</field>
+
+<!-- good — xpath when the shorthand can't express the match -->
+<xpath expr="//page[@name='other_information']//field[@name='user_id']" position="attributes">
+    <attribute name="readonly">1</attribute>
+</xpath>
+
+<!-- bad — breaks as soon as the parent view inserts or reorders anything -->
+<xpath expr="//group[2]/field[3]" position="after">
+    <field name="delivery_instructions"/>
+</xpath>
+```
+
+Shorthand matching is asymmetric: a `field` element matches the first field
+with the same `name` — in document order at **any** depth (use xpath when the
+name recurs in an embedded subview), other locator attributes ignored. Any
+**other** tag matches the first node with the same tag carrying all the
+locator's attributes with equal values (`position` excepted); extra attributes
+on the target are fine.
+
+## Why
+
+- The parent view belongs to another module that changes it freely; a
+  positional match silently lands the change on the wrong element or raises
+  at install on every parent reorganization.
+- The shorthand form reads as "this element, changed", and fails loudly if
+  the anchor disappears.
+
+## Record conventions
+
+- An inheriting view reuses the **same xml id** as the original record; its
+  `name` carries an `.inherit.<details>` suffix.
+- A new **primary** view (a variant, not an extension) sets `mode="primary"`
+  and needs no inherit suffix.
+- Don't re-add fields the parent view already renders.

--- a/skills/odoo-guidelines/guidelines/0015_batch_orm_calls.md
+++ b/skills/odoo-guidelines/guidelines/0015_batch_orm_calls.md
@@ -1,0 +1,44 @@
+# Batch ORM calls
+
+Make **one** ORM call for the whole collection; an ORM call inside a
+`for` loop over records or vals is a query per iteration.
+
+```python
+# bad — one INSERT round-trip per record
+for vals in vals_list:
+    self.env['library.book'].create(vals)
+
+# good — one batched create (and decorate overrides with @api.model_create_multi)
+self.env['library.book'].create(vals_list)
+```
+
+```python
+# bad — one aggregate query per author
+for author in authors:
+    author.book_count = Book.search_count([('author_id', '=', author.id)])
+
+# good — one grouped query, then a dict lookup
+counts = {
+    author.id: count
+    for author, count in Book._read_group(
+        [('author_id', 'in', authors.ids)], ['author_id'], ['__count'],
+    )
+}
+for author in authors:
+    author.book_count = counts.get(author.id, 0)
+```
+
+## Why
+
+- Each call is a full round-trip (Python → SQL → Python); a loop turns O(1)
+  queries into O(n) and dominates response time on real data volumes.
+- Reading fields batches too: iterate a recordset (or `browse` all ids
+  first) and the ORM prefetches each field for the whole set in one query —
+  a record-by-record `browse(id)` loop defeats the prefetch.
+
+## Exceptions
+
+- A loop that only computes in memory on already-read fields is fine — the
+  rule is about calls that hit the database.
+- When a per-record call is truly unavoidable (e.g. an external API per
+  record), bound the batch size.

--- a/skills/odoo-guidelines/guidelines/0016_stable_changes.md
+++ b/skills/odoo-guidelines/guidelines/0016_stable_changes.md
@@ -1,0 +1,26 @@
+# Changes in a stable version
+
+A stable version is any released branch (`17.0`, `18.0`, ...): only bug fixes and
+localizations go there; improvements and features go to master, and an LTS fix is
+forward-ported by the maintainers, never re-submitted per branch.
+
+- Value over risk: keep the change minimal and strictly about the bug. If the risk is
+  high or the value low, it belongs in master, not in stable.
+- No improvements, technical or functional, and no purely cosmetic changes
+  (formatting, PEP 8, restyling). Match the surrounding code's style.
+- Public model methods (no `_` prefix) are API for integrators: never change their
+  signature. Avoid changing private signatures too, extension modules override them.
+- No data-model change: stored columns are never added, removed, or changed to an
+  incompatible type. Compatible tweaks (`ondelete`, `size`) are allowed when needed;
+  a non-stored computed field may be added if really necessary.
+- Keep XML ids of existing data, and don't delete data records that user data may
+  reference, unless essential and the records were `noupdate` from the start.
+- Change XML (views, menus, default data) only when inevitable, and then the Python
+  code must not depend on the change: a database that has not been updated must
+  keep working.
+- A fix may need an explicit module update as long as users who don't run it are
+  safe. A critical security fix must work with a pull and restart alone.
+- Don't modify existing translatable source terms, even for a typo; that breaks
+  existing translations. Correct a term in master, or add an English-to-English
+  translation in stable. Adding or deleting terms is fine; don't ship `.pot`
+  updates, they are exported and synced automatically.

--- a/skills/odoo-review/SKILL.md
+++ b/skills/odoo-review/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: odoo-review
+description: >-
+  Review Odoo addon code against the house rules, dispatching each changed
+  file to the matching odoo-guidelines, odoo-web-guidelines, and
+  odoo-security material. Use when reviewing a diff, commit, PR, or module.
+---
+
+# Reviewing Odoo code
+
+Review against Odoo's framework conventions, not generic Python style alone.
+Flag issues with file/line and a concrete fix; do not auto-fix anything
+ambiguous.
+
+## Process
+
+- Read the module's `__manifest__.py` first to understand scope and `depends`.
+- For each changed file, read the guidelines that match it and apply every
+  rule that fits:
+  - [`odoo-guidelines`](../odoo-guidelines/SKILL.md) — module structure,
+    manifest, Python/ORM, fields, controllers, XML, access rights,
+    performance, tests; its table maps file types to guideline files.
+  - [`odoo-web-guidelines`](../odoo-web-guidelines/SKILL.md) — everything
+    under `static/`: JavaScript, Owl templates, SCSS.
+- If the diff touches controllers, access rules (`ir.access` records), `sudo()`, raw SQL,
+  `eval`, or public/RPC-callable methods, also apply the
+  [`odoo-security`](../odoo-security/SKILL.md) skill.
+- **Stable vs master.** In a *stable* version, the existing file style
+  supersedes the guidelines — never restyle existing code; keep the diff
+  minimal, and check the change against
+  [0016](../odoo-guidelines/guidelines/0016_stable_changes.md). In *master*,
+  apply guidelines to new code, or to existing code only when a file is under
+  major change (do a separate *move* commit first).
+- **Version traps.** Odoo's ORM and view/template syntax change between major
+  versions (`attrs=`, `<tree>`, `name_get`, `read_group` are all gone from
+  recent versions). Before flagging — or writing — an API or attribute,
+  confirm it exists in this checkout (`git grep` the ORM source or a current
+  usage); don't trust a remembered API.
+
+## Code the diff never shows
+
+Odoo modules extend each other: any method can be overridden by another module,
+and any field, XML id, or view element can be referenced by one, including
+modules outside this repository (enterprise, customer addons). A change in
+behaviour, signature, or name can therefore break code that is not in the diff.
+
+- For each changed method, `git grep "def <name>("` across every addons path
+  available, and read the overrides: do they still call `super()` with valid
+  arguments, and does the new behaviour hold with their additions?
+- For each renamed or removed field, XML id, or method, grep for its name in
+  Python, XML, and JavaScript; a stale reference in a view or a domain fails
+  only at runtime.
+- In a stable version, treat a signature change as a bug on its own (see
+  [0016](../odoo-guidelines/guidelines/0016_stable_changes.md)).
+
+Checking the guidelines and the code around the diff is the floor of a review,
+not the end of it. Then review the change on its merits as you would any code.

--- a/skills/odoo-security/SKILL.md
+++ b/skills/odoo-security/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: odoo-security
+description: >-
+  Security audit of Odoo addon code: access control (ir.access, field groups,
+  sudo), injection (SQL, domain, eval, XSS via Markup/markup()), untrusted
+  public methods/RPC,
+  controller auth/CSRF, file access, deserialization, returning complex
+  objects, getattr/setattr, timing attacks. Use when auditing an addon, or
+  judging whether a specific construct (a sudo, raw SQL, a route, …) is safe.
+---
+
+# Security audit of Odoo code
+
+Audit Odoo addons for the framework-specific ways access control and injection
+go wrong. When a feature needs more access than the rules give, it gets the
+minimum, in the narrowest scope, with a comment saying why; a silent widening
+(a bare `sudo()`, a loosened access row) is a finding.
+
+## Process
+
+- Review the `security/` data files against [Access control](#access-control).
+- Sweep the addon for every pattern in the table below; judge each hit against
+  its section. A hit is not a finding by itself — the sections say what makes
+  it one.
+- Report each finding with severity, exact file/line, and a minimal fix.
+
+The audit is complete when every pattern has been swept and every hit judged.
+
+| Sweep for | Judge against |
+| --- | --- |
+| `sudo(`, `with_user(`, `with_company(` | [Don't over-sudo](#dont-over-sudo) |
+| `cr.execute`, `SQL(`, `.format`/`%`/f-string near SQL | [Use the ORM; parameterize SQL](#use-the-orm-parameterize-sql) |
+| domain built from request, RPC, or stored field values | [Domain injection](#domain-injection) |
+| public (non-`_`) model methods | [Default to private methods](#default-to-private-methods) |
+| `@http.route(`, bare `@route(` | [Routes: auth, POST, CSRF](#routes-auth-post-csrf) |
+| `innerHTML`, `insertAdjacentHTML`, `markup(` (JS), `Markup(` (Python), `t-raw` (dead code) | [Prevent XSS](#prevent-xss-escape-on-the-way-into-the-dom) |
+| password/token/secret fields | [Field-level access](#field-level-access) |
+| `related=` crossing models (sudo-computed by default) | [Field-level access](#field-level-access) |
+| `open(` | [Open files with `file_open`](#open-files-with-file_open-not-open) |
+| `eval(`, `exec(`, `safe_eval` | [`eval` is evil](#eval-is-evil) |
+| `pickle` | [Never `pickle`](#never-pickle) |
+| `getattr(`, `setattr(` on records | [`getattr`/`setattr`](#getattrsetattr-are-not-your-friends) |
+| `==` comparing a secret/token | [Timing attacks](#timing-attacks) |
+| `def f(..., x=[])` / `x={}` | [Mutable default arguments](#mutable-default-arguments) |
+| methods returning rich objects | [Don't return complex objects](#dont-return-complex-objects-from-model-methods) |
+
+## Access control
+
+Mechanics of `ir.access` rows and field `groups` are in the `odoo-guidelines`
+skill ([0010](../odoo-guidelines/guidelines/0010_security_data.md),
+[0006](../odoo-guidelines/guidelines/0006_fields.md)); audit `security/` with
+the attacker's reading:
+
+- Flag any `c`/`u`/`d` operation granted to `base.group_everyone`,
+  `base.group_portal`, or `base.group_public`; scrutinize even `r` on models
+  holding personal or business-sensitive data.
+- A permission row's `operation` set is what it grants; a *restriction*
+  (group-less) row covering only some operations leaves the others governed by
+  the permission rows alone — if any permission grants `write`, an attacker
+  can alter records the read restriction hides (`write` checks write access
+  only, never read). Cover **all** CRUD operations that need restricting.
+- Multi-company models need a company restriction row; sensitive models need
+  domain restrictions, not just group permissions.
+
+## Field-level access
+
+- A field's `groups` attribute removes it from views and `fields_get` and
+  raises on explicit read/write. Use it for sensitive fields instead of
+  relying on the UI to hide them.
+- **Passwords and API tokens**: restrict them with `groups="base.group_system"`,
+  or `groups=fields.NO_ACCESS` to hide the field from everyone, admins
+  included. A token field on a model with a permissive access row is readable
+  by any user via `search_read`.
+- **`related` fields are sudo-computed by default** (`related_sudo=True`): a
+  related field reaching sensitive data through a user-writable `Many2one`
+  lets the user point the M2o at an arbitrary record and read the related
+  value with elevated rights — set `related_sudo=False` on sensitive chains.
+  (`readonly=False` write-through is a separate concern: it runs in the
+  user's environment and is access-checked.)
+
+## Default to private methods
+
+- **Any public method is callable via RPC** with attacker-chosen arguments;
+  the records in `self` and the parameters **cannot be trusted** (access
+  control is only enforced on CRUD, not method calls). More public methods =
+  bigger attack surface. **Prefix methods with `_` by default**; drop the `_`
+  only when the method is genuinely meant to be called externally — and then
+  validate inputs. (Privacy alone isn't a control: a `_`-method fed untrusted
+  data is still dangerous.)
+- The RPC guard (`get_public_method`) blocks `_`-prefixed names,
+  classmethods/staticmethods, and anything decorated `@api.private` anywhere
+  in the MRO — check that before flagging a public-named method as exposed;
+  `@api.private` is the sanctioned fix when renaming would break callers.
+
+## Use the ORM; parameterize SQL
+
+- Never use the cursor directly when the ORM can do it: raw SQL bypasses
+  access control, translations, field invalidation, and `active` handling.
+  Prefer `search`/`_read_group` and direct field access (not `read()`). For
+  custom SQL over ORM-filtered rows, build the query with `_search(...)` and
+  `Query.select(SQL(...))`: access rules and `active` handling stay in force.
+- When you must write SQL, **never** interpolate with `+`/`%`/`.format`. Pass
+  values as **parameters** (psycopg2 formats them, including a tuple for
+  `IN %s`), or use the `odoo.tools.SQL` wrapper. For dynamic **identifiers**
+  (table/column names, which can't be parameters) use `SQL.identifier(name)`,
+  which validates the name (via `assert`, so a `-O` deployment skips the
+  check — still never feed it raw user input).
+
+## Domain injection
+
+- Build/extend domains with `fields.Domain` (`domain &= Domain(...)`), never
+  by concatenating a user-provided list onto a security domain (a user could
+  inject `['|', ...]` to widen access).
+
+## Don't over-sudo
+
+- `sudo()` is the top risk — review every use twice, especially in controllers
+  and public methods, never use it to mask an access error. For each `sudo()`,
+  confirm there is no attacker-controlled:
+  - **read**: arbitrary model / record / field;
+  - **create**: arbitrary model / values;
+  - **write**: arbitrary model / record / values;
+  - **search**: arbitrary model / domain / injection.
+- Controllers: never `record.sudo().write(post)` with raw request params —
+  whitelist keys (`{k: post[k] for k in ('name', 'email') if post.get(k)}`).
+- Under `sudo()`, x2many `Command` payloads in `vals` execute with sudo **on
+  the comodel** (unless it sets `_allow_sudo_commands = False`) — a sudo
+  write with raw request values pivots the privilege into other models, so
+  whitelist command lists too.
+- Avoid sudo-computed `related` fields onto `ir.attachment` (arbitrary
+  `attachment_id` → arbitrary file read). Prefer a plain `fields.Binary`, or
+  create/search `ir.attachment` records so the ORM enforces its access rights.
+- `with_user` / `with_company` switches must be intentional, not
+  attacker-driven.
+
+## Routes: auth, POST, CSRF
+
+- Match `auth` to the route's exposure: a `public`/`none` route must not
+  expose internal data or perform privileged writes.
+- A route that writes must use `methods=['POST']`; on a `type='http'` route
+  keep CSRF on (never `csrf=False`, except dedicated webhooks) —
+  `jsonrpc`/`json2` routes have no token check by design, their protection is
+  the JSON content type. State-changing logic on a **GET** route is a CSRF
+  hole: an attacker can auto-submit a hidden form / crafted
+  link and perform the action as the logged-in victim.
+- Templates that POST must include `<input type="hidden" name="csrf_token"
+  t-att-value="request.csrf_token()"/>`.
+
+## Prevent XSS (escape on the way into the DOM)
+
+- Reflected (script in URL/params) and stored (script saved by a
+  low-privileged user) both execute with the victim's session — far more than
+  `alert()`.
+- Server/QWeb: render with `t-out` (escapes by default). `t-raw` no longer
+  exists in either server QWeb or OWL — flag any occurrence as broken legacy
+  code; the raw-HTML vector today is a `Markup`/`markup()` value reaching
+  `t-out`. Build HTML by wrapping **literals** in `markupsafe.Markup` and
+  formatting user content in (Markup auto-escapes; `escape()`/`html_escape`
+  turns `str` into escaped `Markup`). f-strings defeat escaping
+  (`Markup(f"<p>{x}</p>")`) — use `Markup("<p>{x}</p>").format(x=...)`.
+  `_()` escapes when any argument is `Markup`, so keep HTML out of the
+  literal. (`t-esc`: deprecated-but-escaping alias in OWL; server QWeb
+  ignores it and renders nothing — a bug to flag, though not an XSS.)
+- JS: the sinks are `el.innerHTML = …`, `insertAdjacentHTML`, and owl
+  `markup()` on a non-literal — never feed them user/low-privilege strings.
+  Escape with `htmlEscape` (`@odoo/owl`) or use the tagged-template form
+  ``markup`<td>${name}</td>` `` (placeholders auto-escape; plain
+  `markup(str)` marks raw HTML), use the `@web/core/utils/html` helpers
+  (`setInnerHtml`, `htmlJoin`), or render through OWL `t-out`.
+- **Escaping vs sanitizing**: escaping (TEXT→CODE) is always mandatory when
+  mixing data with code, even for trusted data. Sanitizing (CODE→safer CODE)
+  is only for **untrusted** CODE and only works **after** escaping (sanitizing
+  raw TEXT corrupts it). `fields.Html`/`html_sanitize` options
+  (e.g. `strip_classes`) tune the level.
+
+## Open files with `file_open`, not `open`
+
+- Never use the builtin `open()` on a path that can be influenced — it can
+  read *or write* arbitrary files on the host (config, ssh keys, executable
+  Python → RCE). Use `odoo.tools.file_open()`, which confines access to the
+  addons paths, the Odoo root, and registered temporary directories. It
+  refuses to *create* files but will open an existing one in write mode — it
+  is a path confinement, not a write protection.
+
+## `eval` is evil
+
+- Never `eval`/`exec`. To parse data use `json.loads()` or
+  `ast.literal_eval()`; only at worst `odoo.tools.safe_eval.safe_eval` with a
+  constrained namespace, and only for trusted privileged users (it still
+  gives broad capabilities, and plain `eval` allows
+  `__import__('os').popen(...)` RCE; master's extra `--unsafe-policy`
+  whitelist sandbox is observe-only by default).
+
+## Don't return complex objects from model methods
+
+- A public model method that **returns** a rich object (a crypto key, a
+  backend handle) is exploitable from `safe_eval`'d code — server actions,
+  automation rules: the evaluated code calls it and walks single-underscore
+  internals (`._backend._ffi`) to read files or run code. (Dunders are
+  blocked there, and over RPC the return dies in marshalling — safe_eval is
+  the live vector.) Don't factor such logic into a model method if not
+  needed; use a standalone module-level function, or dunder-prefix the
+  method name — dunder names are unreachable from safe_eval, `_`-names over
+  RPC.
+
+## `getattr`/`setattr` are not your friends
+
+- Don't access record fields by dynamic name with `getattr`/`setattr` — it
+  exposes private attributes and methods (`__class__` → `__globals__` →
+  `__import__` → RCE). Use `record[name]` (safe `__getitem__`); still
+  validate the record id and field name, otherwise restrict.
+
+## Never `pickle`
+
+- Builtin `pickle` executes arbitrary code on load (via `__reduce__`). Never
+  unpickle untrusted data; store/exchange with `json` (the framework no
+  longer ships a restricted pickle wrapper).
+
+## Timing attacks
+
+- Compare secrets/tokens in constant time with `odoo.tools.consteq`, not `==`
+  (which short-circuits and leaks length/content via timing). Better, look
+  the token up in the database (`search([('access_token', '=', token)])`).
+
+## Mutable default arguments
+
+- Don't use mutable default parameters (`def f(x, vals=[])`); they persist
+  across calls and can leak/accumulate data.

--- a/skills/odoo-web-guidelines/AUTHORING.md
+++ b/skills/odoo-web-guidelines/AUTHORING.md
@@ -1,0 +1,20 @@
+# Adding a guideline
+
+- One numbered file per rule or per domain of conventions, named
+  `guidelines/NNNN_snake_case_title.md`. `NNNN` is the next free number and is never
+  reused, even if a guideline is deleted. It is an identifier, not a priority: the order
+  of the numbers means nothing.
+- Say each rule so that following it is checkable, then why it exists, then the
+  exceptions.
+- Two kinds of file. A convention is a choice that can be stated in one line and
+  followed as stated: 4-space indent, `o_<module>` class prefix. Conventions are bullets,
+  grouped in one file per domain (one kind of file or one topic). A rule needs an
+  explanation to be applied correctly: a why, an example, exceptions. A rule gets its own
+  file: the rule, code that follows it, the same code breaking it, why, then the cases
+  where it does not apply. A convention that keeps being violated despite being loaded
+  has shown it needs the explanation; promote it to a rule file.
+- Examples are schematic: the smallest tree or snippet that carries the concept. Do not
+  copy real code or point at real files or directories; nothing checks them, and a stale
+  reference is worse than none.
+- Add a row to the table in `SKILL.md`. The "Read it when" cell names the files or the
+  activity that should trigger reading the guideline, not every edit of every file.

--- a/skills/odoo-web-guidelines/SKILL.md
+++ b/skills/odoo-web-guidelines/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: odoo-web-guidelines
+description: >-
+  House rules for the web framework code of Odoo addons: the JavaScript,
+  Owl templates and SCSS in static/src/ and static/tests/ of any addon
+  (community, enterprise, or custom). Use when writing, reviewing, or
+  moving files under static/ in an Odoo addon.
+---
+
+# Odoo web guidelines
+
+These rules apply to the web framework code an addon ships in `static/src/` and
+`static/tests/`: JavaScript, Owl templates (XML) and SCSS. They do not apply to
+`static/lib/`, which holds vendored or library-style code, nor to the images and
+`static/description/` an addon ships alongside. They are house rules, not general web
+development advice.
+
+Each rule lives in its own numbered file in `guidelines/`. The number is an identifier, not
+a priority: no rule outranks another. Read the ones that match the code you are touching
+instead of loading all of them.
+
+| Guideline | Read it when |
+| --- | --- |
+| [0001 Organize files by feature](guidelines/0001_organize_files_by_feature.md) | creating a file, or deciding where new code lives |
+
+To add a guideline, follow [AUTHORING.md](AUTHORING.md).

--- a/skills/odoo-web-guidelines/SKILL.md
+++ b/skills/odoo-web-guidelines/SKILL.md
@@ -22,5 +22,7 @@ instead of loading all of them.
 | Guideline | Read it when |
 | --- | --- |
 | [0001 Organize files by feature](guidelines/0001_organize_files_by_feature.md) | creating a file, or deciding where new code lives |
+| [0002 SCSS & CSS](guidelines/0002_scss.md) | touching `*.scss` |
+| [0003 Assets](guidelines/0003_assets.md) | adding an image, font, or library |
 
 To add a guideline, follow [AUTHORING.md](AUTHORING.md).

--- a/skills/odoo-web-guidelines/guidelines/0001_organize_files_by_feature.md
+++ b/skills/odoo-web-guidelines/guidelines/0001_organize_files_by_feature.md
@@ -1,0 +1,60 @@
+# Organize files by feature, not by type
+
+Every file belonging to a feature goes in one directory named after that feature. The
+feature directory may sit under a grouping directory such as `core/` or `views/`; what
+matters is that one directory, named after the feature, holds all of its files.
+
+```
+static/src/
+    core/
+        notification/
+            notification.js
+            notification.scss
+            notification.xml
+            notification_container.js
+            notification_plugin.js
+```
+
+When a feature ships in several asset bundles, the split happens inside its directory,
+one subdirectory per bundle, the shared part in `common/`. Feature first, then bundle:
+
+```
+static/src/
+    thread/
+        common/
+            thread.js
+            thread.xml
+        web/
+            thread_patch.js
+```
+
+Do not group files by what kind of file they are:
+
+```
+static/src/
+    components/
+        notification.js
+        notification_container.js
+    plugins/
+        notification_plugin.js
+    scss/
+        notification.scss
+    xml/
+        notification.xml
+```
+
+The two notification trees contain the same files. The first tells you the codebase has
+a notification feature. The second tells you the codebase has components.
+
+## Why
+
+- Files that change together live together. Touching a feature usually means touching
+  its component, its plugin and its template at the same time.
+- You can read a feature by listing one directory. No need to hunt for files.
+- Deleting the feature is deleting one directory, and what is left behind is easy to
+  spot.
+
+## When it does not apply
+
+Code that belongs to no feature in particular goes in a generic directory such as
+`utils/`. Keep it small.

--- a/skills/odoo-web-guidelines/guidelines/0002_scss.md
+++ b/skills/odoo-web-guidelines/guidelines/0002_scss.md
@@ -1,0 +1,20 @@
+# SCSS & CSS
+
+- Formatting: 4-space indent (no tabs), ~80-column lines, opening brace on the
+  selector line, closing brace on its own line, one declaration per line.
+- Order properties from the outside in (start at `position`, end with decorative
+  rules like `font`/`filter`); put scoped SCSS and CSS variables at the top,
+  separated by a blank line.
+- Class naming: avoid `id` selectors; prefix classes with `o_<module>` (just
+  `o_` for the webclient). Use the flat "grandchild" approach
+  (`o_element_entry`), not hyper-specific nested names. Classes use
+  underscores (`o_`); SCSS variables, mixins and functions below use hyphens
+  (`o-`).
+- Variable conventions: SCSS `$o-[root]-[element]-[property]-[modifier]`, scoped
+  SCSS `$-[name]`, mixins/functions `o-[name]` (imperative verbs) with
+  optional arguments named in scoped form (`@mixin o-avatar($-size: 1.5em)`), CSS variables
+  in BEM `--[root]__[element]-[property]--[modifier]`. Don't define CSS variables
+  on `:root` (use SCSS for global design; core's few `:root` definitions are
+  deliberate utility APIs); CSS variables are for contextual DOM adaptation.
+  The variable conventions bind *new* code — much of core (plain mixin
+  arguments, `--ComponentName-property` CSS variables) predates them.

--- a/skills/odoo-web-guidelines/guidelines/0003_assets.md
+++ b/skills/odoo-web-guidelines/guidelines/0003_assets.md
@@ -1,0 +1,5 @@
+# Assets
+
+- Every resource a page needs ships in the codebase: copy images, fonts and libraries
+  into the addon instead of linking them by URL.
+- Third-party libraries go in `static/lib/`, unminified, so they can be read and diffed.


### PR DESCRIPTION
Stacked on odoo-dev#5250 (targets its branch so only this commit shows; retarget once it merges).

Adds `skills/odoo-git/`, a single-file skill with Odoo's git conventions, for an agent writing or amending a commit message, choosing the branch a change targets, or opening or updating a pull request:

- **Commit message**: `[TAG] module: summary` header (tag table, `module, *:` for cross-module changes, "if applied, this commit will ..." test, ~50 chars and never past 70), a why-first body, and reference trailers, with a good and a bad example on a schematic module.
- **Trailers**: the ones authors write (`task-`, `opw-`, `runbot-`, `Fixes #`, `Co-authored-by`) versus the ones the mergebot and forward-port bot add (`closes`, `Signed-off-by`, `Related`, `X-original-commit`, `Forward-port-of`, `Part-of`).
- **Branches and PRs**: target branch per kind of change, one PR per patch, `<target>-<topic>-<trigram>` branch naming, one change and one module per commit with `[MOV]` before `[REF]`, rebase and squash, stable changes deferring to odoo-guidelines 0016.

Sources: the git guidelines page of the documentation, the Contributing wiki, and the last 20,000 commits on master for what the docs leave out (tag frequencies, header lengths, bot-added trailers, header shapes, branch naming on odoo-dev).

One file rather than a guidelines folder: an agent making commits needs all of it at once.