### PR TITLE
[IMP] account_peppol: skip recompute peppol if already registered.

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -232,12 +232,19 @@ class ResPartner(models.Model):
         return res
 
     def _compute_peppol_endpoint(self):
-        partners_to_recompute = self.browse([partner.id for partner in self if partner._origin not in self])
+        partners_not_to_recompute = self._get_partners_to_skip_peppol_computation()
+        partners_to_recompute = self.browse([partner.id for partner in self if partner._origin not in partners_not_to_recompute])
         super(ResPartner, partners_to_recompute)._compute_peppol_endpoint()
 
     def _compute_peppol_eas(self):
-        partners_to_recompute = self.browse([partner.id for partner in self if partner._origin not in self])
+        partners_not_to_recompute = self._get_partners_to_skip_peppol_computation()
+        partners_to_recompute = self.browse([partner.id for partner in self if partner._origin not in partners_not_to_recompute])
         super(ResPartner, partners_to_recompute)._compute_peppol_eas()
+
+    def _get_partners_to_skip_peppol_computation(self):
+        return self.env['res.company'].search([
+            ('account_peppol_proxy_state', 'in', self.env['account_edi_proxy_client.user']._get_can_send_domain()),
+        ]).mapped('partner_id')
 
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS

--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -388,3 +388,28 @@ class TestPeppolParticipant(PeppolConnectorCommon):
             p_rec = partner_form.save()
             self.assertEqual(p_rec.commercial_partner_id, p_rec)
             self.assertEqual(p_rec.commercial_partner_id.name, "test")
+
+    def test_do_not_reset_peppol_endpoint(self):
+        company = self.env.company
+        partner = company.partner_id
+        company.write({
+            'country_id': self.env.ref('base.be').id,
+            'vat': 'BE0477472701',
+            'account_peppol_proxy_state': 'not_registered',
+        })
+        company.vat = 'BE0475646428'
+        self.assertRecordValues(partner, [{
+            'peppol_eas': '0208',
+            'peppol_endpoint': '0475646428',
+        }])
+
+        partner.write({
+            'peppol_eas': '0088',
+            'peppol_endpoint': '88888888888',
+        })
+        company.account_peppol_proxy_state = 'sender'
+        company.vat = 'BE0477472701'
+        self.assertRecordValues(partner, [{
+            'peppol_eas': '0088',
+            'peppol_endpoint': '88888888888',
+        }])


### PR DESCRIPTION
When someone is registred on Peppol, we fill his Peppol EAS/Endpoint. But if he later fills his VAT, we recompute these fields, resulting in a broken config. Now, already registered partners are skipped and only unregisered are recomputed

task-6517921